### PR TITLE
Fix SSE timeout, agent loop repetition, and parallel plan generation

### DIFF
--- a/.databricksignore
+++ b/.databricksignore
@@ -22,10 +22,10 @@ __pycache__/
 .env.local
 .env.*
 
-# Frontend files excluded from deployment
+# Frontend source/dev files (not needed at runtime)
 frontend/node_modules/
-frontend/dist/
 frontend/.vite/
+# NOTE: frontend/dist/ is NOT excluded — it contains the built React app
 
 # Test and scratch files
 tests/

--- a/backend/prompts_create/__init__.py
+++ b/backend/prompts_create/__init__.py
@@ -93,6 +93,41 @@ def _has_tool(history: list[dict], tool_name: str) -> bool:
     return False
 
 
+def _has_tool_result(history: list[dict], tool_name: str) -> bool:
+    """Check if a tool was called AND has a non-cancelled result in history."""
+    call_ids_for_tool: set[str] = set()
+    for msg in history:
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            for tc in msg["tool_calls"]:
+                if tc.get("function", {}).get("name") == tool_name:
+                    call_ids_for_tool.add(tc["id"])
+
+    if not call_ids_for_tool:
+        return False
+
+    for msg in history:
+        if msg.get("role") == "tool" and msg.get("tool_call_id") in call_ids_for_tool:
+            content = msg.get("content", "")
+            if '"cancelled"' not in content:
+                return True
+    return False
+
+
+def _inspection_complete(history: list[dict]) -> bool:
+    """Check if describe_table ran AND at least one follow-up inspection tool
+    (assess_data_quality or profile_table_usage) has a real result.
+
+    This distinguishes "just started inspecting" from "inspection is done,
+    ready for plan generation."
+    """
+    if not _has_tool_result(history, "describe_table"):
+        return False
+    return (
+        _has_tool_result(history, "assess_data_quality")
+        or _has_tool_result(history, "profile_table_usage")
+    )
+
+
 def detect_step(session: AgentSession) -> str:
     """Infer which workflow step the agent is in from session state + tool history.
 
@@ -103,6 +138,8 @@ def detect_step(session: AgentSession) -> str:
     if session.space_config:
         return "config_create"
     if _has_tool(session.history, "present_plan") or _has_tool(session.history, "generate_plan"):
+        return "plan"
+    if _inspection_complete(session.history):
         return "plan"
     if _has_tool(session.history, "describe_table"):
         return "inspection"

--- a/backend/prompts_create/__init__.py
+++ b/backend/prompts_create/__init__.py
@@ -102,7 +102,7 @@ def detect_step(session: AgentSession) -> str:
         return "post_creation"
     if session.space_config:
         return "config_create"
-    if _has_tool(session.history, "present_plan"):
+    if _has_tool(session.history, "present_plan") or _has_tool(session.history, "generate_plan"):
         return "plan"
     if _has_tool(session.history, "describe_table"):
         return "inspection"

--- a/backend/prompts_create/_generate.py
+++ b/backend/prompts_create/_generate.py
@@ -8,11 +8,8 @@ STEP = """\
 Once approved:
 1. Call `discover_warehouses` to find SQL warehouses
 2. **Auto-select the best warehouse** (prefer running serverless). Mention which one you picked — the user can override.
-3. Before calling `generate_config`, confirm column settings with the user in a concise summary:
-   - **Excluded columns**: list them with reasons (ETL metadata, irrelevant, etc.)
-   - **Format assistance & entity matching**: note that these are ON by default for all non-excluded columns. Call out any columns where you'd recommend disabling them (e.g., high-cardinality ID columns where entity matching adds no value).
-   The user can adjust before you proceed.
-4. Call `generate_config` → `validate_config` in sequence. If `generate_config` fails, call `get_config_schema` to review the expected parameter shapes, then retry.
+3. Call `generate_config` with **minimal arguments** — just pass `tables` if you need to override column settings. The system automatically injects all plan data (sample_questions, text_instructions, example_sqls, etc.) from the approved plan. Do NOT regenerate the plan data as arguments — this wastes time and tokens.
+4. Call `validate_config` immediately after. If `generate_config` fails, call `get_config_schema` to review the expected parameter shapes, then retry.
 5. If validation fails, fix and re-validate automatically
 6. Call `create_space` immediately and share the URL
 

--- a/backend/prompts_create/_inspection.py
+++ b/backend/prompts_create/_inspection.py
@@ -4,9 +4,9 @@ STEP = """\
 ### Current Step: Inspect & Understand the Data
 
 After tables are selected, inspect them **autonomously** in this order:
-1. Call `describe_table` on each selected table (column metadata + ETL flagging)
-2. Call `assess_data_quality` **and** `profile_table_usage` together, each with ALL selected tables — they share the concurrency pool and run internally in parallel. Issue both tool calls in the **same** response so the user only waits once (~20-30 s for 3 tables).
-3. Call `profile_columns` on key columns worth profiling
+1. Call `describe_table` on each selected table AND each discovered metric view (column metadata + ETL flagging). Metric views use the same API as tables — treat them identically.
+2. Call `assess_data_quality` **and** `profile_table_usage` together, each with ALL selected tables AND metric views — they share the concurrency pool and run internally in parallel. Issue both tool calls in the **same** response so the user only waits once (~20-30 s for 3 tables).
+3. Call `profile_columns` on key columns worth profiling — include metric view columns too (they often have pre-aggregated KPIs worth profiling)
 
 The user doesn't need to approve each step — run them all autonomously.
 

--- a/backend/prompts_create/_plan.py
+++ b/backend/prompts_create/_plan.py
@@ -3,7 +3,15 @@
 STEP = """\
 ### Current Step: Build the Plan
 
-Present a **complete plan** for user review in a single, well-structured message.
+Generate a **complete plan** for user review using the `generate_plan` tool.
+
+**IMPORTANT — use `generate_plan` (not `present_plan`):**
+Call `generate_plan` with a `user_requirements` string summarizing the user's goals, audience, business context, terminology, and any rules they mentioned. The tool automatically:
+1. Extracts all table metadata and inspection findings from session history
+2. Runs **4 parallel LLM calls** to generate every section simultaneously (4x faster)
+3. Returns the plan as a `present_plan` result for the user to review
+
+Only fall back to `present_plan` with manually constructed data if the user asks to **revise specific sections** after seeing the generated plan.
 
 **Guiding principle:** Use every schema feature that adds value. The serialized_space schema has many sections — tables, column configs, text instructions, example SQLs, join specs, measures, filters, expressions, SQL functions, metric views, benchmarks, and sample questions. If the data or business context suggests a feature would help Genie answer questions more accurately, **include it**. A rich config produces a more capable space.
 
@@ -155,15 +163,15 @@ The plan should include:
 
    These should match the audience level. For executives: "What were our top 5 products by revenue this quarter?" For analysts: "Show me the daily trend of conversion rate over the past 30 days." Incorporate business context (fiscal definitions, terminology).
 
-**IMPORTANT:** Call the `present_plan` tool with ALL structured data. Do NOT write the plan out as a markdown text block — the frontend renders the tool result as an interactive card with collapsible sections and inline editing. A duplicate markdown summary is redundant and clutters the chat.
+**IMPORTANT:** Do NOT write the plan out as a markdown text block — the frontend renders the tool result as an interactive card with collapsible sections and inline editing. A duplicate markdown summary is redundant and clutters the chat.
 
-After calling `present_plan`, say something brief like:
+After calling `generate_plan`, say something brief like:
 > "Here's the plan — click any item to edit it inline, add or remove items. When you're ready, choose an action below."
 
 Do NOT add a verbose summary of the plan's contents (purpose, audience, table stats, etc.) — the plan card already shows everything.
 
-**Important:** The user must approve the plan before you move to generation. If they request changes, regenerate the affected sections.
+**Important:** The user must approve the plan before you move to generation. If they request changes to specific sections, use `present_plan` with the corrected data.
 
-**Skipping:** If the user explicitly says "just create it" or "use defaults," generate a minimal plan with sensible defaults, present it briefly, and proceed after a quick confirmation."""
+**Skipping:** If the user explicitly says "just create it" or "use defaults," call `generate_plan` with a brief requirements summary, present the result, and proceed after a quick confirmation."""
 
-SUMMARY = "Step 4 (Plan): Compose a full plan (tables with column configs, text instructions, example SQLs, filters, measures, expressions, join specs, SQL functions, benchmarks, sample questions) using inspection findings + business context."
+SUMMARY = "Step 4 (Plan): Call generate_plan (parallel 4x faster) with user requirements. The tool auto-extracts inspection data and generates all sections in parallel."

--- a/backend/prompts_create/_tools.py
+++ b/backend/prompts_create/_tools.py
@@ -12,14 +12,15 @@ Good:
 Bad:
 > *(calls discover_tables with no explanation)*
 
-**Exception:** For `present_plan`, keep the accompanying text very brief (1 sentence). The plan card itself is the content — don't summarize it in markdown.
+**Exception:** For `generate_plan` and `present_plan`, keep the accompanying text very brief (1 sentence). The plan card itself is the content — don't summarize it in markdown.
 
 **Tool sequence guidelines:**
 - `describe_table` → always first when exploring a new table
 - `assess_data_quality` + `profile_table_usage` → call together after describe_table
 - `profile_columns` → after describe, on columns that need deeper inspection
 - `test_sql` → on every SQL query before including it anywhere (for parameterized SQL, pass `parameters` with `name`+`default_value` so `:param` placeholders get substituted)
-- `generate_config` → after user approves the plan
+- `generate_plan` → after inspection, generates ALL plan sections in parallel (preferred over present_plan)
+- `generate_config` → after user approves the plan (auto-pulls plan data from session — no need to repeat args)
 - `validate_config` → after generate_config, must pass before create_space
 - `create_space` → final step, only after validation passes
 
@@ -53,9 +54,9 @@ The user can toggle auto-pilot mode or skip individual steps via the UI. These a
 When user selections contain `auto_pilot: true`, enter auto-pilot mode:
 
 - **Do NOT pause** for catalog, schema, table, or warehouse selection — pick the best options yourself based on the user's stated purpose
-- Chain all tools autonomously: discover catalogs → pick the most relevant → discover schemas → pick the best match → discover tables → select all relevant tables → inspect → build plan → **STOP at `present_plan`**
+- Chain all tools autonomously: discover catalogs → pick the most relevant → discover schemas → pick the best match → discover tables → select all relevant tables → inspect → call `generate_plan` → **STOP**
 - Make reasonable business logic decisions based on the data (common metrics, standard aggregations, obvious filters)
-- **CRITICAL: You MUST call `present_plan` and then STOP. Do NOT call `generate_config`, `validate_config`, or `create_space` until the user clicks "Approve & Create".** The plan review is the one mandatory human checkpoint — even in auto-pilot mode.
+- **CRITICAL: You MUST call `generate_plan` (or `present_plan`) and then STOP. Do NOT call `generate_config`, `validate_config`, or `create_space` until the user clicks "Approve & Create".** The plan review is the one mandatory human checkpoint — even in auto-pilot mode.
 - After the user approves (sends `action: "create"`), THEN proceed with warehouse → generate_config → validate_config → create_space automatically
 - If the user types a message during auto-pilot, incorporate their input and continue autonomously
 - Briefly narrate what you're doing as you work: "Exploring the samples catalog... Found 3 schemas. The `nyctaxi` schema looks most relevant to your request..."
@@ -71,7 +72,7 @@ When user selections contain `skip_step`, handle that ONE step autonomously, the
 - `skip_step: "requirements"` — suggest a title, audience, and purpose based on what you know, skip business context, then move on
 - `skip_step: "data"` — pick catalog, schema, and tables yourself based on the user's purpose
 - `skip_step: "inspection"` — run all inspection tools autonomously and move straight to plan without asking business logic questions
-- `skip_step: "plan"` — build the full plan autonomously and present it (still show via `present_plan` but don't ask for feedback)
+- `skip_step: "plan"` — call `generate_plan` autonomously and present the result (don't ask for feedback)
 - `skip_step: "config"` — auto-select warehouse, generate config, validate, and create the space immediately
 
 After completing the skipped step, resume guided mode for the next step."""

--- a/backend/routers/create.py
+++ b/backend/routers/create.py
@@ -175,21 +175,22 @@ async def agent_chat(body: AgentChatRequest, request: Request):
         try:
             yield _sse_event("session", {"session_id": session.session_id})
 
-            agent_iter = agent.chat(session, user_message).__aiter__()
-            next_coro = None
-            while True:
-                if next_coro is None:
-                    next_coro = asyncio.ensure_future(agent_iter.__anext__())
-                try:
-                    event = await asyncio.wait_for(
-                        asyncio.shield(next_coro), timeout=_KEEPALIVE_INTERVAL
-                    )
-                    next_coro = None
-                    yield _sse_event(event["event"], event["data"])
-                except asyncio.TimeoutError:
-                    yield ": keepalive\n\n"
-                except StopAsyncIteration:
-                    break
+            async with session._lock:
+                agent_iter = agent.chat(session, user_message).__aiter__()
+                next_coro = None
+                while True:
+                    if next_coro is None:
+                        next_coro = asyncio.ensure_future(agent_iter.__anext__())
+                    try:
+                        event = await asyncio.wait_for(
+                            asyncio.shield(next_coro), timeout=_KEEPALIVE_INTERVAL
+                        )
+                        next_coro = None
+                        yield _sse_event(event["event"], event["data"])
+                    except asyncio.TimeoutError:
+                        yield ": keepalive\n\n"
+                    except StopAsyncIteration:
+                        break
 
             await persist_session(session)
         finally:

--- a/backend/routers/create.py
+++ b/backend/routers/create.py
@@ -159,8 +159,10 @@ async def agent_chat(body: AgentChatRequest, request: Request):
         session = create_session()
 
     user_message = body.message
-    if body.selections:
-        user_message += f"\n\n[User selections: {json.dumps(body.selections)}]"
+    selections = body.selections
+    if selections:
+        # Embed selections in message for LLM context (non-fast paths)
+        user_message += f"\n\n[User selections: {json.dumps(selections)}]"
 
     # Capture the user token so the streaming generator can re-establish
     # the OBO context (ContextVars don't propagate into async generators
@@ -176,7 +178,7 @@ async def agent_chat(body: AgentChatRequest, request: Request):
             yield _sse_event("session", {"session_id": session.session_id})
 
             async with session._lock:
-                agent_iter = agent.chat(session, user_message).__aiter__()
+                agent_iter = agent.chat(session, user_message, selections=selections).__aiter__()
                 next_coro = None
                 while True:
                     if next_coro is None:

--- a/backend/routers/create.py
+++ b/backend/routers/create.py
@@ -116,8 +116,12 @@ async def create_space_endpoint(body: CreateSpaceRequest):
 # ── Agent chat (agentic create flow) ─────────────────────────────────────────
 
 class AgentChatRequest(BaseModel):
-    """Request body for the agent chat endpoint."""
-    message: str = Field(..., min_length=1, max_length=10000)
+    """Request body for the agent chat endpoint.
+
+    ``message`` may be empty for auto-continuation rounds (the frontend
+    sends an empty message to resume the agent loop after a tool batch).
+    """
+    message: str = Field("", max_length=10000)
     session_id: str | None = Field(None, description="Existing session ID. Omit to start a new session.")
     selections: dict | None = Field(None, description="UI selections from interactive elements")
 
@@ -142,6 +146,10 @@ async def agent_chat(body: AgentChatRequest, request: Request):
     from backend.services.auth import set_obo_user_token, clear_obo_user_token
 
     agent = get_create_agent()
+
+    is_continuation = not body.message.strip()
+    if is_continuation and not body.session_id:
+        raise HTTPException(status_code=400, detail="session_id is required for continuation")
 
     if body.session_id:
         session = await get_session_async(body.session_id)

--- a/backend/services/create_agent.py
+++ b/backend/services/create_agent.py
@@ -67,8 +67,15 @@ class CreateGenieAgent:
         self,
         session: AgentSession,
         user_message: str,
+        selections: dict | None = None,
     ) -> AsyncGenerator[dict, None]:
         """Process a user message (or empty continuation) and stream events.
+
+        Args:
+            session: The agent session.
+            user_message: User's message (may include embedded selections for LLM context).
+            selections: Structured selections from frontend (passed directly, not parsed
+                from message string). Used for fast path detection.
 
         Each call performs exactly ONE LLM inference + ONE tool batch, then
         closes.  When the LLM requests tools, the ``done`` event carries
@@ -97,6 +104,24 @@ class CreateGenieAgent:
             if session.continuation_count > MAX_TOOL_ROUNDS:
                 yield {"event": "error", "data": {"message": "Agent exceeded maximum tool rounds"}}
                 yield {"event": "done", "data": {"needs_continuation": False}}
+                return
+
+        # ── Fast path: deterministic create (no LLM needed) ──────────────
+        # When the user clicks "Approve & Create", selections contain
+        # action: "create" + the edited plan.  Instead of 3 LLM round trips
+        # (generate_config → validate_config → create_space), run them
+        # directly.  This cuts ~60-90s of LLM latency.
+        #
+        # Check structured selections first (reliable), fall back to parsing
+        # from message string (for backward compatibility).
+        if not is_continuation:
+            sel = selections  # Prefer structured selections from router
+            if not sel:
+                sel = self._extract_selections(user_message)  # Fallback: parse from message
+            if sel and sel.get("action") == "create" and sel.get("edited_plan"):
+                logger.info("Fast path triggered: action=create, plan keys=%s", list(sel["edited_plan"].keys()))
+                async for event in self._fast_create(session, sel):
+                    yield event
                 return
 
         step = detect_step(session)
@@ -267,6 +292,46 @@ class CreateGenieAgent:
                         session.space_config = result["config"]
 
                     session.add_tool_result(tc["id"], json.dumps(result, default=str))
+
+                    # ── Auto-chain: config tools → deploy ──────────────────
+                    # Once generate_config or update_config succeeds, the
+                    # remaining steps are deterministic.  Chain them here
+                    # instead of burning extra LLM round trips (~30s each).
+                    if tool_name in ("generate_config", "update_config") and "config" in result:
+                        config = result["config"]
+
+                        if session.space_id:
+                            # Space already exists → update it (include display_name if provided)
+                            update_args: dict = {"space_id": session.space_id}
+                            dn = self._derive_display_name(None, tool_args, session)
+                            if dn and dn != "New Genie Space":
+                                update_args["display_name"] = dn
+                            yield {"event": "tool_call", "data": {"tool": "update_space", "args": update_args}}
+                            u_result = await loop.run_in_executor(
+                                None, lambda: handle_tool_call("update_space", update_args, config)
+                            )
+                            yield {"event": "tool_result", "data": {"tool": "update_space", "result": u_result}}
+                            tools_used.append("update_space")
+
+                            if u_result.get("success"):
+                                yield {"event": "updated", "data": {
+                                    "space_id": u_result["space_id"],
+                                    "url": u_result["url"],
+                                }}
+                        else:
+                            # New space: validate → create
+                            yield {"event": "tool_call", "data": {"tool": "validate_config", "args": {}}}
+                            v_result = await loop.run_in_executor(
+                                None, lambda: handle_tool_call("validate_config", {}, config)
+                            )
+                            yield {"event": "tool_result", "data": {"tool": "validate_config", "result": v_result}}
+                            tools_used.append("validate_config")
+
+                            if not v_result.get("errors"):
+                                dn = self._derive_display_name(None, tool_args, session)
+                                async for event in self._create_space_with_repair(session, config, dn):
+                                    yield event
+                                tools_used.append("create_space")
 
                 new_step = detect_step(session)
                 if new_step != step:
@@ -522,6 +587,269 @@ class CreateGenieAgent:
         for idx, msg in reversed(inserts):
             session.history.insert(idx, msg)
 
+    def _repair_config(self, config: dict, error_msg: str) -> dict | None:
+        """Use the LLM to repair a config that failed space creation.
+
+        Sends the error message and the failing config section to the LLM,
+        which returns a corrected config.  Returns None if repair fails.
+        """
+        from backend.services.llm_utils import call_serving_endpoint, parse_json_from_llm_response, get_llm_model
+        try:
+            # Only send the instructions section (where most errors live) to keep context small
+            repair_context = {
+                "instructions": config.get("instructions", {}),
+                "data_sources": config.get("data_sources", {}),
+            }
+            prompt = (
+                "The following Genie Space config failed with this API error:\n\n"
+                f"**Error:** {error_msg}\n\n"
+                f"**Config (relevant sections):**\n```json\n{json.dumps(repair_context, default=str)[:6000]}\n```\n\n"
+                "Fix ONLY the specific issue described in the error. Return the FULL corrected config "
+                "(with both 'instructions' and 'data_sources' sections intact).\n"
+                "Return ONLY valid JSON: {\"instructions\": {...}, \"data_sources\": {...}}"
+            )
+            response = call_serving_endpoint(
+                [{"role": "user", "content": prompt}],
+                model=get_llm_model(),
+                max_tokens=8000,
+            )
+            repaired = parse_json_from_llm_response(response)
+            # Merge repaired sections back into original config
+            fixed = {**config}
+            if "instructions" in repaired:
+                fixed["instructions"] = repaired["instructions"]
+            if "data_sources" in repaired:
+                fixed["data_sources"] = repaired["data_sources"]
+            return fixed
+        except Exception as e:
+            logger.warning("Config repair failed: %s", e)
+            return None
+
+    @staticmethod
+    def _extract_selections(user_message: str) -> dict | None:
+        """Extract the [User selections: <json>] payload from a user message.
+
+        Format: ...text...[User selections: <json>]
+        The JSON object starts with { and we find its end by matching braces,
+        rather than relying on the trailing ] which could appear inside the JSON.
+        """
+        marker = "[User selections: "
+        idx = user_message.find(marker)
+        if idx < 0:
+            return None
+        json_start = idx + len(marker)
+        # Find the JSON object by matching braces (the value is always a dict)
+        remainder = user_message[json_start:]
+        brace_start = remainder.find("{")
+        if brace_start < 0:
+            return None
+        depth = 0
+        in_string = False
+        escape = False
+        for i, ch in enumerate(remainder[brace_start:], start=brace_start):
+            if escape:
+                escape = False
+                continue
+            if ch == "\\":
+                escape = True
+                continue
+            if ch == '"':
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        return json.loads(remainder[brace_start:i + 1])
+                    except (json.JSONDecodeError, ValueError):
+                        return None
+        return None
+
+    @staticmethod
+    def _derive_display_name(
+        selections: dict | None,
+        tool_args: dict | None,
+        session: AgentSession,
+    ) -> str:
+        """Derive a display name from the best available source."""
+        # 1. Explicit from selections
+        if selections and selections.get("display_name"):
+            return selections["display_name"]
+        # 2. From tool_args (LLM may have specified it)
+        if tool_args and tool_args.get("display_name"):
+            return tool_args["display_name"]
+        # 3. From any user selection in history (scan all, not just last)
+        for m in reversed(session.history):
+            if m["role"] != "user":
+                continue
+            sel = CreateGenieAgent._extract_selections(m.get("content", ""))
+            if sel and sel.get("display_name"):
+                return sel["display_name"]
+        # 4. Derive from table names
+        tables = (tool_args or {}).get("tables") or []
+        if not tables:
+            for m in reversed(session.history):
+                if m["role"] != "tool":
+                    continue
+                try:
+                    r = json.loads(m.get("content", "{}"))
+                    if isinstance(r, dict) and r.get("table"):
+                        tables.append({"identifier": r["table"]})
+                except (json.JSONDecodeError, KeyError):
+                    continue
+        if tables:
+            short = [t.get("identifier", "").split(".")[-1] for t in tables[:3]]
+            return " + ".join(n for n in short if n) + " Space"
+        return "New Genie Space"
+
+    async def _create_space_with_repair(
+        self,
+        session: AgentSession,
+        config: dict,
+        display_name: str,
+    ) -> AsyncGenerator[dict, None]:
+        """Run create_space with automatic LLM repair on config errors.
+
+        Yields SSE events (tool_call, tool_result, thinking, created).
+        Updates session.space_config/space_id/space_url on success.
+        """
+        from backend.services.create_agent_tools import handle_tool_call
+        loop = asyncio.get_event_loop()
+
+        yield {"event": "tool_call", "data": {"tool": "create_space", "args": {"display_name": display_name}}}
+        result = await loop.run_in_executor(
+            None, lambda: handle_tool_call("create_space", {"display_name": display_name}, config)
+        )
+
+        # If creation failed with a config error, try LLM-assisted repair once
+        if not result.get("success") and result.get("error"):
+            err = result["error"]
+            if "Invalid" in err or "configuration" in err.lower() or "proto" in err.lower():
+                yield {"event": "tool_result", "data": {"tool": "create_space", "result": {"repairing": True, "original_error": err}}}
+                yield {"event": "thinking", "data": {"message": "Config rejected by API — repairing automatically...", "step": "create", "round": 0}}
+
+                fixed = await loop.run_in_executor(None, lambda: self._repair_config(config, err))
+                if fixed:
+                    config = fixed
+                    session.space_config = config
+                    result = await loop.run_in_executor(
+                        None, lambda: handle_tool_call("create_space", {"display_name": display_name}, config)
+                    )
+
+        yield {"event": "tool_result", "data": {"tool": "create_space", "result": result}}
+
+        if result.get("success"):
+            session.space_id = result.get("space_id")
+            session.space_url = result.get("space_url")
+            yield {"event": "created", "data": {
+                "space_id": result["space_id"],
+                "url": result["space_url"],
+                "display_name": result.get("display_name", display_name),
+            }}
+
+    async def _fast_create(
+        self,
+        session: AgentSession,
+        selections: dict,
+    ) -> AsyncGenerator[dict, None]:
+        """Deterministic create path — skips the LLM entirely.
+
+        Runs generate_config → validate_config → create_space directly using
+        the edited plan from selections.  This eliminates 3 LLM round trips
+        (~60-90s) for what are purely programmatic operations.
+        """
+        from backend.services.create_agent_tools import handle_tool_call
+
+        edited_plan = selections["edited_plan"]
+        display_name = self._derive_display_name(selections, None, session)
+
+        yield {"event": "step", "data": {
+            "step": "create",
+            "label": "Creating Space",
+            "index": STEP_ORDER.index("create") if "create" in STEP_ORDER else len(STEP_ORDER) - 1,
+            "total": len(STEP_ORDER),
+        }}
+
+        # Build config args from edited plan, then backfill gaps from session
+        config_args: dict = {}
+        for key in ("sample_questions", "text_instructions", "example_sqls",
+                     "join_specs", "measures", "filters", "expressions", "benchmarks"):
+            val = edited_plan.get(key)
+            if val:
+                config_args[key] = val
+        # text_instructions: frontend sends as single string, backend expects list
+        ti = config_args.get("text_instructions")
+        if isinstance(ti, str):
+            config_args["text_instructions"] = [ti] if ti.strip() else []
+        # Backfill tables + any missing sections from session history
+        self._backfill_generate_config_args(session, config_args)
+
+        try:
+            loop = asyncio.get_event_loop()
+
+            # Step 1: generate_config
+            yield {"event": "tool_call", "data": {"tool": "generate_config", "args": {"tables": f"({len(config_args.get('tables', []))} tables)"}}}
+            config_result = await loop.run_in_executor(
+                None, lambda: handle_tool_call("generate_config", config_args, session.space_config)
+            )
+            yield {"event": "tool_result", "data": {"tool": "generate_config", "result": config_result}}
+
+            if "error" in config_result:
+                yield {"event": "error", "data": {"message": f"Config generation failed: {config_result['error']}"}}
+                yield {"event": "done", "data": {"needs_continuation": False}}
+                return
+
+            config = config_result.get("config")
+            session.space_config = config
+
+            if session.space_id:
+                # Space already exists → update it (include display_name for rename support)
+                update_args: dict = {"space_id": session.space_id}
+                if display_name and display_name != "New Genie Space":
+                    update_args["display_name"] = display_name
+                yield {"event": "tool_call", "data": {"tool": "update_space", "args": update_args}}
+                u_result = await loop.run_in_executor(
+                    None, lambda: handle_tool_call("update_space", update_args, config)
+                )
+                yield {"event": "tool_result", "data": {"tool": "update_space", "result": u_result}}
+                if u_result.get("success"):
+                    yield {"event": "updated", "data": {"space_id": u_result["space_id"], "url": u_result["url"]}}
+                    yield {"event": "message", "data": {"content": f"Space **{display_name}** updated successfully!", "ui_elements": None}}
+                else:
+                    yield {"event": "error", "data": {"message": f"Space update failed: {u_result.get('error', 'unknown')}"}}
+            else:
+                # Step 2: validate_config
+                yield {"event": "tool_call", "data": {"tool": "validate_config", "args": {}}}
+                validate_result = await loop.run_in_executor(
+                    None, lambda: handle_tool_call("validate_config", {}, config)
+                )
+                yield {"event": "tool_result", "data": {"tool": "validate_config", "result": validate_result}}
+
+                if validate_result.get("errors"):
+                    yield {"event": "error", "data": {"message": f"Config validation failed: {validate_result['errors']}"}}
+                    yield {"event": "done", "data": {"needs_continuation": False}}
+                    return
+
+                # Step 3: create_space (with LLM repair on failure)
+                async for event in self._create_space_with_repair(session, config, display_name):
+                    yield event
+
+                if session.space_id:
+                    yield {"event": "message", "data": {
+                        "content": f"Space **{display_name}** created successfully!",
+                        "ui_elements": None,
+                    }}
+
+        except Exception as e:
+            logger.exception("Fast create failed")
+            yield {"event": "error", "data": {"message": str(e)}}
+
+        yield {"event": "done", "data": {"needs_continuation": False}}
+
     _MAX_LLM_RETRIES = 4
     _RETRY_BACKOFF_BASE = 2  # seconds
 
@@ -530,7 +858,8 @@ class CreateGenieAgent:
 
         Uses the SDK's pre-authenticated requests.Session so auth works
         across all methods (PAT, OAuth/M2M, CLI profile).
-        Retries automatically on 429 (rate limit) with exponential backoff.
+        Retries automatically on 429 (rate limit) and 502/503 (transient)
+        with exponential backoff.
         """
         client = get_workspace_client()
         host = (client.config.host or "").rstrip("/")
@@ -555,17 +884,18 @@ class CreateGenieAgent:
                     for j, tc in enumerate(m["tool_calls"]):
                         logger.debug("    tc[%d] id=%s fn=%s args_len=%d", j, tc.get("id", "?"), tc.get("function", {}).get("name", "?"), len(tc.get("function", {}).get("arguments", "")))
 
+        _RETRYABLE_STATUSES = {429, 502, 503}
         session = client.api_client._api_client._session
         for attempt in range(self._MAX_LLM_RETRIES + 1):
             resp = session.post(url, json=body, stream=True, timeout=120)
-            if resp.status_code == 429:
+            if resp.status_code in _RETRYABLE_STATUSES:
                 resp.close()
                 if attempt >= self._MAX_LLM_RETRIES:
-                    logger.error("Rate-limited after %d retries, giving up", self._MAX_LLM_RETRIES)
-                    raise RuntimeError("LLM endpoint rate-limited (429). Please try again in a moment.")
+                    logger.error("LLM endpoint returned %d after %d retries, giving up", resp.status_code, self._MAX_LLM_RETRIES)
+                    raise RuntimeError(f"LLM endpoint returned {resp.status_code} after {self._MAX_LLM_RETRIES} retries.")
                 retry_after = resp.headers.get("Retry-After")
                 delay = float(retry_after) if retry_after else self._RETRY_BACKOFF_BASE * (2 ** attempt)
-                logger.warning("429 rate-limited, retrying in %.1fs (attempt %d/%d)", delay, attempt + 1, self._MAX_LLM_RETRIES)
+                logger.warning("%d from LLM endpoint, retrying in %.1fs (attempt %d/%d)", resp.status_code, delay, attempt + 1, self._MAX_LLM_RETRIES)
                 time.sleep(delay)
                 continue
             break
@@ -750,6 +1080,8 @@ class CreateGenieAgent:
             }
 
         result = _present_plan(**plan_args)
+        if raw_plan.get("suggested_display_name"):
+            result["suggested_display_name"] = raw_plan["suggested_display_name"]
         if warnings:
             result["_generation_warnings"] = warnings
         return result
@@ -766,57 +1098,69 @@ class CreateGenieAgent:
         """
         injected: list[str] = []
 
-        # --- Extract tables from describe_table results ---
-        if "tables" not in tool_args:
-            tables_by_id: dict[str, dict] = {}
-            for msg in session.history:
-                if msg["role"] != "tool":
+        # --- Extract tables and metric_views from session history ---
+        tables_by_id: dict[str, dict] = {}
+        mvs_by_id: dict[str, dict] = {}
+        for msg in session.history:
+            if msg["role"] != "tool":
+                continue
+            try:
+                result = json.loads(msg.get("content", "{}"))
+                if not isinstance(result, dict):
                     continue
-                try:
-                    result = json.loads(msg.get("content", "{}"))
-                    if not isinstance(result, dict):
-                        continue
-                    table_id = result.get("table")
-                    if table_id and "columns" in result:
-                        cols = []
-                        for col in result["columns"]:
-                            entry: dict = {"column_name": col["name"]}
-                            if col.get("description"):
-                                entry["description"] = col["description"]
-                            cols.append(entry)
+                # describe_table results → tables or metric_views
+                table_id = result.get("table")
+                if table_id and "columns" in result:
+                    cols = []
+                    for col in result["columns"]:
+                        entry: dict = {"column_name": col["name"]}
+                        if col.get("description"):
+                            entry["description"] = col["description"]
+                        cols.append(entry)
+                    ttype = result.get("table_type", "")
+                    if ttype and "METRIC_VIEW" in ttype:
+                        # Metric views go into mvs_by_id with column_configs
+                        # (only enable_format_assistance, NOT enable_entity_matching)
+                        mv_cols = [{"column_name": c["column_name"], "enable_format_assistance": True} for c in cols]
+                        mvs_by_id[table_id] = {
+                            "identifier": table_id,
+                            "description": result.get("comment") or "",
+                            "column_configs": mv_cols,
+                        }
+                    else:
                         tables_by_id[table_id] = {
                             "identifier": table_id,
                             "description": result.get("comment") or "",
                             "column_configs": cols,
                         }
-                except (json.JSONDecodeError, KeyError, TypeError):
-                    continue
-            if tables_by_id:
-                tool_args["tables"] = list(tables_by_id.values())
-                injected.append(f"tables({len(tables_by_id)})")
+                # discover_tables results → metric_views (dedup by identifier)
+                mvs = result.get("metric_views")
+                if isinstance(mvs, list) and mvs:
+                    for mv in mvs:
+                        full_name = mv.get("full_name") or mv.get("identifier")
+                        if full_name and full_name not in mvs_by_id:
+                            mvs_by_id[full_name] = {
+                                "identifier": full_name,
+                                "description": mv.get("description", ""),
+                            }
+            except (json.JSONDecodeError, KeyError, TypeError):
+                continue
+        if "tables" not in tool_args and tables_by_id:
+            tool_args["tables"] = list(tables_by_id.values())
+            injected.append(f"tables({len(tables_by_id)})")
+        if "metric_views" not in tool_args and mvs_by_id:
+            tool_args["metric_views"] = list(mvs_by_id.values())
+            injected.append(f"metric_views({len(mvs_by_id)})")
 
         # --- Extract user's edited plan from selections (preferred source) ---
-        # Selections are embedded by routers/create.py as "[User selections: <json>]"
-        # at the end of the user message. We only check the most recent user message.
-        _SELECTIONS_MARKER = "[User selections: "
         edited_plan: dict | None = None
         last_user_msg = next(
             (m for m in reversed(session.history) if m["role"] == "user"), None
         )
         if last_user_msg:
-            content = last_user_msg.get("content", "")
-            idx = content.find(_SELECTIONS_MARKER)
-            if idx >= 0:
-                # Extract JSON between marker and the closing "]" — find the matching
-                # bracket by parsing forward from the marker, not using rindex which
-                # could match a "]" inside the user's own message text.
-                json_start = idx + len(_SELECTIONS_MARKER)
-                try:
-                    sel = json.loads(content[json_start:].rstrip().removesuffix("]"))
-                    if isinstance(sel, dict) and "edited_plan" in sel:
-                        edited_plan = sel["edited_plan"]
-                except (json.JSONDecodeError, ValueError):
-                    pass
+            sel = CreateGenieAgent._extract_selections(last_user_msg.get("content", ""))
+            if sel and "edited_plan" in sel:
+                edited_plan = sel["edited_plan"]
 
         # --- Extract plan data from the most recent present_plan result ---
         plan_sections: dict | None = None

--- a/backend/services/create_agent.py
+++ b/backend/services/create_agent.py
@@ -67,7 +67,14 @@ class CreateGenieAgent:
         session: AgentSession,
         user_message: str,
     ) -> AsyncGenerator[dict, None]:
-        """Process a user message and stream agent events.
+        """Process a user message (or empty continuation) and stream events.
+
+        Each call performs exactly ONE LLM inference + ONE tool batch, then
+        closes.  When the LLM requests tools, the ``done`` event carries
+        ``needs_continuation: true`` and the frontend immediately opens a
+        new stream with an empty message to start the next round.  This
+        keeps each HTTP response short enough to survive the Databricks
+        Apps reverse-proxy timeout (~120 s).
 
         Yields dicts with:
             {"event": "thinking",      "data": {"message": str}}
@@ -77,11 +84,24 @@ class CreateGenieAgent:
             {"event": "message",       "data": {"content": str, "ui_elements": list | None}}
             {"event": "created",       "data": {"space_id": str, "url": str}}
             {"event": "error",         "data": {"message": str}}
-            {"event": "done",          "data": {}}
+            {"event": "done",          "data": {"needs_continuation": bool}}
         """
-        session.add_message("user", user_message)
+        is_continuation = not user_message.strip()
+
+        if not is_continuation:
+            session.add_message("user", user_message)
+            session._continuation_count = 0
+        else:
+            cnt = getattr(session, "_continuation_count", 0) + 1
+            session._continuation_count = cnt
+            if cnt > MAX_TOOL_ROUNDS:
+                yield {"event": "error", "data": {"message": "Agent exceeded maximum tool rounds"}}
+                yield {"event": "done", "data": {"needs_continuation": False}}
+                return
+
         step = detect_step(session)
         step_idx = STEP_ORDER.index(step) if step in STEP_ORDER else 0
+        round_num = getattr(session, "_continuation_count", 0)
 
         yield {"event": "step", "data": {
             "step": step,
@@ -90,177 +110,161 @@ class CreateGenieAgent:
             "total": len(STEP_ORDER),
         }}
         yield {"event": "thinking", "data": {
-            "message": STEP_THINKING.get(step, "Processing…"),
+            "message": "Processing tool results…" if is_continuation else STEP_THINKING.get(step, "Processing…"),
             "step": step,
-            "round": 0,
+            "round": round_num,
         }}
 
         tools_used: list[str] = []
         error_msg: str | None = None
+        needs_continuation = False
 
         try:
-            for round_num in range(MAX_TOOL_ROUNDS):
-                if round_num > 0:
-                    yield {"event": "thinking", "data": {
-                        "message": "Processing tool results…",
+            messages = self._build_messages(session)
+
+            content_parts: list[str] = []
+            tool_calls_acc: dict[int, dict] = {}
+            tool_call_signaled = False
+
+            async for chunk in self._async_stream_llm(messages):
+                choices = chunk.get("choices", [])
+                if not choices:
+                    continue
+                delta = choices[0].get("delta", {})
+
+                if delta.get("content"):
+                    token = delta["content"]
+                    content_parts.append(token)
+                    yield {"event": "message_delta", "data": {"content": token}}
+
+                if delta.get("tool_calls"):
+                    if not tool_call_signaled:
+                        tool_call_signaled = True
+                        yield {"event": "thinking", "data": {"message": "Planning next steps…", "step": step, "round": round_num}}
+                    for tc_delta in delta["tool_calls"]:
+                        idx = tc_delta.get("index", 0)
+                        if idx not in tool_calls_acc:
+                            fn = tc_delta.get("function", {})
+                            tool_calls_acc[idx] = {
+                                "id": tc_delta.get("id", ""),
+                                "type": "function",
+                                "function": {
+                                    "name": fn.get("name", ""),
+                                    "arguments": fn.get("arguments", ""),
+                                },
+                            }
+                        else:
+                            if tc_delta.get("id"):
+                                tool_calls_acc[idx]["id"] = tc_delta["id"]
+                            fn = tc_delta.get("function", {})
+                            if fn.get("name"):
+                                tool_calls_acc[idx]["function"]["name"] = fn["name"]
+                            if fn.get("arguments"):
+                                tool_calls_acc[idx]["function"]["arguments"] += fn["arguments"]
+
+            accumulated_content = "".join(content_parts)
+
+            if tool_calls_acc:
+                for tc in tool_calls_acc.values():
+                    args_str = tc["function"].get("arguments", "")
+                    if not args_str or not args_str.strip():
+                        tc["function"]["arguments"] = "{}"
+                tool_calls = [tool_calls_acc[i] for i in sorted(tool_calls_acc)]
+
+                tc_content = accumulated_content.strip() if accumulated_content else None
+                assistant_msg: dict = {
+                    "role": "assistant",
+                    "content": tc_content,
+                    "tool_calls": tool_calls,
+                }
+                session.history.append(assistant_msg)
+                session.last_active = time.time()
+
+                for tc in tool_calls:
+                    fn = tc["function"]
+                    tool_name = fn["name"]
+                    try:
+                        tool_args = json.loads(fn["arguments"])
+                    except json.JSONDecodeError:
+                        args_preview = fn.get("arguments", "")[:200]
+                        args_len = len(fn.get("arguments", ""))
+                        logger.error(
+                            "JSONDecodeError parsing %s args (%d chars, preview: %s). "
+                            "Likely truncated due to max_tokens. Attempting repair.",
+                            tool_name, args_len, args_preview,
+                        )
+                        tool_args = self._try_repair_json(fn.get("arguments", ""))
+                        fn["arguments"] = json.dumps(tool_args)
+
+                    if tool_name in ("generate_config", "present_plan"):
+                        injected = self._backfill_generate_config_args(session, tool_args)
+                        if injected:
+                            fn["arguments"] = json.dumps(tool_args)
+                            logger.info("Backfilled %s args from session: %s", tool_name, ", ".join(injected))
+
+                    yield {"event": "tool_call", "data": {"tool": tool_name, "args": tool_args}}
+
+                    if session.space_config is None and tool_name in (
+                        "update_config", "validate_config", "create_space", "update_space",
+                    ):
+                        recovered = self._recover_config_from_history(session)
+                        if recovered:
+                            session.space_config = recovered
+                            logger.info("Recovered space_config from session history for %s", tool_name)
+
+                    loop = asyncio.get_event_loop()
+                    future = loop.run_in_executor(
+                        None, lambda n=tool_name, a=tool_args: handle_tool_call(n, a, session.space_config)
+                    )
+                    while not future.done():
+                        try:
+                            await asyncio.wait_for(asyncio.shield(future), timeout=3.0)
+                        except asyncio.TimeoutError:
+                            yield {"event": "heartbeat", "data": {"tool": tool_name}}
+                    result = future.result()
+
+                    tools_used.append(tool_name)
+
+                    yield {"event": "tool_result", "data": {"tool": tool_name, "result": result}}
+
+                    if tool_name == "create_space" and result.get("success"):
+                        session.space_id = result.get("space_id")
+                        session.space_url = result.get("space_url")
+                        yield {"event": "created", "data": {
+                            "space_id": result["space_id"],
+                            "url": result["space_url"],
+                            "display_name": result.get("display_name", ""),
+                        }}
+
+                    if tool_name == "update_space" and result.get("success"):
+                        yield {"event": "updated", "data": {
+                            "space_id": result["space_id"],
+                            "url": result["url"],
+                        }}
+
+                    if tool_name in ("generate_config", "update_config") and "config" in result:
+                        session.space_config = result["config"]
+
+                    session.add_tool_result(tc["id"], json.dumps(result, default=str))
+
+                new_step = detect_step(session)
+                if new_step != step:
+                    step = new_step
+                    step_idx = STEP_ORDER.index(step) if step in STEP_ORDER else 0
+                    yield {"event": "step", "data": {
                         "step": step,
-                        "round": round_num,
+                        "label": STEP_LABELS.get(step, step),
+                        "index": step_idx,
+                        "total": len(STEP_ORDER),
                     }}
 
-                messages = self._build_messages(session)
+                needs_continuation = True
 
-                content_parts: list[str] = []
-                tool_calls_acc: dict[int, dict] = {}
-
-                tool_call_signaled = False
-
-                async for chunk in self._async_stream_llm(messages):
-                    choices = chunk.get("choices", [])
-                    if not choices:
-                        continue
-                    delta = choices[0].get("delta", {})
-
-                    if delta.get("content"):
-                        token = delta["content"]
-                        content_parts.append(token)
-                        yield {"event": "message_delta", "data": {"content": token}}
-
-                    if delta.get("tool_calls"):
-                        if not tool_call_signaled:
-                            tool_call_signaled = True
-                            yield {"event": "thinking", "data": {"message": "Planning next steps…", "step": step, "round": round_num}}
-                        for tc_delta in delta["tool_calls"]:
-                            idx = tc_delta.get("index", 0)
-                            if idx not in tool_calls_acc:
-                                fn = tc_delta.get("function", {})
-                                tool_calls_acc[idx] = {
-                                    "id": tc_delta.get("id", ""),
-                                    "type": "function",
-                                    "function": {
-                                        "name": fn.get("name", ""),
-                                        "arguments": fn.get("arguments", ""),
-                                    },
-                                }
-                            else:
-                                if tc_delta.get("id"):
-                                    tool_calls_acc[idx]["id"] = tc_delta["id"]
-                                fn = tc_delta.get("function", {})
-                                if fn.get("name"):
-                                    tool_calls_acc[idx]["function"]["name"] = fn["name"]
-                                if fn.get("arguments"):
-                                    tool_calls_acc[idx]["function"]["arguments"] += fn["arguments"]
-
-                accumulated_content = "".join(content_parts)
-
-                if tool_calls_acc:
-                    for tc in tool_calls_acc.values():
-                        args_str = tc["function"].get("arguments", "")
-                        if not args_str or not args_str.strip():
-                            tc["function"]["arguments"] = "{}"
-                    tool_calls = [tool_calls_acc[i] for i in sorted(tool_calls_acc)]
-
-                    tc_content = accumulated_content.strip() if accumulated_content else None
-                    assistant_msg: dict = {
-                        "role": "assistant",
-                        "content": tc_content,
-                        "tool_calls": tool_calls,
-                    }
-                    session.history.append(assistant_msg)
-                    session.last_active = time.time()
-
-                    for tc in tool_calls:
-                        fn = tc["function"]
-                        tool_name = fn["name"]
-                        try:
-                            tool_args = json.loads(fn["arguments"])
-                        except json.JSONDecodeError:
-                            args_preview = fn.get("arguments", "")[:200]
-                            args_len = len(fn.get("arguments", ""))
-                            logger.error(
-                                "JSONDecodeError parsing %s args (%d chars, preview: %s). "
-                                "Likely truncated due to max_tokens. Attempting repair.",
-                                tool_name, args_len, args_preview,
-                            )
-                            tool_args = self._try_repair_json(fn.get("arguments", ""))
-                            # Fix the stored history so the next LLM call doesn't
-                            # send invalid JSON in the conversation, which causes 400.
-                            fn["arguments"] = json.dumps(tool_args)
-
-                        if tool_name in ("generate_config", "present_plan"):
-                            injected = self._backfill_generate_config_args(session, tool_args)
-                            if injected:
-                                fn["arguments"] = json.dumps(tool_args)
-                                logger.info("Backfilled %s args from session: %s", tool_name, ", ".join(injected))
-
-                        yield {"event": "tool_call", "data": {"tool": tool_name, "args": tool_args}}
-
-                        # Recover space_config from history if it was lost
-                        if session.space_config is None and tool_name in (
-                            "update_config", "validate_config", "create_space", "update_space",
-                        ):
-                            recovered = self._recover_config_from_history(session)
-                            if recovered:
-                                session.space_config = recovered
-                                logger.info("Recovered space_config from session history for %s", tool_name)
-
-                        loop = asyncio.get_event_loop()
-                        future = loop.run_in_executor(
-                            None, lambda n=tool_name, a=tool_args: handle_tool_call(n, a, session.space_config)
-                        )
-                        while not future.done():
-                            try:
-                                await asyncio.wait_for(asyncio.shield(future), timeout=3.0)
-                            except asyncio.TimeoutError:
-                                yield {"event": "heartbeat", "data": {"tool": tool_name}}
-                        result = future.result()
-
-                        tools_used.append(tool_name)
-
-                        yield {"event": "tool_result", "data": {"tool": tool_name, "result": result}}
-
-                        if tool_name == "create_space" and result.get("success"):
-                            session.space_id = result.get("space_id")
-                            session.space_url = result.get("space_url")
-                            yield {"event": "created", "data": {
-                                "space_id": result["space_id"],
-                                "url": result["space_url"],
-                                "display_name": result.get("display_name", ""),
-                            }}
-
-                        if tool_name == "update_space" and result.get("success"):
-                            yield {"event": "updated", "data": {
-                                "space_id": result["space_id"],
-                                "url": result["url"],
-                            }}
-
-                        if tool_name in ("generate_config", "update_config") and "config" in result:
-                            session.space_config = result["config"]
-
-                        session.add_tool_result(tc["id"], json.dumps(result, default=str))
-
-                    new_step = detect_step(session)
-                    if new_step != step:
-                        step = new_step
-                        step_idx = STEP_ORDER.index(step) if step in STEP_ORDER else 0
-                        yield {"event": "step", "data": {
-                            "step": step,
-                            "label": STEP_LABELS.get(step, step),
-                            "index": step_idx,
-                            "total": len(STEP_ORDER),
-                        }}
-                    else:
-                        step = new_step
-                    continue
-
+            else:
                 # Text-only response — conversation turn is done
                 session.add_message("assistant", accumulated_content)
                 ui_elements = self._extract_ui_hints(session)
                 yield {"event": "message", "data": {"content": accumulated_content, "ui_elements": ui_elements}}
-                break
-
-            else:
-                error_msg = "Agent exceeded maximum tool rounds"
-                yield {"event": "error", "data": {"message": error_msg}}
 
         except Exception as e:
             logger.exception("Create agent chat failed")
@@ -269,11 +273,11 @@ class CreateGenieAgent:
 
         if tools_used:
             logger.info(
-                "Agent turn complete: step=%s tools=%s error=%s",
-                step, tools_used, error_msg,
+                "Agent round complete: round=%d step=%s tools=%s continuation=%s error=%s",
+                round_num, step, tools_used, needs_continuation, error_msg,
             )
 
-        yield {"event": "done", "data": {}}
+        yield {"event": "done", "data": {"needs_continuation": needs_continuation}}
 
     _TOOL_RESULT_CHAR_LIMIT = 3000
     _COMPRESSIBLE_TOOLS = frozenset({
@@ -564,9 +568,13 @@ class CreateGenieAgent:
         if tool_name == "profile_table_usage":
             parts = []
             for tbl, info in data.get("tables", {}).items():
-                freq = info.get("query_frequency", "?")
-                users = info.get("distinct_users", "?")
-                parts.append(f"  - {tbl}: {freq} queries, {users} users")
+                queries = info.get("recent_queries", [])
+                freq = len(queries)
+                users = len({q.get("executed_by") for q in queries if q.get("executed_by")})
+                lin = info.get("lineage", {})
+                up = len(lin.get("upstream", []))
+                down = len(lin.get("downstream", []))
+                parts.append(f"  - {tbl}: {freq} queries, {users} users, {up} upstream, {down} downstream")
             if parts:
                 return "Usage profiles:\n" + "\n".join(parts)
             return None

--- a/backend/services/create_agent.py
+++ b/backend/services/create_agent.py
@@ -14,7 +14,8 @@ from typing import AsyncGenerator, Generator
 from backend.services.llm_utils import get_llm_model
 from backend.services.auth import get_workspace_client
 from backend.services.create_agent_session import AgentSession
-from backend.services.create_agent_tools import TOOL_DEFINITIONS, handle_tool_call
+from backend.services.create_agent_tools import TOOL_DEFINITIONS, handle_tool_call, _present_plan
+from backend.services import plan_builder
 from backend.prompts_create import assemble_system_prompt, detect_step
 
 logger = logging.getLogger(__name__)
@@ -212,10 +213,16 @@ class CreateGenieAgent:
                             session.space_config = recovered
                             logger.info("Recovered space_config from session history for %s", tool_name)
 
-                    loop = asyncio.get_event_loop()
-                    future = loop.run_in_executor(
-                        None, lambda n=tool_name, a=tool_args: handle_tool_call(n, a, session.space_config)
-                    )
+                    if tool_name == "generate_plan":
+                        loop = asyncio.get_event_loop()
+                        future = loop.run_in_executor(
+                            None, lambda a=tool_args: self._run_generate_plan(session, a)
+                        )
+                    else:
+                        loop = asyncio.get_event_loop()
+                        future = loop.run_in_executor(
+                            None, lambda n=tool_name, a=tool_args: handle_tool_call(n, a, session.space_config)
+                        )
                     while not future.done():
                         try:
                             await asyncio.wait_for(asyncio.shield(future), timeout=3.0)
@@ -776,6 +783,81 @@ class CreateGenieAgent:
 
         logger.warning("Could not repair truncated JSON (%d chars)", len(s))
         return {}
+
+    @staticmethod
+    def _run_generate_plan(session: AgentSession, tool_args: dict) -> dict:
+        """Run parallel plan generation using plan_builder.
+
+        Extracts tables_context and inspection_summaries from session history,
+        then calls plan_builder.generate_plan() which makes 4 parallel LLM calls.
+        Wraps the result through _present_plan for frontend rendering.
+        """
+        tables_context = []
+        inspection_summaries: dict = {}
+
+        for msg in session.history:
+            if msg["role"] != "tool":
+                continue
+            try:
+                result = json.loads(msg.get("content", "{}"))
+                if not isinstance(result, dict):
+                    continue
+
+                # describe_table results → tables_context
+                table_id = result.get("table")
+                if table_id and "columns" in result:
+                    existing_ids = {t.get("table") or t.get("table_name") for t in tables_context}
+                    if table_id not in existing_ids:
+                        tables_context.append(result)
+
+                # assess_data_quality results
+                if "overall_assessment" in result and "table_details" in result:
+                    inspection_summaries["quality"] = result
+
+                # profile_table_usage results
+                if "tables" in result and any(
+                    "recent_queries" in t for t in result.get("tables", []) if isinstance(t, dict)
+                ):
+                    inspection_summaries["usage"] = result
+
+                # profile_columns results
+                if "profiles" in result:
+                    inspection_summaries["profiles"] = result
+
+            except (json.JSONDecodeError, KeyError, TypeError):
+                continue
+
+        user_requirements = tool_args.get("user_requirements", "")
+
+        if not tables_context:
+            return {
+                "error": "No table inspection data found in session. Run describe_table first.",
+                "hint": "Call describe_table on each table before calling generate_plan.",
+            }
+
+        logger.info(
+            "Running parallel plan generation: %d tables, %d inspection sections, requirements=%d chars",
+            len(tables_context), len(inspection_summaries), len(user_requirements),
+        )
+
+        raw_plan = plan_builder.generate_plan(tables_context, inspection_summaries, user_requirements)
+
+        if "error" in raw_plan and "tables" not in raw_plan:
+            return raw_plan
+
+        warnings = raw_plan.pop("_generation_warnings", None)
+
+        _PLAN_KEYS = {
+            "tables", "sample_questions", "text_instructions", "example_sqls",
+            "measures", "filters", "expressions", "join_specs", "benchmarks",
+            "metric_views",
+        }
+        plan_args = {k: v for k, v in raw_plan.items() if k in _PLAN_KEYS}
+
+        result = _present_plan(**plan_args)
+        if warnings:
+            result["_generation_warnings"] = warnings
+        return result
 
     @staticmethod
     def _backfill_generate_config_args(session: AgentSession, tool_args: dict) -> list[str]:

--- a/backend/services/create_agent.py
+++ b/backend/services/create_agent.py
@@ -91,18 +91,17 @@ class CreateGenieAgent:
 
         if not is_continuation:
             session.add_message("user", user_message)
-            session._continuation_count = 0
+            session.continuation_count = 0
         else:
-            cnt = getattr(session, "_continuation_count", 0) + 1
-            session._continuation_count = cnt
-            if cnt > MAX_TOOL_ROUNDS:
+            session.continuation_count += 1
+            if session.continuation_count > MAX_TOOL_ROUNDS:
                 yield {"event": "error", "data": {"message": "Agent exceeded maximum tool rounds"}}
                 yield {"event": "done", "data": {"needs_continuation": False}}
                 return
 
         step = detect_step(session)
         step_idx = STEP_ORDER.index(step) if step in STEP_ORDER else 0
-        round_num = getattr(session, "_continuation_count", 0)
+        round_num = session.continuation_count
 
         yield {"event": "step", "data": {
             "step": step,
@@ -213,11 +212,26 @@ class CreateGenieAgent:
                             session.space_config = recovered
                             logger.info("Recovered space_config from session history for %s", tool_name)
 
-                    if tool_name == "generate_plan":
-                        loop = asyncio.get_event_loop()
-                        future = loop.run_in_executor(
-                            None, lambda a=tool_args: self._run_generate_plan(session, a)
+                    if tool_name in ("generate_plan", "present_plan"):
+                        plan_item_count = sum(
+                            len(v) for v in tool_args.values() if isinstance(v, list)
                         )
+                        use_parallel = (
+                            tool_name == "generate_plan"
+                            or plan_item_count < 15
+                        )
+                        if use_parallel:
+                            if tool_name == "present_plan":
+                                logger.info("Redirecting sparse present_plan (%d items) to parallel generate_plan", plan_item_count)
+                            loop = asyncio.get_event_loop()
+                            future = loop.run_in_executor(
+                                None, lambda a=tool_args: self._run_generate_plan(session, a)
+                            )
+                        else:
+                            loop = asyncio.get_event_loop()
+                            future = loop.run_in_executor(
+                                None, lambda n=tool_name, a=tool_args: handle_tool_call(n, a, session.space_config)
+                            )
                     else:
                         loop = asyncio.get_event_loop()
                         future = loop.run_in_executor(
@@ -265,7 +279,11 @@ class CreateGenieAgent:
                         "total": len(STEP_ORDER),
                     }}
 
-                needs_continuation = True
+                _STOP_TOOLS = {"generate_plan", "present_plan", "create_space", "update_space"}
+                if _STOP_TOOLS.intersection(tools_used):
+                    needs_continuation = False
+                else:
+                    needs_continuation = True
 
             else:
                 # Text-only response — conversation turn is done
@@ -351,11 +369,10 @@ class CreateGenieAgent:
             return compressed[:cls._TOOL_RESULT_CHAR_LIMIT] + "\n...(truncated)"
         return compressed
 
-    _INSPECTION_TOOLS = frozenset({
+    _COMPRESSIBLE_TOOLS_SET = frozenset({
         "describe_table", "profile_columns", "profile_table_usage",
         "assess_data_quality", "test_sql",
     })
-    _POST_INSPECTION_STEPS = frozenset({"plan", "config_create", "post_creation"})
 
     def _build_messages(self, session: AgentSession) -> list[dict]:
         """Build the full message list for the LLM call.
@@ -369,14 +386,11 @@ class CreateGenieAgent:
         3. Orphaned tool_use blocks: if the user stopped the stream mid-tool-call,
            inject synthetic "cancelled" results so Claude doesn't reject the history
 
-        When the workflow has moved past inspection (plan step or later),
-        old inspection tool-call/result pairs are replaced with a compact
-        summary to cut context size by ~70%.
+        Individual tool results are compressed (capped at 3000 chars) for
+        data-heavy tools, but the full conversation history is always
+        preserved so the LLM can see which tools have already been called.
         """
         self._heal_orphaned_tool_calls(session)
-
-        step = detect_step(session)
-        compact = step in self._POST_INSPECTION_STEPS
 
         prompt = assemble_system_prompt(session, self._get_schema_content())
         messages: list[dict] = [{"role": "system", "content": prompt}]
@@ -387,16 +401,50 @@ class CreateGenieAgent:
                 for tc in msg["tool_calls"]:
                     tc_id_to_name[tc["id"]] = tc["function"]["name"]
 
-        if compact:
-            messages = self._build_compacted_messages(
-                session, messages, tc_id_to_name,
-            )
-        else:
-            messages = self._build_full_messages(
-                session, messages, tc_id_to_name,
-            )
+        messages = self._build_full_messages(
+            session, messages, tc_id_to_name,
+        )
 
+        messages = self._sanitize_messages(messages)
         return messages
+
+    @staticmethod
+    def _sanitize_messages(messages: list[dict]) -> list[dict]:
+        """Fix message structure issues that cause Claude API 400 errors.
+
+        - Merges consecutive assistant messages (without tool/user in between)
+        - Ensures conversation ends with a user message (required by Databricks
+          Claude endpoint — no assistant prefill support)
+        """
+        if len(messages) < 2:
+            return messages
+
+        sanitized: list[dict] = [messages[0]]
+
+        for msg in messages[1:]:
+            prev = sanitized[-1]
+
+            if (
+                msg["role"] == "assistant"
+                and prev["role"] == "assistant"
+                and not prev.get("tool_calls")
+                and not msg.get("tool_calls")
+            ):
+                prev_content = prev.get("content") or ""
+                new_content = msg.get("content") or ""
+                merged = (prev_content + "\n\n" + new_content).strip()
+                prev["content"] = merged
+                logger.warning("Merged consecutive assistant messages (%d + %d chars)", len(prev_content), len(new_content))
+                continue
+
+            sanitized.append(msg)
+
+        last = sanitized[-1]
+        if last["role"] != "user":
+            sanitized.append({"role": "user", "content": "Continue."})
+            logger.info("Appended 'Continue.' user message — endpoint requires user-last")
+
+        return sanitized
 
     def _build_full_messages(
         self,
@@ -441,175 +489,6 @@ class CreateGenieAgent:
                     "content": msg.get("content") or " ",
                 })
         return messages
-
-    def _build_compacted_messages(
-        self,
-        session: AgentSession,
-        messages: list[dict],
-        tc_id_to_name: dict[str, str],
-    ) -> list[dict]:
-        """Build messages with inspection-phase tool results compacted.
-
-        Replaces verbose tool call/result pairs from profiling tools with
-        a single summary message, cutting context by ~70% for post-inspection
-        steps (plan, config_create, post_creation).
-        """
-        inspection_findings: list[str] = []
-        skip_tool_ids: set[str] = set()
-
-        # First pass: collect inspection tool results into summaries
-        for msg in session.history:
-            if msg["role"] == "tool":
-                tool_name = tc_id_to_name.get(msg["tool_call_id"], "unknown")
-                if tool_name in self._INSPECTION_TOOLS:
-                    skip_tool_ids.add(msg["tool_call_id"])
-                    summary = self._summarize_tool_result(tool_name, msg.get("content") or "{}")
-                    if summary:
-                        inspection_findings.append(summary)
-
-        # Also mark assistant messages whose tool_calls are ALL inspection tools
-        # so we can skip those too
-        skip_assistant_indices: set[int] = set()
-        for i, msg in enumerate(session.history):
-            if msg["role"] == "assistant" and msg.get("tool_calls"):
-                tc_ids = {tc["id"] for tc in msg["tool_calls"]}
-                if tc_ids and tc_ids.issubset(skip_tool_ids):
-                    skip_assistant_indices.add(i)
-
-        # Inject the compacted summary after the last user message before
-        # the first skipped block
-        summary_injected = False
-
-        for i, msg in enumerate(session.history):
-            if msg["role"] == "tool":
-                if msg["tool_call_id"] in skip_tool_ids:
-                    # Inject summary right before we start skipping
-                    if not summary_injected and inspection_findings:
-                        summary_text = (
-                            "Here is a summary of the data inspection findings:\n\n"
-                            + "\n\n".join(inspection_findings)
-                        )
-                        messages.append({"role": "assistant", "content": summary_text})
-                        summary_injected = True
-                    continue
-                tool_name = tc_id_to_name.get(msg["tool_call_id"], "unknown")
-                raw_content = msg.get("content") or "{}"
-                messages.append({
-                    "role": "tool",
-                    "tool_call_id": msg["tool_call_id"],
-                    "name": tool_name,
-                    "content": self._compress_tool_result(tool_name, raw_content),
-                })
-            elif i in skip_assistant_indices:
-                continue
-            elif msg["role"] == "assistant" and msg.get("tool_calls"):
-                # Mixed: some inspection, some not — keep only non-inspection calls
-                kept_tcs = [tc for tc in msg["tool_calls"] if tc["id"] not in skip_tool_ids]
-                if not kept_tcs:
-                    continue
-                tc_content = (msg.get("content") or "").strip() or None
-                normalized_tcs = []
-                for tc in kept_tcs:
-                    normalized_tcs.append({
-                        "id": tc["id"],
-                        "type": "function",
-                        "function": {
-                            "name": tc["function"]["name"],
-                            "arguments": tc["function"].get("arguments") or "{}",
-                        },
-                    })
-                tc_msg: dict = {"role": "assistant", "content": tc_content, "tool_calls": normalized_tcs}
-                messages.append(tc_msg)
-            elif msg["role"] == "assistant":
-                content = msg.get("content") or ""
-                if not content.strip():
-                    continue
-                messages.append({"role": "assistant", "content": content})
-            else:
-                messages.append({
-                    "role": msg["role"],
-                    "content": msg.get("content") or " ",
-                })
-
-        # If we collected findings but never injected (edge case), append now
-        if not summary_injected and inspection_findings:
-            summary_text = (
-                "Here is a summary of the data inspection findings:\n\n"
-                + "\n\n".join(inspection_findings)
-            )
-            messages.append({"role": "assistant", "content": summary_text})
-
-        return messages
-
-    @staticmethod
-    def _summarize_tool_result(tool_name: str, content: str) -> str | None:
-        """Extract a compact summary from an inspection tool result."""
-        try:
-            data = json.loads(content)
-        except (json.JSONDecodeError, TypeError):
-            return None
-
-        if tool_name == "describe_table":
-            table = data.get("table_name", "?")
-            cols = data.get("columns", [])
-            col_names = [c.get("name", "?") for c in cols[:50]]
-            row_count = data.get("row_count", "?")
-            return (
-                f"**{table}**: {len(cols)} columns ({', '.join(col_names)}), "
-                f"~{row_count} rows"
-            )
-
-        if tool_name == "profile_columns":
-            parts = []
-            for col, profile in data.get("profiles", {}).items():
-                dtype = profile.get("data_type", "?")
-                nulls = profile.get("null_pct", "?")
-                distinct = profile.get("distinct_count", "?")
-                vals = profile.get("distinct_values", [])[:5]
-                vals_str = ", ".join(str(v) for v in vals)
-                parts.append(f"  - {col} ({dtype}): {distinct} distinct, {nulls}% null, samples=[{vals_str}]")
-            if parts:
-                return "Column profiles:\n" + "\n".join(parts)
-            return None
-
-        if tool_name == "profile_table_usage":
-            parts = []
-            for tbl, info in data.get("tables", {}).items():
-                queries = info.get("recent_queries", [])
-                freq = len(queries)
-                users = len({q.get("executed_by") for q in queries if q.get("executed_by")})
-                lin = info.get("lineage", {})
-                up = len(lin.get("upstream", []))
-                down = len(lin.get("downstream", []))
-                parts.append(f"  - {tbl}: {freq} queries, {users} users, {up} upstream, {down} downstream")
-            if parts:
-                return "Usage profiles:\n" + "\n".join(parts)
-            return None
-
-        if tool_name == "assess_data_quality":
-            parts = []
-            for tbl, info in data.get("tables", {}).items():
-                if isinstance(info, dict):
-                    score = info.get("overall_score", info.get("quality_score", "?"))
-                    issues = info.get("issues", [])
-                    issue_str = "; ".join(str(i) for i in issues[:3]) if issues else "none"
-                    parts.append(f"  - {tbl}: score={score}, issues: {issue_str}")
-            if parts:
-                return "Data quality:\n" + "\n".join(parts)
-            return None
-
-        if tool_name == "test_sql":
-            status = "OK" if data.get("success") or "data" in data else "FAILED"
-            query = data.get("query", data.get("sql", "?"))[:120]
-            row_ct = len(data.get("data", []))
-            cols = data.get("columns", [])
-            col_str = ", ".join(str(c) for c in cols[:10]) if cols else "?"
-            error = data.get("error", "")
-            if error:
-                return f"SQL test ({status}): `{query}` → error: {error[:200]}"
-            return f"SQL test ({status}): `{query}` → {row_ct} rows, columns=[{col_str}]"
-
-        return None
 
     @staticmethod
     def _heal_orphaned_tool_calls(session: AgentSession) -> None:
@@ -693,9 +572,11 @@ class CreateGenieAgent:
 
         try:
             if not resp.ok:
-                error_body = resp.text[:500]
+                error_body = resp.text[:1000]
                 logger.error("LLM endpoint returned %s: %s", resp.status_code, error_body)
-                resp.raise_for_status()
+                raise RuntimeError(
+                    f"LLM endpoint returned {resp.status_code}: {error_body[:300]}"
+                )
 
             resp.encoding = "utf-8"
             for line in resp.iter_lines(decode_unicode=True):
@@ -853,6 +734,15 @@ class CreateGenieAgent:
             "metric_views",
         }
         plan_args = {k: v for k, v in raw_plan.items() if k in _PLAN_KEYS}
+
+        total_items = sum(len(v) for v in plan_args.values() if isinstance(v, list))
+        if total_items == 0:
+            logger.error("generate_plan produced an empty plan. raw_plan keys: %s, warnings: %s", list(raw_plan.keys()), warnings)
+            return {
+                "error": "Plan generation produced empty results. This usually means the parallel LLM calls failed.",
+                "details": warnings or "No warnings captured — check server logs.",
+                "hint": "Try again, or use present_plan with manually constructed data.",
+            }
 
         result = _present_plan(**plan_args)
         if warnings:

--- a/backend/services/create_agent.py
+++ b/backend/services/create_agent.py
@@ -691,21 +691,26 @@ class CreateGenieAgent:
                     if table_id not in existing_ids:
                         tables_context.append(result)
 
-                # assess_data_quality results
-                if "overall_assessment" in result and "table_details" in result:
+                # assess_data_quality results — returns {"tables": {...}, "summary": {"tables_assessed": N, ...}}
+                summary_val = result.get("summary")
+                if isinstance(summary_val, dict) and "tables_assessed" in summary_val:
                     inspection_summaries["quality"] = result
 
-                # profile_table_usage results
-                if "tables" in result and any(
-                    "recent_queries" in t for t in result.get("tables", []) if isinstance(t, dict)
+                # profile_table_usage results — tables is a dict keyed by table id
+                # (discover_tables also has "tables" but as a list — guard with isinstance)
+                tables_val = result.get("tables")
+                if isinstance(tables_val, dict) and any(
+                    "recent_queries" in v for v in tables_val.values() if isinstance(v, dict)
                 ):
                     inspection_summaries["usage"] = result
 
-                # profile_columns results
-                if "profiles" in result:
-                    inspection_summaries["profiles"] = result
+                # profile_columns results — accumulate across tables
+                if "profiles" in result and result.get("table"):
+                    if "profiles" not in inspection_summaries:
+                        inspection_summaries["profiles"] = {}
+                    inspection_summaries["profiles"][result["table"]] = result["profiles"]
 
-            except (json.JSONDecodeError, KeyError, TypeError):
+            except (json.JSONDecodeError, KeyError, TypeError, AttributeError):
                 continue
 
         user_requirements = tool_args.get("user_requirements", "")
@@ -790,6 +795,29 @@ class CreateGenieAgent:
                 tool_args["tables"] = list(tables_by_id.values())
                 injected.append(f"tables({len(tables_by_id)})")
 
+        # --- Extract user's edited plan from selections (preferred source) ---
+        # Selections are embedded by routers/create.py as "[User selections: <json>]"
+        # at the end of the user message. We only check the most recent user message.
+        _SELECTIONS_MARKER = "[User selections: "
+        edited_plan: dict | None = None
+        last_user_msg = next(
+            (m for m in reversed(session.history) if m["role"] == "user"), None
+        )
+        if last_user_msg:
+            content = last_user_msg.get("content", "")
+            idx = content.find(_SELECTIONS_MARKER)
+            if idx >= 0:
+                # Extract JSON between marker and the closing "]" — find the matching
+                # bracket by parsing forward from the marker, not using rindex which
+                # could match a "]" inside the user's own message text.
+                json_start = idx + len(_SELECTIONS_MARKER)
+                try:
+                    sel = json.loads(content[json_start:].rstrip().removesuffix("]"))
+                    if isinstance(sel, dict) and "edited_plan" in sel:
+                        edited_plan = sel["edited_plan"]
+                except (json.JSONDecodeError, ValueError):
+                    pass
+
         # --- Extract plan data from the most recent present_plan result ---
         plan_sections: dict | None = None
         for msg in reversed(session.history):
@@ -803,7 +831,19 @@ class CreateGenieAgent:
             except (json.JSONDecodeError, KeyError, TypeError):
                 continue
 
+        # Merge: edited_plan overrides plan_sections where present
+        merged: dict = {}
         if plan_sections:
+            merged.update(plan_sections)
+        if edited_plan:
+            # text_instructions comes as a single string from frontend; convert to list
+            if "text_instructions" in edited_plan:
+                ti = edited_plan["text_instructions"]
+                if isinstance(ti, str):
+                    edited_plan["text_instructions"] = [ti] if ti.strip() else []
+            merged.update({k: v for k, v in edited_plan.items() if v})
+
+        if merged:
             mapping = {
                 "tables": "tables",
                 "sample_questions": "sample_questions",
@@ -816,13 +856,14 @@ class CreateGenieAgent:
                 "benchmarks": "benchmarks",
                 "metric_views": "metric_views",
             }
+            source = "edited_plan" if edited_plan else "plan_sections"
             for plan_key, arg_key in mapping.items():
                 if arg_key not in tool_args:
-                    val = plan_sections.get(plan_key)
+                    val = merged.get(plan_key)
                     if val:
                         tool_args[arg_key] = val
                         count = len(val) if isinstance(val, list) else 1
-                        injected.append(f"{arg_key}({count})")
+                        injected.append(f"{arg_key}({count}|{source})")
 
         return injected
 

--- a/backend/services/create_agent_session.py
+++ b/backend/services/create_agent_session.py
@@ -4,6 +4,7 @@ Maintains conversation history and accumulated state per session.
 Persists to Lakebase (PostgreSQL) when available, falls back to in-memory.
 """
 
+import asyncio
 import json
 import time
 import logging
@@ -25,6 +26,8 @@ class AgentSession:
     space_config: dict | None = None
     space_id: str | None = None
     space_url: str | None = None
+    continuation_count: int = 0
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
 
     def add_message(self, role: str, content: str) -> None:
         self.history.append({"role": role, "content": content})

--- a/backend/services/create_agent_tools.py
+++ b/backend/services/create_agent_tools.py
@@ -44,6 +44,14 @@ _DATE_TYPES = {"date", "timestamp", "timestamp_ntz"}
 _NUMERIC_TYPES = {"int", "bigint", "smallint", "tinyint", "float", "double", "decimal"}
 _BOOLEAN_TYPES = {"boolean"}
 
+# Genie API accepts: STRING, INTEGER, DOUBLE, DECIMAL, DATE, BOOLEAN.
+# Map common LLM-generated aliases to valid values.
+_TYPE_HINT_MAP = {
+    "NUMBER": "INTEGER", "INT": "INTEGER", "BIGINT": "INTEGER",
+    "SMALLINT": "INTEGER", "TINYINT": "INTEGER",
+    "FLOAT": "DOUBLE", "TIMESTAMP": "DATE",
+}
+
 # Cap concurrent SQL statements to avoid overwhelming the warehouse.
 # 3 is safe for even a 2X-Small Pro warehouse; serverless could handle
 # much more but we design for the lowest common denominator.
@@ -704,12 +712,13 @@ TOOL_DEFINITIONS = [
         "type": "function",
         "function": {
             "name": "update_space",
-            "description": "Update an existing Genie space with a new configuration. Use this instead of create_space when the space has already been created and the user wants to modify it.",
+            "description": "Update an existing Genie space — config, display name, or both. Use this instead of create_space when the space has already been created. Supports renaming.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "space_id": {"type": "string", "description": "The ID of the existing Genie space to update"},
                     "config": {"type": "object", "description": "The validated serialized_space dict (optional — defaults to last generated config)"},
+                    "display_name": {"type": "string", "description": "New display name for the space (optional — only if renaming)"},
                 },
                 "required": ["space_id"],
             },
@@ -1017,8 +1026,11 @@ def _describe_table(table_identifier: str) -> dict:
         if host:
             uc_url = f"{host}/explore/data/{parts[0]}/{parts[1]}/{parts[2]}"
 
+    table_type = str(table_info.table_type) if table_info.table_type else None
+
     result_dict: dict[str, Any] = {
         "table": table_identifier,
+        "table_type": table_type,
         "comment": table_info.comment,
         "columns": columns,
         "column_count": len(columns),
@@ -1955,8 +1967,7 @@ def _generate_config(
                 params = []
                 for p in eq["parameters"]:
                     raw_hint = p.get("type_hint", "STRING").upper()
-                    _NUMERIC_HINTS = {"INTEGER", "INT", "DECIMAL", "FLOAT", "DOUBLE", "BIGINT", "SMALLINT", "TINYINT"}
-                    normalized_hint = "NUMBER" if raw_hint in _NUMERIC_HINTS else raw_hint
+                    normalized_hint = _TYPE_HINT_MAP.get(raw_hint, raw_hint)
                     param_entry: dict[str, Any] = {
                         "name": p["name"],
                         "type_hint": normalized_hint,
@@ -1966,6 +1977,7 @@ def _generate_config(
                     if p.get("default_value"):
                         param_entry["default_value"] = {"values": [p["default_value"]]}
                     params.append(param_entry)
+                params.sort(key=lambda x: x["name"])
                 entry["parameters"] = params
             eq_items.append(entry)
         eq_items.sort(key=lambda x: x["id"])
@@ -2730,21 +2742,25 @@ def _create_space(display_name: str, config: dict | None = None, parent_path: st
 
 
 @mlflow.trace(name="update_space", span_type=SpanType.TOOL)
-def _update_space(space_id: str, config: dict | None = None) -> dict:
-    """Update an existing Genie space with a new configuration."""
-    if not config:
-        return {"success": False, "error": "No config provided — call generate_config first"}
+def _update_space(space_id: str, config: dict | None = None, display_name: str | None = None) -> dict:
+    """Update an existing Genie space with a new configuration and/or name."""
+    if not config and not display_name:
+        return {"success": False, "error": "No config or display_name provided"}
     try:
         from backend.services.auth import get_workspace_client, get_databricks_host
         from backend.genie_creator import _enforce_constraints, _clean_config
 
-        constrained = _enforce_constraints(config)
-        cleaned = _clean_config(constrained)
-        serialized = json.dumps(cleaned)
+        body: dict[str, Any] = {}
+
+        if config:
+            constrained = _enforce_constraints(config)
+            cleaned = _clean_config(constrained)
+            body["serialized_space"] = json.dumps(cleaned)
+
+        if display_name:
+            body["display_name"] = display_name
 
         warehouse_id = get_sql_warehouse_id()
-
-        body: dict[str, Any] = {"serialized_space": serialized}
         if warehouse_id:
             body["warehouse_id"] = warehouse_id
 

--- a/backend/services/create_agent_tools.py
+++ b/backend/services/create_agent_tools.py
@@ -445,11 +445,39 @@ TOOL_DEFINITIONS = [
     {
         "type": "function",
         "function": {
+            "name": "generate_plan",
+            "description": (
+                "Generate the complete Genie Space plan using PARALLEL LLM calls (4x faster than "
+                "building it manually). Extracts table context and inspection findings from session "
+                "history automatically — you only need to pass user_requirements summarizing the "
+                "user's goals and business context. Returns the plan as a present_plan result for "
+                "user review. Use this INSTEAD of calling present_plan with manually constructed data."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "user_requirements": {
+                        "type": "string",
+                        "description": (
+                            "Summary of the user's goals, audience, business context, and any "
+                            "specific rules they mentioned. Include terminology definitions, "
+                            "fiscal calendars, default assumptions — anything the plan should reflect."
+                        ),
+                    },
+                },
+                "required": ["user_requirements"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "present_plan",
             "description": (
                 "Present a structured plan for the user to review BEFORE generating the config. "
                 "The frontend renders this as collapsible sections mirroring the Genie Space UI tabs. "
-                "Call this after the business logic checkpoint — the user must approve the plan before "
+                "Prefer generate_plan (parallel, faster) unless you need to manually construct "
+                "or revise specific plan sections. The user must approve the plan before "
                 "you call generate_config. Parameters are IDENTICAL to generate_config so the plan "
                 "is a 1:1 preview of what will be created."
             ),
@@ -831,6 +859,7 @@ def handle_tool_call(name: str, arguments: dict, session_config: dict | None = N
         "profile_columns": _profile_columns,
         "test_sql": _test_sql,
         "discover_warehouses": _discover_warehouses,
+        "generate_plan": _generate_plan_fallback,
         "present_plan": _present_plan,
         "get_config_schema": _get_config_schema,
         "generate_config": _generate_config,
@@ -1647,8 +1676,8 @@ def _substitute_params(sql: str, parameters: list[dict] | None) -> str:
         if not name:
             continue
         type_hint = param.get("type_hint", "STRING").upper()
-        if type_hint in ("NUMBER", "BOOLEAN"):
-            literal = value
+        if type_hint in ("NUMBER", "BOOLEAN", "INTEGER", "INT", "DECIMAL", "FLOAT", "DOUBLE", "BIGINT", "SMALLINT", "TINYINT"):
+            literal = str(value)
         else:
             literal = f"'{value}'"
         sql = re.sub(rf":{re.escape(name)}\b", literal, sql)
@@ -1733,6 +1762,21 @@ def _get_config_schema() -> dict:
     except FileNotFoundError:
         return {"error": "Schema reference file not found"}
     return {"schema_reference": content}
+
+
+def _generate_plan_fallback(**kwargs) -> dict:
+    """Fallback if generate_plan is called through normal dispatch.
+
+    The real implementation lives in create_agent.py which has access to
+    session history.  This returns an error nudging the agent to provide
+    the context manually via present_plan.
+    """
+    return {
+        "error": (
+            "generate_plan requires session context (handled by the agent). "
+            "If you see this, call present_plan with the plan data instead."
+        ),
+    }
 
 
 def _present_plan(
@@ -1910,9 +1954,12 @@ def _generate_config(
             if eq.get("parameters"):
                 params = []
                 for p in eq["parameters"]:
+                    raw_hint = p.get("type_hint", "STRING").upper()
+                    _NUMERIC_HINTS = {"INTEGER", "INT", "DECIMAL", "FLOAT", "DOUBLE", "BIGINT", "SMALLINT", "TINYINT"}
+                    normalized_hint = "NUMBER" if raw_hint in _NUMERIC_HINTS else raw_hint
                     param_entry: dict[str, Any] = {
                         "name": p["name"],
-                        "type_hint": p.get("type_hint", "STRING"),
+                        "type_hint": normalized_hint,
                     }
                     if p.get("description"):
                         param_entry["description"] = [p["description"]]

--- a/backend/services/create_agent_tools.py
+++ b/backend/services/create_agent_tools.py
@@ -1498,10 +1498,12 @@ def _profile_table_usage(table_identifiers: list[str]) -> dict:
             hist = {"error": str(e)}
 
     for tbl in table_identifiers:
-        tbl_short = tbl.split(".")[-1]
+        tbl_lower = tbl.lower()
+        tbl_short_lower = tbl.split(".")[-1].lower()
         tbl_hist = [
             q for q in hist.get("queries", [])
-            if tbl in q.get("query_preview", "") or tbl_short in q.get("query_preview", "")
+            if tbl_lower in q.get("query_preview", "").lower()
+            or tbl_short_lower in q.get("query_preview", "").lower()
         ]
         results.setdefault(tbl, {})["recent_queries"] = tbl_hist[:10]
 
@@ -1548,18 +1550,18 @@ def _fetch_query_history(table_identifiers: list[str]) -> dict:
         return {"queries": []}
 
     like_clauses = " OR ".join(
-        f"statement_text LIKE '%{tbl}%'" for tbl in table_identifiers
+        f"LOWER(statement_text) LIKE '%{tbl.lower()}%'" for tbl in table_identifiers
     )
     sql = (
         f"SELECT executed_by, "
-        f"SUBSTRING(statement_text, 1, 150) AS query_preview, "
+        f"SUBSTRING(statement_text, 1, 300) AS query_preview, "
         f"total_duration_ms, produced_rows "
         f"FROM system.query.history "
         f"WHERE start_time >= date_sub(current_date(), 7) "
         f"AND execution_status = 'FINISHED' "
         f"AND ({like_clauses}) "
         f"ORDER BY start_time DESC "
-        f"LIMIT 10"
+        f"LIMIT 50"
     )
     result = _execute_sql_throttled(sql)
     if result.get("error"):

--- a/backend/services/plan_builder.py
+++ b/backend/services/plan_builder.py
@@ -197,12 +197,16 @@ def _gen_questions_instructions(shared: str) -> dict:
         f"Context:\n{shared}"
     )
 
-    response = call_serving_endpoint(
-        [{"role": "user", "content": prompt}],
-        model=get_llm_model(),
-        max_tokens=1024,
-    )
-    return parse_json_from_llm_response(response)
+    try:
+        response = call_serving_endpoint(
+            [{"role": "user", "content": prompt}],
+            model=get_llm_model(),
+            max_tokens=2048,
+        )
+        return parse_json_from_llm_response(response)
+    except Exception as e:
+        logger.exception("questions/instructions generation failed")
+        raise RuntimeError(f"questions/instructions LLM call failed: {e}") from e
 
 
 def _gen_sqls_benchmarks(shared: str) -> dict:
@@ -262,7 +266,7 @@ def _gen_analytics(shared: str) -> dict:
     response = call_serving_endpoint(
         [{"role": "user", "content": prompt}],
         model=get_llm_model(),
-        max_tokens=1024,
+        max_tokens=2048,
     )
     return parse_json_from_llm_response(response)
 

--- a/backend/services/plan_builder.py
+++ b/backend/services/plan_builder.py
@@ -1,21 +1,23 @@
 """Parallel plan generation — builds a Genie Space plan via concurrent LLM calls.
 
 Instead of one monolithic LLM call that generates the entire plan JSON (slow,
-truncation-prone), this module splits the plan into 4 independent sections and
+truncation-prone), this module splits the plan into 5 independent sections and
 generates them in parallel. Each section gets a focused prompt and a small
 max_tokens budget, then results are assembled programmatically.
 
 Parallel calls:
   A: table descriptions + column_configs  (mostly programmatic, LLM for descriptions)
   B: sample_questions + text_instructions
-  C: example_sqls + benchmarks
-  D: join_specs + measures + filters + expressions
+  C: example_sqls
+  D: benchmarks
+  E: join_specs + measures + filters + expressions (analytics)
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
@@ -24,7 +26,13 @@ from backend.services.create_agent_tools import _test_sql
 
 logger = logging.getLogger(__name__)
 
-_CONCURRENCY = 4
+# Thread pool size matches the 5 parallel plan sections (tables, questions,
+# example_sqls, benchmarks, analytics) so all sections start simultaneously.
+_CONCURRENCY = 5
+
+# SQL validation can have up to 15 tasks (5 example_sqls + 10 benchmarks).
+# Higher parallelism than plan generation since each task is a SQL warehouse call.
+_VALIDATION_CONCURRENCY = 8
 
 
 def generate_plan(
@@ -48,7 +56,8 @@ def generate_plan(
     section_specs: list[tuple[str, callable, dict]] = [
         ("tables", _gen_tables, {"shared": shared_context, "tables_context": tables_context}),
         ("questions", _gen_questions_instructions, {"shared": shared_context}),
-        ("sqls", _gen_sqls_benchmarks, {"shared": shared_context}),
+        ("example_sqls", _gen_example_sqls, {"shared": shared_context}),
+        ("benchmarks", _gen_benchmarks, {"shared": shared_context}),
         ("analytics", _gen_analytics, {"shared": shared_context}),
     ]
 
@@ -71,7 +80,7 @@ def generate_plan(
 
     plan = _assemble(results, tables_context)
 
-    validated = _validate_plan_sqls(plan)
+    validated = _validate_plan_sqls(plan, shared_context=shared_context)
     if validated:
         errors.extend(validated)
 
@@ -80,6 +89,29 @@ def generate_plan(
         logger.warning("Plan generated with %d section error(s): %s", len(errors), errors)
 
     return plan
+
+
+def _table_id(t: dict) -> str:
+    """Extract the canonical table identifier from a describe_table result."""
+    return t.get("table") or t.get("table_name") or t.get("identifier", "?")
+
+
+def _call_llm_section(prompt: str, max_tokens: int, section_name: str) -> dict:
+    """Call the LLM serving endpoint and parse the JSON response.
+
+    Raises RuntimeError (re-raised from the original) on failure so the
+    ThreadPoolExecutor in generate_plan can catch and log it per-section.
+    """
+    try:
+        response = call_serving_endpoint(
+            [{"role": "user", "content": prompt}],
+            model=get_llm_model(),
+            max_tokens=max_tokens,
+        )
+        return parse_json_from_llm_response(response)
+    except Exception as e:
+        logger.exception("%s generation failed", section_name)
+        raise RuntimeError(f"{section_name} LLM call failed: {e}") from e
 
 
 def _build_shared_context(
@@ -95,7 +127,7 @@ def _build_shared_context(
 
     table_lines = []
     for t in tables_context:
-        name = t.get("table") or t.get("table_name") or t.get("identifier", "?")
+        name = _table_id(t)
         comment = t.get("comment", "")
         cols = t.get("columns", [])
         col_summary = ", ".join(c.get("name", "?") for c in cols[:20])
@@ -114,17 +146,114 @@ def _build_shared_context(
 
     quality = inspection_summaries.get("quality")
     if quality and not quality.get("error"):
-        parts.append(f"## Data Quality\n{json.dumps(quality, indent=2, default=str)[:2000]}")
+        parts.append(f"## Data Quality\n{json.dumps(quality, indent=2, default=str)[:3000]}")
 
     profiles = inspection_summaries.get("profiles")
     if profiles:
-        parts.append(f"## Column Profiles\n{json.dumps(profiles, indent=2, default=str)[:2000]}")
+        # Only include profiles for tables the user selected, not ones they explored and discarded
+        selected_ids = {_table_id(t) for t in tables_context}
+        relevant = {k: v for k, v in profiles.items() if k in selected_ids} if selected_ids else profiles
+        parts.append(f"## Column Profiles (actual values from data)\n{_summarize_profiles(relevant)}")
 
     usage = inspection_summaries.get("usage")
     if usage and not usage.get("error"):
-        parts.append(f"## Usage Patterns\n{json.dumps(usage, indent=2, default=str)[:1500]}")
+        parts.append(f"## Usage Patterns\n{_summarize_usage(usage)}")
 
     return "\n\n".join(parts)
+
+
+def _normalize_sql(sql: str) -> str:
+    """Normalize a SQL snippet to a pattern key for deduplication.
+
+    Strips string literals, numbers, and extra whitespace so that
+    repeated executions of the same query (with different filter values)
+    collapse to the same pattern.
+    """
+    s = sql.lower()
+    s = re.sub(r"'[^']*'", "?", s)          # strip string literals
+    s = re.sub(r"\b\d+(\.\d+)?\b", "?", s)  # strip numeric literals
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def _summarize_usage(usage: dict) -> str:
+    """Convert raw profile_table_usage output into compact, dense signal.
+
+    Instead of dumping JSON (mostly structure overhead), surfaces:
+    - Top columns by query frequency (already extracted by _extract_column_patterns)
+    - Unique query patterns (deduplicated by normalized SQL, not raw text)
+    - Lineage summary (upstream sources, downstream consumers)
+    """
+    lines: list[str] = []
+
+    # Column frequency — already computed, zero processing needed
+    col_usage: dict[str, int] = usage.get("column_usage", {})
+    if col_usage:
+        top_cols = sorted(col_usage.items(), key=lambda x: -x[1])[:10]
+        lines.append("Most queried columns: " + ", ".join(f"{c} ({n}x)" for c, n in top_cols))
+
+    # Unique query patterns per table
+    seen_patterns: set[str] = set()
+    pattern_lines: list[str] = []
+
+    for tbl, info in usage.get("tables", {}).items():
+        if not isinstance(info, dict):
+            continue
+        short = tbl.split(".")[-1]
+        queries = info.get("recent_queries", [])
+        for q in queries:
+            preview = q.get("query_preview", "")
+            if not preview:
+                continue
+            pattern = _normalize_sql(preview)
+            if pattern in seen_patterns:
+                continue
+            seen_patterns.add(pattern)
+            pattern_lines.append(f"  [{short}] {preview[:120]}")
+
+    if pattern_lines:
+        lines.append(f"Unique query patterns ({len(seen_patterns)} total):")
+        lines.extend(pattern_lines[:15])  # cap at 15 to control token spend
+
+    # Lineage summary
+    summary = usage.get("summary", {})
+    downstream = summary.get("total_downstream_consumers", 0)
+    upstream = summary.get("total_upstream_sources", 0)
+    if downstream or upstream:
+        lines.append(f"Lineage: {upstream} upstream source(s), {downstream} downstream consumer(s)")
+
+    return "\n".join(lines) if lines else "No recent query activity found."
+
+
+def _summarize_profiles(profiles: dict) -> str:
+    """Convert accumulated profile_columns data into compact text.
+
+    profiles is a dict keyed by table identifier, each value is a dict
+    of column_name → {"distinct_values": [...], "has_more": bool}.
+    Renders as: table.column: val1, val2, val3 (+ more)
+    This ensures the LLM sees REAL data values, not hallucinated ones.
+    """
+    lines: list[str] = []
+    for table_id, col_profiles in profiles.items():
+        if not isinstance(col_profiles, dict):
+            continue
+        short_table = table_id.split(".")[-1] if "." in table_id else table_id
+        for col_name, info in col_profiles.items():
+            if not isinstance(info, dict) or "error" in info:
+                continue
+            values = info.get("distinct_values", [])
+            if not values:
+                continue
+            val_str = ", ".join(str(v) for v in values[:10])
+            suffix = " (+ more)" if info.get("has_more") else ""
+            lines.append(f"  {short_table}.{col_name}: {val_str}{suffix}")
+            if len(lines) >= 60:  # cap to control LLM context size
+                break
+        if len(lines) >= 60:
+            break
+    if not lines:
+        return "No column profiles available."
+    return "IMPORTANT — Use ONLY these actual values in SQL and instructions:\n" + "\n".join(lines)
 
 
 def _gen_tables(shared: str, tables_context: list[dict]) -> dict:
@@ -132,10 +261,11 @@ def _gen_tables(shared: str, tables_context: list[dict]) -> dict:
 
     Mostly programmatic (columns come from inspection), with an LLM call
     to generate human-readable descriptions for ambiguous columns.
+    Falls back to raw metadata on LLM failure — table configs are optional enrichment.
     """
     tables = []
     for t in tables_context:
-        name = t.get("table") or t.get("table_name") or t.get("identifier", "?")
+        name = _table_id(t)
         cols = t.get("columns", [])
         recs = t.get("recommendations", {})
         exclude = set(recs.get("exclude_etl", []))
@@ -170,12 +300,7 @@ def _gen_tables(shared: str, tables_context: list[dict]) -> dict:
     )
 
     try:
-        response = call_serving_endpoint(
-            [{"role": "user", "content": prompt}],
-            model=get_llm_model(),
-            max_tokens=2048,
-        )
-        result = parse_json_from_llm_response(response)
+        result = _call_llm_section(prompt, max_tokens=2048, section_name="tables")
         return result if "tables" in result else {"tables": tables}
     except Exception:
         logger.warning("Table description enrichment failed, using raw metadata")
@@ -191,90 +316,164 @@ def _gen_questions_instructions(shared: str) -> dict:
         "2. **text_instructions**: Domain knowledge for the Genie agent, organized under "
         "category headers (## Terminology, ## Default Assumptions, ## Data Quality Warnings, etc.)\n\n"
         "Text instructions should contain ONLY business logic and terminology — NOT SQL formulas, "
-        "filter expressions, or join definitions (those go in other sections).\n\n"
+        "filter expressions, or join definitions (those go in other sections).\n"
+        "CRITICAL: Only reference category names, tiers, statuses, and labels that appear in the "
+        "Column Profiles section below. Do NOT invent terms — use real data values.\n\n"
         "Return ONLY valid JSON:\n"
         '{"sample_questions": ["..."], "text_instructions": ["## Terminology\\n- ...", "## Default Assumptions\\n- ..."]}\n\n'
         f"Context:\n{shared}"
     )
-
-    try:
-        response = call_serving_endpoint(
-            [{"role": "user", "content": prompt}],
-            model=get_llm_model(),
-            max_tokens=2048,
-        )
-        return parse_json_from_llm_response(response)
-    except Exception as e:
-        logger.exception("questions/instructions generation failed")
-        raise RuntimeError(f"questions/instructions LLM call failed: {e}") from e
+    return _call_llm_section(prompt, max_tokens=3000, section_name="questions/instructions")
 
 
-def _gen_sqls_benchmarks(shared: str) -> dict:
-    """Generate example_sqls and benchmarks."""
+def _gen_example_sqls(shared: str) -> dict:
+    """Generate example_sqls (question + SQL pairs that teach Genie query patterns).
+
+    Hard cap: exactly 5 pairs. At ~300 tokens each (question + SQL + params + JSON),
+    5 pairs = ~1500 tokens — well within the 3000 max_tokens budget even for
+    complex multi-table queries with CTEs.
+    """
     prompt = (
-        "You are creating example SQL queries and benchmark tests for a Databricks Genie Space.\n\n"
-        "Based on the context below, generate:\n"
-        "1. **example_sqls**: 5-8 question+SQL pairs that teach Genie query patterns.\n"
+        "You are creating example SQL queries for a Databricks Genie Space.\n\n"
+        "Generate EXACTLY 5 question+SQL pairs that teach Genie how to write correct queries.\n"
         "   - Use fully-qualified table names (catalog.schema.table)\n"
         "   - Use parameterized SQL (:param_name) when the question involves user-supplied values\n"
         "   - Each parameter needs: name, type_hint (STRING/NUMBER/DATE/BOOLEAN), "
         "default_value (real value from data), description\n"
         "   - The question should be concrete (use the default value, not a placeholder)\n"
-        "   - Mix: ~3 hardcoded patterns + ~3-5 parameterized queries\n\n"
-        "2. **benchmarks**: EXACTLY 12 question + expected_sql pairs for validation.\n"
-        "   This is the most important section — the space quality depends on benchmark coverage.\n"
-        "   - Cover edge cases (nulls, empty results, ambiguous terms)\n"
-        "   - Include time-range and metric-definition tests\n"
-        "   - Include aggregation, filtering, grouping, and join patterns\n"
-        "   - Mix simple single-table queries with complex multi-table queries\n"
-        "   - You MUST generate at least 10 benchmarks. 12 is ideal.\n\n"
+        "   - Mix: ~2 hardcoded patterns + ~3 parameterized queries\n"
+        "   - IMPORTANT: Generate no more than 5 pairs total.\n"
+        "   - CRITICAL: Only use filter values that appear in the Column Profiles section below.\n"
+        "     Do NOT invent status values, tier names, or category labels — use real data.\n\n"
         "Return ONLY valid JSON:\n"
-        '{"example_sqls": [{"question": "...", "sql": "...", "parameters": [...]}], '
-        '"benchmarks": [{"question": "...", "expected_sql": "..."}]}\n\n'
+        '{"example_sqls": [{"question": "...", "sql": "...", "parameters": [...]}]}\n\n'
         f"Context:\n{shared}"
     )
+    return _call_llm_section(prompt, max_tokens=3000, section_name="example_sqls")
 
-    response = call_serving_endpoint(
-        [{"role": "user", "content": prompt}],
-        model=get_llm_model(),
-        max_tokens=4096,
+
+def _gen_benchmarks(shared: str) -> dict:
+    """Generate benchmark questions (ground-truth Q+SQL for space quality scoring).
+
+    Hard cap: exactly 10 benchmarks. At ~300 tokens each (question + SQL + JSON),
+    10 benchmarks = ~3000 tokens — well within the 5000 max_tokens budget even for
+    complex multi-table queries.
+    """
+    prompt = (
+        "You are creating benchmark tests for a Databricks Genie Space.\n\n"
+        "Generate EXACTLY 10 question + expected_sql pairs for validation.\n"
+        "These are used to score the Genie space quality — cover a representative spread.\n"
+        "   - Use fully-qualified table names (catalog.schema.table)\n"
+        "   - Benchmarks MUST use hardcoded literal values — NO :param_name placeholders\n"
+        "   - Include aggregation, filtering, grouping, and join patterns\n"
+        "   - Mix simple single-table queries with multi-table queries\n"
+        "   - IMPORTANT: Generate no more than 10 pairs total.\n"
+        "   - CRITICAL: Only use filter values that appear in the Column Profiles section below.\n"
+        "     Do NOT invent status values, tier names, or category labels — use real data.\n\n"
+        "Return ONLY valid JSON:\n"
+        '{"benchmarks": [{"question": "...", "expected_sql": "..."}]}\n\n'
+        f"Context:\n{shared}"
     )
-    return parse_json_from_llm_response(response)
+    return _call_llm_section(prompt, max_tokens=5000, section_name="benchmarks")
 
 
 def _gen_analytics(shared: str) -> dict:
-    """Generate join_specs, measures, filters, and expressions."""
+    """Generate join_specs, measures, filters, and expressions.
+
+    Hard cap: ~20 items total (up to 5 joins + 5 measures + 5 filters + 4 expressions).
+    At ~120 tokens each with fully-qualified names, 20 items = ~2400 tokens — well
+    within the 5000 max_tokens budget.
+    """
     prompt = (
         "You are creating analytics scaffolding for a Databricks Genie Space.\n\n"
-        "Based on the context below, generate:\n"
-        "1. **join_specs**: Table relationships for multi-table queries.\n"
+        "Based on the context below, generate ALL of the following sections:\n\n"
+        "1. **join_specs**: Table relationships for multi-table queries (up to 5).\n"
         "   Each: {left_table, right_table, left_column, right_column, "
-        "relationship (MANY_TO_ONE/ONE_TO_MANY/MANY_TO_MANY)}\n\n"
-        "2. **measures**: Reusable aggregation expressions.\n"
-        "   Each: {alias, sql (aggregate expr like 'SUM(amount)'), display_name}\n\n"
-        "3. **filters**: Reusable WHERE clause snippets.\n"
-        "   Each: {display_name, sql (WHERE condition without WHERE keyword)}\n\n"
-        "4. **expressions**: Computed dimension columns.\n"
-        "   Each: {alias, sql (expression), display_name}\n\n"
-        "Only include sections where the data supports them. "
-        "If only one table exists, skip join_specs.\n\n"
+        "relationship (MANY_TO_ONE/ONE_TO_MANY/MANY_TO_MANY)}\n"
+        "   - REQUIRED if 2+ tables exist. Skip only if there is exactly 1 table.\n"
+        "   - Only include one direction per relationship (e.g., orders→customers, not both directions).\n\n"
+        "2. **measures**: EXACTLY 5 reusable aggregation expressions.\n"
+        "   Each: {alias, sql (aggregate expr using fully-qualified table.column), display_name}\n"
+        "   - Include COUNT, SUM, AVG on numeric/date columns. Always generate these.\n\n"
+        "3. **filters**: EXACTLY 5 reusable WHERE clause snippets.\n"
+        "   Each: {display_name, sql (WHERE condition without WHERE keyword, fully-qualified columns)}\n"
+        "   - Include date range filters, status/category filters, and common lookups.\n\n"
+        "4. **expressions**: EXACTLY 3 computed dimension columns.\n"
+        "   Each: {alias, sql (expression, fully-qualified columns), display_name}\n"
+        "   - Date parts (YEAR/MONTH), CASE labels, concatenations, etc.\n\n"
+        "IMPORTANT: measures, filters, and expressions are always applicable — "
+        "generate them even for single tables. Do not exceed the counts above.\n"
+        "Use fully-qualified table names (catalog.schema.table) in all SQL.\n\n"
         "Return ONLY valid JSON:\n"
         '{"join_specs": [...], "measures": [...], "filters": [...], "expressions": [...]}\n\n'
         f"Context:\n{shared}"
     )
-
-    response = call_serving_endpoint(
-        [{"role": "user", "content": prompt}],
-        model=get_llm_model(),
-        max_tokens=2048,
-    )
-    return parse_json_from_llm_response(response)
+    return _call_llm_section(prompt, max_tokens=5000, section_name="analytics")
 
 
-def _validate_plan_sqls(plan: dict) -> list[str]:
-    """Test all example_sqls and benchmark SQLs in parallel, removing failures.
+def _repair_unbound_sql(item: dict, kind: str, shared_context: str) -> dict | None:
+    """Ask the LLM to fix missing parameter default_values in a parameterized SQL.
 
-    Returns a list of warning strings for dropped items.
+    For example_sqls: fills in default_value for each :param so _substitute_params
+    can run the SQL without unbound placeholders.
+    For benchmarks: converts parameterized SQL to a hardcoded equivalent using
+    literal values (benchmarks must be concrete — no :param_name syntax allowed).
+
+    Returns the repaired item dict, or None if repair failed.
+    """
+    if kind == "example_sql":
+        sql = item.get("sql", "")
+        params = item.get("parameters") or []
+        prompt = (
+            "The following example SQL has parameters that are missing `default_value` fields. "
+            "Fill in a realistic `default_value` for each parameter based on the table context. "
+            "The default_value must be a real value that exists in the data — not a placeholder.\n\n"
+            f"SQL: {sql}\n\n"
+            f"Current parameters: {json.dumps(params)}\n\n"
+            "Return ONLY valid JSON with the corrected parameters array:\n"
+            '{"parameters": [{"name": "...", "type_hint": "...", "default_value": "...", "description": "..."}]}\n\n'
+            f"Context:\n{shared_context[:2000]}"
+        )
+        try:
+            result = _call_llm_section(prompt, max_tokens=512, section_name="param repair")
+            repaired_params = result.get("parameters")
+            if repaired_params:
+                return {**item, "parameters": repaired_params}
+        except Exception:
+            logger.warning("Parameter repair failed for example SQL: %s", sql[:80])
+        return None
+
+    if kind == "benchmark":
+        sql = item.get("expected_sql", "")
+        prompt = (
+            "The following benchmark SQL uses :param_name placeholders. "
+            "Rewrite it as a concrete hardcoded SQL using realistic literal values from the table context. "
+            "Do NOT use any :param_name syntax in the output.\n\n"
+            f"SQL: {sql}\n\n"
+            "Return ONLY valid JSON:\n"
+            '{"expected_sql": "..."}\n\n'
+            f"Context:\n{shared_context[:2000]}"
+        )
+        try:
+            result = _call_llm_section(prompt, max_tokens=512, section_name="benchmark repair")
+            repaired_sql = result.get("expected_sql", "")
+            # Verify no :param placeholders remain anywhere in the repaired SQL
+            if repaired_sql and not re.search(r":[a-zA-Z_]\w*", repaired_sql):
+                return {**item, "expected_sql": repaired_sql}
+        except Exception:
+            logger.warning("Benchmark SQL repair failed: %s", sql[:80])
+        return None
+
+
+def _validate_plan_sqls(plan: dict, shared_context: str = "") -> list[str]:
+    """Test all example_sqls and benchmark SQLs in parallel.
+
+    Unbound-parameter failures get an LLM repair pass (example_sqls have
+    default_values filled in; benchmarks are de-parameterized to concrete SQL),
+    then re-tested. Hard failures (syntax errors, missing tables) are dropped —
+    incorrect SQL in the plan is worse than no SQL.
+
+    Returns a list of warning strings for repaired or dropped items.
     """
     example_sqls: list[dict] = plan.get("example_sqls", [])
     benchmarks: list[dict] = plan.get("benchmarks", [])
@@ -285,10 +484,8 @@ def _validate_plan_sqls(plan: dict) -> list[str]:
     tasks: list[tuple[str, int, str, list[dict] | None]] = []
     for i, eq in enumerate(example_sqls):
         sql = eq.get("sql", "")
-        params = eq.get("parameters")
         if sql:
-            tasks.append(("example_sql", i, sql, params))
-
+            tasks.append(("example_sql", i, sql, eq.get("parameters")))
     for i, bm in enumerate(benchmarks):
         sql = bm.get("expected_sql", "")
         if sql:
@@ -297,9 +494,16 @@ def _validate_plan_sqls(plan: dict) -> list[str]:
     if not tasks:
         return []
 
+    # All three phases (test → repair → retest) share a single pool to avoid
+    # repeated thread-creation overhead. Phases are sequential by necessity.
     test_results: dict[tuple[str, int], dict] = {}
+    needs_repair: list[tuple[str, int]] = []
+    hard_failures: dict[tuple[str, int], str] = {}
+    repaired: dict[tuple[str, int], dict] = {}
+    warnings: list[str] = []
 
-    with ThreadPoolExecutor(max_workers=8) as pool:
+    with ThreadPoolExecutor(max_workers=_VALIDATION_CONCURRENCY) as pool:
+        # Phase 1: initial test pass
         futures = {
             pool.submit(_test_sql, sql, params): (kind, idx)
             for kind, idx, sql, params in tasks
@@ -311,23 +515,81 @@ def _validate_plan_sqls(plan: dict) -> list[str]:
             except Exception as e:
                 test_results[key] = {"success": False, "error": str(e)}
 
-    warnings: list[str] = []
+        # Triage: unbound params are repairable; everything else is a hard failure
+        for (kind, idx), result in test_results.items():
+            if not result.get("success"):
+                err = result.get("error", "unknown")
+                if "Unbound SQL parameters" in err:
+                    needs_repair.append((kind, idx))
+                else:
+                    hard_failures[(kind, idx)] = err
 
-    failed_example_idxs = set()
-    for (kind, idx), result in test_results.items():
-        if kind == "example_sql" and not result.get("success"):
-            failed_example_idxs.add(idx)
-            q = example_sqls[idx].get("question", "?")[:80]
-            err = result.get("error", "unknown")[:120]
-            warnings.append(f"Dropped example SQL #{idx+1} ({q}): {err}")
+        # Phase 2: repair unbound-param failures
+        if needs_repair and shared_context:
+            repair_items = [
+                (kind, idx, example_sqls[idx] if kind == "example_sql" else benchmarks[idx])
+                for kind, idx in needs_repair
+            ]
+            repair_futures = {
+                pool.submit(_repair_unbound_sql, item, kind, shared_context): (kind, idx)
+                for kind, idx, item in repair_items
+            }
+            for future in as_completed(repair_futures):
+                key = repair_futures[future]
+                try:
+                    result = future.result()
+                    if result is not None:
+                        repaired[key] = result
+                except Exception as e:
+                    logger.warning("Repair task failed for %s[%d]: %s", key[0], key[1], e)
 
-    failed_bench_idxs = set()
-    for (kind, idx), result in test_results.items():
-        if kind == "benchmark" and not result.get("success"):
-            failed_bench_idxs.add(idx)
-            q = benchmarks[idx].get("question", "?")[:80]
-            err = result.get("error", "unknown")[:120]
-            warnings.append(f"Dropped benchmark #{idx+1} ({q}): {err}")
+            # Phase 3: re-test repaired items; failures become hard failures
+            if repaired:
+                retest_tasks = [
+                    (kind, idx,
+                     item.get("sql", "") if kind == "example_sql" else item.get("expected_sql", ""),
+                     item.get("parameters") if kind == "example_sql" else None)
+                    for (kind, idx), item in repaired.items()
+                ]
+                retest_futures = {
+                    pool.submit(_test_sql, sql, params): (kind, idx)
+                    for kind, idx, sql, params in retest_tasks
+                }
+                for future in as_completed(retest_futures):
+                    key = retest_futures[future]
+                    kind, idx = key
+                    try:
+                        result = future.result()
+                        if result.get("success"):
+                            q = repaired[key].get("question", "?")[:80]
+                            if kind == "example_sql":
+                                example_sqls[idx] = repaired[key]
+                                warnings.append(f"Repaired example SQL #{idx+1} ({q}): filled in missing parameter defaults")
+                            else:
+                                benchmarks[idx] = repaired[key]
+                                warnings.append(f"Repaired benchmark #{idx+1} ({q}): converted to hardcoded SQL")
+                        else:
+                            hard_failures[key] = result.get("error", "repair re-test failed")
+                    except Exception as e:
+                        hard_failures[key] = str(e)
+
+            # Unrepaired items (repair returned None) → hard failure
+            for kind, idx in needs_repair:
+                if (kind, idx) not in repaired and (kind, idx) not in hard_failures:
+                    hard_failures[(kind, idx)] = "repair produced no result"
+
+        elif needs_repair:
+            for kind, idx in needs_repair:
+                hard_failures[(kind, idx)] = "unbound parameters (no context for repair)"
+
+    # Drop hard failures
+    failed_example_idxs = {idx for (kind, idx) in hard_failures if kind == "example_sql"}
+    failed_bench_idxs = {idx for (kind, idx) in hard_failures if kind == "benchmark"}
+
+    for (kind, idx), err in hard_failures.items():
+        item = example_sqls[idx] if kind == "example_sql" else benchmarks[idx]
+        q = item.get("question", "?")[:80]
+        warnings.append(f"Dropped {kind} #{idx+1} ({q}): {err[:120]}")
 
     if failed_example_idxs:
         plan["example_sqls"] = [eq for i, eq in enumerate(example_sqls) if i not in failed_example_idxs]
@@ -336,13 +598,10 @@ def _validate_plan_sqls(plan: dict) -> list[str]:
 
     kept_ex = len(plan.get("example_sqls", []))
     kept_bm = len(plan.get("benchmarks", []))
-    total_tested = len(tasks)
-    total_dropped = len(failed_example_idxs) + len(failed_bench_idxs)
     logger.info(
-        "SQL validation: tested %d, dropped %d (kept %d examples, %d benchmarks)",
-        total_tested, total_dropped, kept_ex, kept_bm,
+        "SQL validation: tested %d, kept %d examples + %d benchmarks, dropped %d",
+        len(tasks), kept_ex, kept_bm, len(hard_failures),
     )
-
     return warnings
 
 
@@ -356,7 +615,7 @@ def _assemble(results: dict[str, dict], tables_context: list[dict]) -> dict:
     if not plan["tables"] and tables_context:
         plan["tables"] = [
             {
-                "identifier": t.get("table") or t.get("table_name") or t.get("identifier", "?"),
+                "identifier": _table_id(t),
                 "description": t.get("comment", ""),
                 "column_configs": [
                     {"column_name": c.get("name", "?")}
@@ -370,9 +629,8 @@ def _assemble(results: dict[str, dict], tables_context: list[dict]) -> dict:
     plan["sample_questions"] = qi.get("sample_questions", [])
     plan["text_instructions"] = qi.get("text_instructions", [])
 
-    sqls = results.get("sqls", {})
-    plan["example_sqls"] = sqls.get("example_sqls", [])
-    plan["benchmarks"] = sqls.get("benchmarks", [])
+    plan["example_sqls"] = results.get("example_sqls", {}).get("example_sqls", [])
+    plan["benchmarks"] = results.get("benchmarks", {}).get("benchmarks", [])
 
     analytics = results.get("analytics", {})
     plan["join_specs"] = analytics.get("join_specs", [])

--- a/backend/services/plan_builder.py
+++ b/backend/services/plan_builder.py
@@ -312,15 +312,17 @@ def _gen_questions_instructions(shared: str) -> dict:
     prompt = (
         "You are creating sample questions and text instructions for a Databricks Genie Space.\n\n"
         "Based on the context below, generate:\n"
-        "1. **sample_questions**: 5-8 natural-language questions a business user would ask\n"
-        "2. **text_instructions**: Domain knowledge for the Genie agent, organized under "
+        "1. **suggested_display_name**: A concise, professional name for the Genie Space "
+        "(e.g., 'NYC Taxi Revenue Performance', 'TPC-H Sales Analytics', 'Customer Support Dashboard')\n"
+        "2. **sample_questions**: EXACTLY 5 natural-language questions a business user would ask\n"
+        "3. **text_instructions**: Domain knowledge for the Genie agent, organized under "
         "category headers (## Terminology, ## Default Assumptions, ## Data Quality Warnings, etc.)\n\n"
         "Text instructions should contain ONLY business logic and terminology — NOT SQL formulas, "
         "filter expressions, or join definitions (those go in other sections).\n"
         "CRITICAL: Only reference category names, tiers, statuses, and labels that appear in the "
         "Column Profiles section below. Do NOT invent terms — use real data values.\n\n"
         "Return ONLY valid JSON:\n"
-        '{"sample_questions": ["..."], "text_instructions": ["## Terminology\\n- ...", "## Default Assumptions\\n- ..."]}\n\n'
+        '{"suggested_display_name": "...", "sample_questions": ["..."], "text_instructions": ["## Terminology\\n- ...", "## Default Assumptions\\n- ..."]}\n\n'
         f"Context:\n{shared}"
     )
     return _call_llm_section(prompt, max_tokens=3000, section_name="questions/instructions")
@@ -338,7 +340,7 @@ def _gen_example_sqls(shared: str) -> dict:
         "Generate EXACTLY 5 question+SQL pairs that teach Genie how to write correct queries.\n"
         "   - Use fully-qualified table names (catalog.schema.table)\n"
         "   - Use parameterized SQL (:param_name) when the question involves user-supplied values\n"
-        "   - Each parameter needs: name, type_hint (STRING/NUMBER/DATE/BOOLEAN), "
+        "   - Each parameter needs: name, type_hint (STRING/INTEGER/DOUBLE/DECIMAL/DATE/BOOLEAN), "
         "default_value (real value from data), description\n"
         "   - The question should be concrete (use the default value, not a placeholder)\n"
         "   - Mix: ~2 hardcoded patterns + ~3 parameterized queries\n"
@@ -628,6 +630,8 @@ def _assemble(results: dict[str, dict], tables_context: list[dict]) -> dict:
     qi = results.get("questions", {})
     plan["sample_questions"] = qi.get("sample_questions", [])
     plan["text_instructions"] = qi.get("text_instructions", [])
+    if qi.get("suggested_display_name"):
+        plan["suggested_display_name"] = qi["suggested_display_name"]
 
     plan["example_sqls"] = results.get("example_sqls", {}).get("example_sqls", [])
     plan["benchmarks"] = results.get("benchmarks", {}).get("benchmarks", [])

--- a/backend/services/plan_builder.py
+++ b/backend/services/plan_builder.py
@@ -1,0 +1,299 @@
+"""Parallel plan generation — builds a Genie Space plan via concurrent LLM calls.
+
+Instead of one monolithic LLM call that generates the entire plan JSON (slow,
+truncation-prone), this module splits the plan into 4 independent sections and
+generates them in parallel. Each section gets a focused prompt and a small
+max_tokens budget, then results are assembled programmatically.
+
+Parallel calls:
+  A: table descriptions + column_configs  (mostly programmatic, LLM for descriptions)
+  B: sample_questions + text_instructions
+  C: example_sqls + benchmarks
+  D: join_specs + measures + filters + expressions
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
+
+from backend.services.llm_utils import call_serving_endpoint, parse_json_from_llm_response, get_llm_model
+
+logger = logging.getLogger(__name__)
+
+_CONCURRENCY = 4
+
+
+def generate_plan(
+    tables_context: list[dict],
+    inspection_summaries: dict[str, Any],
+    user_requirements: str,
+) -> dict:
+    """Generate a complete Genie Space plan via parallel LLM calls.
+
+    Args:
+        tables_context: List of table dicts from describe_table results, each with
+            keys like "table" / "table_name", "columns", "comment", "row_count".
+        inspection_summaries: Combined inspection data — quality, usage, profiles.
+        user_requirements: Concatenated user messages describing their needs.
+
+    Returns:
+        Assembled plan dict ready for present_plan, or dict with "error" key.
+    """
+    shared_context = _build_shared_context(tables_context, inspection_summaries, user_requirements)
+
+    section_specs: list[tuple[str, callable, dict]] = [
+        ("tables", _gen_tables, {"shared": shared_context, "tables_context": tables_context}),
+        ("questions", _gen_questions_instructions, {"shared": shared_context}),
+        ("sqls", _gen_sqls_benchmarks, {"shared": shared_context}),
+        ("analytics", _gen_analytics, {"shared": shared_context}),
+    ]
+
+    results: dict[str, dict] = {}
+    errors: list[str] = []
+
+    with ThreadPoolExecutor(max_workers=_CONCURRENCY) as pool:
+        futures = {
+            pool.submit(fn, **kwargs): name
+            for name, fn, kwargs in section_specs
+        }
+        for future in as_completed(futures):
+            section_name = futures[future]
+            try:
+                results[section_name] = future.result()
+            except Exception as e:
+                logger.exception("Plan section %s failed", section_name)
+                errors.append(f"{section_name}: {e}")
+                results[section_name] = {}
+
+    plan = _assemble(results, tables_context)
+
+    if errors:
+        plan["_generation_warnings"] = errors
+        logger.warning("Plan generated with %d section error(s): %s", len(errors), errors)
+
+    return plan
+
+
+def _build_shared_context(
+    tables_context: list[dict],
+    inspection_summaries: dict[str, Any],
+    user_requirements: str,
+) -> str:
+    """Build the shared context block that all 4 LLM calls receive."""
+    parts: list[str] = []
+
+    if user_requirements:
+        parts.append(f"## User Requirements\n{user_requirements}")
+
+    table_lines = []
+    for t in tables_context:
+        name = t.get("table") or t.get("table_name") or t.get("identifier", "?")
+        comment = t.get("comment", "")
+        cols = t.get("columns", [])
+        col_summary = ", ".join(c.get("name", "?") for c in cols[:20])
+        if len(cols) > 20:
+            col_summary += f" (+{len(cols) - 20} more)"
+        row_count = t.get("row_count", "?")
+        table_lines.append(f"- **{name}** ({len(cols)} cols, ~{row_count} rows): {comment}")
+        table_lines.append(f"  Columns: {col_summary}")
+
+        recs = t.get("recommendations", {})
+        if recs.get("exclude_etl"):
+            table_lines.append(f"  ETL columns to exclude: {', '.join(recs['exclude_etl'])}")
+
+    if table_lines:
+        parts.append("## Tables\n" + "\n".join(table_lines))
+
+    quality = inspection_summaries.get("quality")
+    if quality and not quality.get("error"):
+        parts.append(f"## Data Quality\n{json.dumps(quality, indent=2, default=str)[:2000]}")
+
+    profiles = inspection_summaries.get("profiles")
+    if profiles:
+        parts.append(f"## Column Profiles\n{json.dumps(profiles, indent=2, default=str)[:2000]}")
+
+    usage = inspection_summaries.get("usage")
+    if usage and not usage.get("error"):
+        parts.append(f"## Usage Patterns\n{json.dumps(usage, indent=2, default=str)[:1500]}")
+
+    return "\n\n".join(parts)
+
+
+def _gen_tables(shared: str, tables_context: list[dict]) -> dict:
+    """Generate table descriptions and column_configs.
+
+    Mostly programmatic (columns come from inspection), with an LLM call
+    to generate human-readable descriptions for ambiguous columns.
+    """
+    tables = []
+    for t in tables_context:
+        name = t.get("table") or t.get("table_name") or t.get("identifier", "?")
+        cols = t.get("columns", [])
+        recs = t.get("recommendations", {})
+        exclude = set(recs.get("exclude_etl", []))
+
+        column_configs = []
+        for c in cols:
+            col_name = c.get("name", "?")
+            if col_name in exclude:
+                continue
+            entry: dict[str, str] = {"column_name": col_name}
+            if c.get("description"):
+                entry["description"] = c["description"]
+            column_configs.append(entry)
+
+        tables.append({
+            "identifier": name,
+            "description": t.get("comment", ""),
+            "column_configs": column_configs,
+        })
+
+    if not tables:
+        return {"tables": []}
+
+    prompt = (
+        "You are enriching table and column metadata for a Databricks Genie Space.\n\n"
+        "For each table below, improve the table description (1-2 sentences) and add "
+        "a brief description for any column that doesn't already have one. "
+        "Only describe columns whose names are ambiguous or domain-specific.\n\n"
+        "Return ONLY valid JSON: {\"tables\": [...]}\n\n"
+        f"Current tables:\n```json\n{json.dumps(tables, indent=2)}\n```\n\n"
+        f"Context:\n{shared[:3000]}"
+    )
+
+    try:
+        response = call_serving_endpoint(
+            [{"role": "user", "content": prompt}],
+            model=get_llm_model(),
+            max_tokens=2048,
+        )
+        result = parse_json_from_llm_response(response)
+        return result if "tables" in result else {"tables": tables}
+    except Exception:
+        logger.warning("Table description enrichment failed, using raw metadata")
+        return {"tables": tables}
+
+
+def _gen_questions_instructions(shared: str) -> dict:
+    """Generate sample_questions and text_instructions."""
+    prompt = (
+        "You are creating sample questions and text instructions for a Databricks Genie Space.\n\n"
+        "Based on the context below, generate:\n"
+        "1. **sample_questions**: 5-8 natural-language questions a business user would ask\n"
+        "2. **text_instructions**: Domain knowledge for the Genie agent, organized under "
+        "category headers (## Terminology, ## Default Assumptions, ## Data Quality Warnings, etc.)\n\n"
+        "Text instructions should contain ONLY business logic and terminology — NOT SQL formulas, "
+        "filter expressions, or join definitions (those go in other sections).\n\n"
+        "Return ONLY valid JSON:\n"
+        '{"sample_questions": ["..."], "text_instructions": ["## Terminology\\n- ...", "## Default Assumptions\\n- ..."]}\n\n'
+        f"Context:\n{shared}"
+    )
+
+    response = call_serving_endpoint(
+        [{"role": "user", "content": prompt}],
+        model=get_llm_model(),
+        max_tokens=1024,
+    )
+    return parse_json_from_llm_response(response)
+
+
+def _gen_sqls_benchmarks(shared: str) -> dict:
+    """Generate example_sqls and benchmarks."""
+    prompt = (
+        "You are creating example SQL queries and benchmark tests for a Databricks Genie Space.\n\n"
+        "Based on the context below, generate:\n"
+        "1. **example_sqls**: 5-8 question+SQL pairs that teach Genie query patterns.\n"
+        "   - Use fully-qualified table names (catalog.schema.table)\n"
+        "   - Use parameterized SQL (:param_name) when the question involves user-supplied values\n"
+        "   - Each parameter needs: name, type_hint (STRING/DATE/INTEGER/DECIMAL/BOOLEAN), "
+        "default_value (real value from data), description\n"
+        "   - The question should be concrete (use the default value, not a placeholder)\n"
+        "   - Mix: ~3 hardcoded patterns + ~3-5 parameterized queries\n\n"
+        "2. **benchmarks**: EXACTLY 12 question + expected_sql pairs for validation.\n"
+        "   This is the most important section — the space quality depends on benchmark coverage.\n"
+        "   - Cover edge cases (nulls, empty results, ambiguous terms)\n"
+        "   - Include time-range and metric-definition tests\n"
+        "   - Include aggregation, filtering, grouping, and join patterns\n"
+        "   - Mix simple single-table queries with complex multi-table queries\n"
+        "   - You MUST generate at least 10 benchmarks. 12 is ideal.\n\n"
+        "Return ONLY valid JSON:\n"
+        '{"example_sqls": [{"question": "...", "sql": "...", "parameters": [...]}], '
+        '"benchmarks": [{"question": "...", "expected_sql": "..."}]}\n\n'
+        f"Context:\n{shared}"
+    )
+
+    response = call_serving_endpoint(
+        [{"role": "user", "content": prompt}],
+        model=get_llm_model(),
+        max_tokens=4096,
+    )
+    return parse_json_from_llm_response(response)
+
+
+def _gen_analytics(shared: str) -> dict:
+    """Generate join_specs, measures, filters, and expressions."""
+    prompt = (
+        "You are creating analytics scaffolding for a Databricks Genie Space.\n\n"
+        "Based on the context below, generate:\n"
+        "1. **join_specs**: Table relationships for multi-table queries.\n"
+        "   Each: {left_table, right_table, left_column, right_column, "
+        "relationship (MANY_TO_ONE/ONE_TO_MANY/MANY_TO_MANY)}\n\n"
+        "2. **measures**: Reusable aggregation expressions.\n"
+        "   Each: {alias, sql (aggregate expr like 'SUM(amount)'), display_name}\n\n"
+        "3. **filters**: Reusable WHERE clause snippets.\n"
+        "   Each: {display_name, sql (WHERE condition without WHERE keyword)}\n\n"
+        "4. **expressions**: Computed dimension columns.\n"
+        "   Each: {alias, sql (expression), display_name}\n\n"
+        "Only include sections where the data supports them. "
+        "If only one table exists, skip join_specs.\n\n"
+        "Return ONLY valid JSON:\n"
+        '{"join_specs": [...], "measures": [...], "filters": [...], "expressions": [...]}\n\n'
+        f"Context:\n{shared}"
+    )
+
+    response = call_serving_endpoint(
+        [{"role": "user", "content": prompt}],
+        model=get_llm_model(),
+        max_tokens=1024,
+    )
+    return parse_json_from_llm_response(response)
+
+
+def _assemble(results: dict[str, dict], tables_context: list[dict]) -> dict:
+    """Merge parallel results into a single plan dict."""
+    plan: dict[str, Any] = {}
+
+    tables_result = results.get("tables", {})
+    plan["tables"] = tables_result.get("tables", [])
+
+    if not plan["tables"] and tables_context:
+        plan["tables"] = [
+            {
+                "identifier": t.get("table") or t.get("table_name") or t.get("identifier", "?"),
+                "description": t.get("comment", ""),
+                "column_configs": [
+                    {"column_name": c.get("name", "?")}
+                    for c in t.get("columns", [])
+                ],
+            }
+            for t in tables_context
+        ]
+
+    qi = results.get("questions", {})
+    plan["sample_questions"] = qi.get("sample_questions", [])
+    plan["text_instructions"] = qi.get("text_instructions", [])
+
+    sqls = results.get("sqls", {})
+    plan["example_sqls"] = sqls.get("example_sqls", [])
+    plan["benchmarks"] = sqls.get("benchmarks", [])
+
+    analytics = results.get("analytics", {})
+    plan["join_specs"] = analytics.get("join_specs", [])
+    plan["measures"] = analytics.get("measures", [])
+    plan["filters"] = analytics.get("filters", [])
+    plan["expressions"] = analytics.get("expressions", [])
+
+    return plan

--- a/backend/services/plan_builder.py
+++ b/backend/services/plan_builder.py
@@ -20,6 +20,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 from backend.services.llm_utils import call_serving_endpoint, parse_json_from_llm_response, get_llm_model
+from backend.services.create_agent_tools import _test_sql
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +70,10 @@ def generate_plan(
                 results[section_name] = {}
 
     plan = _assemble(results, tables_context)
+
+    validated = _validate_plan_sqls(plan)
+    if validated:
+        errors.extend(validated)
 
     if errors:
         plan["_generation_warnings"] = errors
@@ -208,7 +213,7 @@ def _gen_sqls_benchmarks(shared: str) -> dict:
         "1. **example_sqls**: 5-8 question+SQL pairs that teach Genie query patterns.\n"
         "   - Use fully-qualified table names (catalog.schema.table)\n"
         "   - Use parameterized SQL (:param_name) when the question involves user-supplied values\n"
-        "   - Each parameter needs: name, type_hint (STRING/DATE/INTEGER/DECIMAL/BOOLEAN), "
+        "   - Each parameter needs: name, type_hint (STRING/NUMBER/DATE/BOOLEAN), "
         "default_value (real value from data), description\n"
         "   - The question should be concrete (use the default value, not a placeholder)\n"
         "   - Mix: ~3 hardcoded patterns + ~3-5 parameterized queries\n\n"
@@ -260,6 +265,81 @@ def _gen_analytics(shared: str) -> dict:
         max_tokens=1024,
     )
     return parse_json_from_llm_response(response)
+
+
+def _validate_plan_sqls(plan: dict) -> list[str]:
+    """Test all example_sqls and benchmark SQLs in parallel, removing failures.
+
+    Returns a list of warning strings for dropped items.
+    """
+    example_sqls: list[dict] = plan.get("example_sqls", [])
+    benchmarks: list[dict] = plan.get("benchmarks", [])
+
+    if not example_sqls and not benchmarks:
+        return []
+
+    tasks: list[tuple[str, int, str, list[dict] | None]] = []
+    for i, eq in enumerate(example_sqls):
+        sql = eq.get("sql", "")
+        params = eq.get("parameters")
+        if sql:
+            tasks.append(("example_sql", i, sql, params))
+
+    for i, bm in enumerate(benchmarks):
+        sql = bm.get("expected_sql", "")
+        if sql:
+            tasks.append(("benchmark", i, sql, None))
+
+    if not tasks:
+        return []
+
+    test_results: dict[tuple[str, int], dict] = {}
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = {
+            pool.submit(_test_sql, sql, params): (kind, idx)
+            for kind, idx, sql, params in tasks
+        }
+        for future in as_completed(futures):
+            key = futures[future]
+            try:
+                test_results[key] = future.result()
+            except Exception as e:
+                test_results[key] = {"success": False, "error": str(e)}
+
+    warnings: list[str] = []
+
+    failed_example_idxs = set()
+    for (kind, idx), result in test_results.items():
+        if kind == "example_sql" and not result.get("success"):
+            failed_example_idxs.add(idx)
+            q = example_sqls[idx].get("question", "?")[:80]
+            err = result.get("error", "unknown")[:120]
+            warnings.append(f"Dropped example SQL #{idx+1} ({q}): {err}")
+
+    failed_bench_idxs = set()
+    for (kind, idx), result in test_results.items():
+        if kind == "benchmark" and not result.get("success"):
+            failed_bench_idxs.add(idx)
+            q = benchmarks[idx].get("question", "?")[:80]
+            err = result.get("error", "unknown")[:120]
+            warnings.append(f"Dropped benchmark #{idx+1} ({q}): {err}")
+
+    if failed_example_idxs:
+        plan["example_sqls"] = [eq for i, eq in enumerate(example_sqls) if i not in failed_example_idxs]
+    if failed_bench_idxs:
+        plan["benchmarks"] = [bm for i, bm in enumerate(benchmarks) if i not in failed_bench_idxs]
+
+    kept_ex = len(plan.get("example_sqls", []))
+    kept_bm = len(plan.get("benchmarks", []))
+    total_tested = len(tasks)
+    total_dropped = len(failed_example_idxs) + len(failed_bench_idxs)
+    logger.info(
+        "SQL validation: tested %d, dropped %d (kept %d examples, %d benchmarks)",
+        total_tested, total_dropped, kept_ex, kept_bm,
+    )
+
+    return warnings
 
 
 def _assemble(results: dict[str, dict], tables_context: list[dict]) -> dict:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -120,17 +120,17 @@ export default function App() {
           <AdminDashboard onSelectSpace={handleSelectSpace} />
         )}
 
-        {currentView === "create" && (
-          <div>
-            <div className="mb-4">
-              <h1 className="text-2xl font-bold text-primary">Create Genie Space</h1>
-              <p className="text-muted text-sm mt-1">
-                AI-guided creation with live progress tracking — describe what you need and fill in details as you go
-              </p>
-            </div>
-            <CreateAgentChat onCreated={handleCreated} />
+        {/* CreateAgentChat stays mounted (hidden when inactive) so SSE streams
+            and component state survive navigation to other pages. */}
+        <div className={currentView === "create" ? undefined : "hidden"}>
+          <div className="mb-4">
+            <h1 className="text-2xl font-bold text-primary">Create Genie Space</h1>
+            <p className="text-muted text-sm mt-1">
+              AI-guided creation with live progress tracking — describe what you need and fill in details as you go
+            </p>
           </div>
-        )}
+          <CreateAgentChat onCreated={handleCreated} />
+        </div>
       </main>
     </div>
   )

--- a/frontend/src/components/CreateAgentChat.tsx
+++ b/frontend/src/components/CreateAgentChat.tsx
@@ -310,6 +310,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const stopRef = useRef<(() => void) | null>(null)
+  const sessionIdRef = useRef<string | null>(sessionId)
 
   // Streaming message state — accumulate tokens in a ref and flush to React
   // state on an animation-frame schedule to keep renders at ~60 fps.
@@ -350,8 +351,9 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
 
   const sendMessage = useCallback(
     (text: string, selections?: Record<string, unknown>) => {
-      if (!text.trim()) return
-      if (isStreaming) {
+      const isContinuation = text === ""
+      if (!isContinuation && !text.trim()) return
+      if (isStreaming && !isContinuation) {
         const trimmed = text.trim()
         queuedMessageRef.current = trimmed
         setQueuedMessage(trimmed)
@@ -359,14 +361,16 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
         return
       }
 
-      const userMsg: AgentChatMessage = {
-        id: nextId(),
-        role: "user",
-        content: text.trim(),
-        timestamp: Date.now(),
+      if (!isContinuation) {
+        const userMsg: AgentChatMessage = {
+          id: nextId(),
+          role: "user",
+          content: text.trim(),
+          timestamp: Date.now(),
+        }
+        setMessages((prev) => [...prev, userMsg])
+        setInput("")
       }
-      setMessages((prev) => [...prev, userMsg])
-      setInput("")
       setIsStreaming(true)
 
       let pendingToolCalls: AgentChatMessage[] = []
@@ -405,8 +409,8 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
         )
       }
 
-      stopRef.current = streamAgentChat(text.trim(), sessionId, selections ?? null, {
-        onSession: (sid) => setSessionId(sid),
+      stopRef.current = streamAgentChat(isContinuation ? "" : text.trim(), sessionIdRef.current, selections ?? null, {
+        onSession: (sid) => { sessionIdRef.current = sid; setSessionId(sid) },
         onStep: () => {},
         onThinking: (message, _step, _round) => {
           setAgentStatus(message)
@@ -627,9 +631,8 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
             } as AgentChatMessage,
           ])
         },
-        onDone: () => {
+        onDone: (needsContinuation) => {
           setAgentStatus(null)
-          setIsStreaming(false)
           // Clean up streaming refs
           if (streamingRafRef.current) {
             cancelAnimationFrame(streamingRafRef.current)
@@ -638,6 +641,15 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
           streamingContentRef.current = ""
           streamingMsgIdRef.current = null
           pendingToolCalls = []
+
+          if (needsContinuation && sessionIdRef.current) {
+            // Keep isStreaming=true — the agent loop continues in the
+            // next HTTP round.  sendMessage("") opens a new SSE stream.
+            requestAnimationFrame(() => sendMessage(""))
+            return
+          }
+
+          setIsStreaming(false)
           const pending = queuedMessageRef.current
           queuedMessageRef.current = null
           setQueuedMessage(null)
@@ -1350,7 +1362,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
                                 onKeyDown={(e) => e.key === "Enter" && stopEdit()}
                                 className="flex-1 bg-elevated border border-accent/30 rounded px-2 py-1 text-secondary focus:outline-none focus:ring-1 focus:ring-accent/40"
                               />
-                              <button onClick={() => removePlanItem("sample_questions", i)} className="p-1 text-red-400 hover:text-red-300 flex-shrink-0">
+                              <button onMouseDown={(e) => e.preventDefault()} onClick={() => removePlanItem("sample_questions", i)} className="p-1 text-red-400 hover:text-red-300 flex-shrink-0">
                                 <Trash2 className="w-3 h-3" />
                               </button>
                             </div>
@@ -1435,7 +1447,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
                       </div>
                     )}
 
-                    {/* Joins (read-only — complex structure) */}
+                    {/* Joins */}
                     {sec.key === "join_specs" && (
                       <div className="overflow-x-auto">
                         <table className="w-full text-left">
@@ -1445,6 +1457,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
                               <th className="px-2 py-1.5 font-medium">Relationship</th>
                               <th className="px-2 py-1.5 font-medium">Right Table</th>
                               <th className="px-2 py-1.5 font-medium">Condition</th>
+                              <th className="px-2 py-1.5 w-8"></th>
                             </tr>
                           </thead>
                           <tbody>
@@ -1453,7 +1466,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
                               const rightShort = (j.right_table || "").split(".").pop() || j.right_table
                               const rel = j.relationship || "—"
                               return (
-                                <tr key={i} className="border-b border-default last:border-0">
+                                <tr key={i} className="border-b border-default last:border-0 group/join">
                                   <td className="px-2 py-1.5 font-mono text-primary">{leftShort}</td>
                                   <td className="px-2 py-1.5">
                                     <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-400 whitespace-nowrap">{rel}</span>
@@ -1461,6 +1474,11 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
                                   <td className="px-2 py-1.5 font-mono text-primary">{rightShort}</td>
                                   <td className="px-2 py-1.5 font-mono text-secondary">
                                     {leftShort}.{j.left_column} = {rightShort}.{j.right_column}
+                                  </td>
+                                  <td className="px-2 py-1.5">
+                                    <button onClick={() => removePlanItem("join_specs", i)} className="p-1 text-red-400 hover:text-red-300 opacity-0 group-hover/join:opacity-100 transition-opacity">
+                                      <Trash2 className="w-3 h-3" />
+                                    </button>
                                   </td>
                                 </tr>
                               )

--- a/frontend/src/components/CreateAgentChat.tsx
+++ b/frontend/src/components/CreateAgentChat.tsx
@@ -320,6 +320,12 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
   const stopRef = useRef<(() => void) | null>(null)
   const sessionIdRef = useRef<string | null>(sessionId)
 
+  // Auto-reconnect state: tracks consecutive connection failures so we can
+  // retry automatically (up to a limit) when the Databricks Apps proxy drops
+  // the SSE stream during long-running tool calls.
+  const reconnectCountRef = useRef(0)
+  const MAX_AUTO_RECONNECTS = 3
+
   // Streaming message state — accumulate tokens in a ref and flush to React
   // state on an animation-frame schedule to keep renders at ~60 fps.
   const streamingContentRef = useRef("")
@@ -419,7 +425,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
       }
 
       stopRef.current = streamAgentChat(isContinuation ? "" : text.trim(), sessionIdRef.current, selections ?? null, {
-        onSession: (sid) => { sessionIdRef.current = sid; setSessionId(sid) },
+        onSession: (sid) => { sessionIdRef.current = sid; setSessionId(sid); reconnectCountRef.current = 0 },
         onStep: () => {},
         onThinking: (message, _step, _round) => {
           setAgentStatus(message)
@@ -507,9 +513,12 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
             const plan = planFromResult(result as Record<string, unknown>)
             setEditedPlan(plan)
             setEditingPlanItem(null)
+            const suggestedName = (result as Record<string, unknown>).suggested_display_name as string | undefined
             setProgress((p) => ({
               ...p,
               planReady: true,
+              // Set title from LLM suggestion if user hasn't already named it
+              title: p.title || suggestedName || p.title,
               planSummary: {
                 questions: plan.sample_questions.length,
                 benchmarks: plan.benchmarks.length,
@@ -651,13 +660,42 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
           streamingMsgIdRef.current = null
           pendingToolCalls = []
 
+          // Auto-reconnect on proxy/network disconnects (up to MAX_AUTO_RECONNECTS).
+          // The backend session is persisted and orphaned tool calls are healed,
+          // so resuming with an empty message picks up exactly where we left off.
+          if (needsContinuation === "connection_lost" && sessionIdRef.current) {
+            reconnectCountRef.current += 1
+            if (reconnectCountRef.current <= MAX_AUTO_RECONNECTS) {
+              const attempt = reconnectCountRef.current
+              setAgentStatus(`Reconnecting (attempt ${attempt}/${MAX_AUTO_RECONNECTS})...`)
+              setTimeout(() => sendMessage(""), 2000 * attempt)
+              return
+            }
+            // Exhausted retries — show error and stop
+            setMessages((prev) => [
+              ...prev,
+              {
+                id: nextId(),
+                role: "assistant",
+                content: "Connection lost after multiple retries. Your session is saved — click Send to resume.",
+                timestamp: Date.now(),
+                is_error: true,
+              } as AgentChatMessage,
+            ])
+            reconnectCountRef.current = 0
+            setIsStreaming(false)
+            return
+          }
+
           if (needsContinuation && sessionIdRef.current) {
             // Keep isStreaming=true — the agent loop continues in the
             // next HTTP round.  sendMessage("") opens a new SSE stream.
+            reconnectCountRef.current = 0  // successful round — reset reconnect counter
             requestAnimationFrame(() => sendMessage(""))
             return
           }
 
+          reconnectCountRef.current = 0
           setIsStreaming(false)
           const pending = queuedMessageRef.current
           queuedMessageRef.current = null
@@ -707,6 +745,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
     stopRef.current?.()
     setMessages([])
     setSessionId(null)
+    sessionIdRef.current = null
     setIsStreaming(false)
     setAgentStatus(null)
     if (streamingRafRef.current) {
@@ -726,8 +765,10 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
     setEditedPlan(null)
     setEditingPlanItem(null)
     setAutoPilot(false)
+    reconnectCountRef.current = 0
     queuedMessageRef.current = null
     setQueuedMessage(null)
+    setElementSearch({})
     setShowClearConfirm(false)
     sessionStorage.removeItem(STORAGE_KEY)
   }
@@ -1271,7 +1312,11 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
 
   const approvePlanAndCreate = () => {
     if (!editedPlan) return
-    sendMessage("Plan approved — go ahead and create the space.", { edited_plan: editedPlan, action: "create" })
+    sendMessage("Plan approved — go ahead and create the space.", {
+      edited_plan: editedPlan,
+      action: "create",
+      display_name: progress.title || undefined,
+    })
   }
 
   const requestAIReview = () => {

--- a/frontend/src/components/CreateAgentChat.tsx
+++ b/frontend/src/components/CreateAgentChat.tsx
@@ -56,6 +56,7 @@ const TOOL_LABELS: Record<string, string> = {
   profile_columns: "Profiling columns",
   test_sql: "Testing SQL",
   discover_warehouses: "Finding warehouses",
+  generate_plan: "Generating plan (parallel)...",
   present_plan: "Preparing plan for review",
   get_config_schema: "Fetching config schema",
   generate_config: "Generating config",
@@ -233,7 +234,7 @@ function loadState(): PersistedState | null {
     if (!parsed.editedPlan && parsed.messages) {
       for (let i = parsed.messages.length - 1; i >= 0; i--) {
         const m = parsed.messages[i]
-        if (m.role === "tool" && m.tool_name === "present_plan" && m.tool_result && !m.tool_result.error) {
+        if (m.role === "tool" && (m.tool_name === "present_plan" || m.tool_name === "generate_plan") && m.tool_result && !m.tool_result.error) {
           parsed.editedPlan = planFromResult(m.tool_result as Record<string, unknown>)
           break
         }
@@ -389,6 +390,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
           case "profile_columns": return tableName ? `Profiling ${tableName}...` : "Profiling data..."
           case "test_sql": return "Testing SQL..."
           case "discover_warehouses": return "Finding warehouses..."
+          case "generate_plan": return "Generating plan in parallel..."
           case "present_plan": return "Preparing plan..."
           case "get_config_schema": return "Fetching config schema..."
           case "generate_config": return "Generating configuration..."
@@ -493,7 +495,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
               return updated
             })
           }
-          if (tool === "present_plan" && !result.error) {
+          if ((tool === "present_plan" || tool === "generate_plan") && !result.error) {
             if (resolvedId) setExpandedTools((et) => new Set(et).add(resolvedId))
             const plan = planFromResult(result as Record<string, unknown>)
             setEditedPlan(plan)
@@ -1675,7 +1677,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
   }
 
   const hasRichCard = (msg: AgentChatMessage): boolean =>
-    !!msg.tool_result && !msg.tool_result.error && (msg.tool_name === "describe_table" || msg.tool_name === "profile_columns" || msg.tool_name === "present_plan" || msg.tool_name === "test_sql" || msg.tool_name === "assess_data_quality" || msg.tool_name === "profile_table_usage")
+    !!msg.tool_result && !msg.tool_result.error && (msg.tool_name === "describe_table" || msg.tool_name === "profile_columns" || msg.tool_name === "present_plan" || msg.tool_name === "generate_plan" || msg.tool_name === "test_sql" || msg.tool_name === "assess_data_quality" || msg.tool_name === "profile_table_usage")
 
   const getToolSummary = (msg: AgentChatMessage): string | null => {
     if (!msg.tool_result || msg.tool_result.error) return null
@@ -1719,7 +1721,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
   }
 
   const renderToolCall = (msg: AgentChatMessage) => {
-    if (msg.tool_name === "present_plan" && msg.tool_result && !msg.tool_result.error) {
+    if ((msg.tool_name === "present_plan" || msg.tool_name === "generate_plan") && msg.tool_result && !msg.tool_result.error) {
       return <div key={msg.id} className="mx-4 my-2">{renderPlanCard(msg.tool_result)}</div>
     }
     const isExpanded = expandedTools.has(msg.id)
@@ -1753,7 +1755,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
           rich ? (
             msg.tool_name === "describe_table"
               ? renderDescribeCard(msg.tool_result)
-              : msg.tool_name === "present_plan"
+              : (msg.tool_name === "present_plan" || msg.tool_name === "generate_plan")
                 ? renderPlanCard(msg.tool_result)
                 : msg.tool_name === "test_sql"
                   ? renderTestSqlCard(msg.tool_result)

--- a/frontend/src/components/CreateAgentChat.tsx
+++ b/frontend/src/components/CreateAgentChat.tsx
@@ -250,6 +250,13 @@ function loadState(): PersistedState | null {
 
 const INSPECTION_TOOLS = new Set(["describe_table", "profile_columns", "assess_data_quality", "profile_table_usage"])
 
+// Plan sections that always appear in the review UI even when empty (so users
+// know they exist and can add items manually).
+const ALWAYS_SHOW_PLAN_SECTIONS = new Set([
+  "sample_questions", "example_sqls", "benchmarks",
+  "text_instructions", "join_specs", "sql_expressions",
+])
+
 type RenderItem =
   | { type: "message"; msg: AgentChatMessage }
   | { type: "inspection_group"; msgs: AgentChatMessage[]; id: string }
@@ -1324,8 +1331,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
 
         <div className="divide-y divide-[var(--border-color)]">
           {PLAN_SECTIONS.map((sec) => {
-            const alwaysShow = ["sample_questions", "example_sqls", "benchmarks", "text_instructions"]
-            if (sec.count === 0 && !alwaysShow.includes(sec.key)) return null
+            if (sec.count === 0 && !ALWAYS_SHOW_PLAN_SECTIONS.has(sec.key)) return null
             const isOpen = expandedPlanSections.has(sec.key)
             const { Icon } = sec
             return (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -622,7 +622,7 @@ export interface AgentChatCallbacks {
   onCreated: (spaceId: string, url: string, displayName: string) => void
   onUpdated: (spaceId: string, url: string) => void
   onError: (message: string) => void
-  onDone: () => void
+  onDone: (needsContinuation?: boolean) => void
 }
 
 export function streamAgentChat(
@@ -679,7 +679,7 @@ export function streamAgentChat(
               case "created": callbacks.onCreated(data.space_id, data.url, data.display_name); break
               case "updated": callbacks.onUpdated(data.space_id, data.url); break
               case "error": callbacks.onError(data.message); break
-              case "done": callbacks.onDone(); break
+              case "done": callbacks.onDone(data.needs_continuation === true); break
             }
           } catch { /* ignore parse errors */ }
         }
@@ -687,10 +687,10 @@ export function streamAgentChat(
     })
     .catch((error) => {
       if (error.name !== "AbortError") {
-        callbacks.onError(error.message === "network error"
-          ? "Connection interrupted — your progress is saved. Send another message to continue."
-          : (error.message || "Connection failed"))
-        callbacks.onDone()
+        // Proxy disconnect or network error — assume we need continuation.
+        // The session state is persisted server-side so the next round
+        // picks up where we left off.
+        callbacks.onDone(true)
       }
     })
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -687,10 +687,10 @@ export function streamAgentChat(
     })
     .catch((error) => {
       if (error.name !== "AbortError") {
-        // Proxy disconnect or network error — assume we need continuation.
-        // The session state is persisted server-side so the next round
-        // picks up where we left off.
-        callbacks.onDone(true)
+        // Network error or proxy disconnect — show the user an error instead
+        // of silently retrying (which could loop infinitely if the backend is down).
+        callbacks.onError("Connection interrupted. Your session is saved — click Send to resume.")
+        callbacks.onDone(false)
       }
     })
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -622,7 +622,7 @@ export interface AgentChatCallbacks {
   onCreated: (spaceId: string, url: string, displayName: string) => void
   onUpdated: (spaceId: string, url: string) => void
   onError: (message: string) => void
-  onDone: (needsContinuation?: boolean) => void
+  onDone: (needsContinuation?: boolean | "connection_lost") => void
 }
 
 export function streamAgentChat(
@@ -687,10 +687,9 @@ export function streamAgentChat(
     })
     .catch((error) => {
       if (error.name !== "AbortError") {
-        // Network error or proxy disconnect — show the user an error instead
-        // of silently retrying (which could loop infinitely if the backend is down).
-        callbacks.onError("Connection interrupted. Your session is saved — click Send to resume.")
-        callbacks.onDone(false)
+        // Network error or proxy disconnect — signal as a connection drop so
+        // the UI can auto-reconnect (distinct from backend error events).
+        callbacks.onDone("connection_lost")
       }
     })
 

--- a/tests/test_compaction_400.py
+++ b/tests/test_compaction_400.py
@@ -1,0 +1,220 @@
+"""Test: verify message building after inspection → plan step transition.
+
+Simulates the user's exact scenario: auto-pilot, 1 table (nyctaxi trips),
+full inspection with describe_table + assess_data_quality + profile_table_usage.
+Verifies:
+  1. detect_step returns "plan" after inspection completes
+  2. Message list preserves ALL tool calls (no compaction erasure)
+  3. Messages end with a user message (Claude endpoint requirement)
+  4. No consecutive assistant messages
+"""
+
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from backend.services.create_agent_session import AgentSession
+from backend.services.create_agent import CreateGenieAgent
+from backend.prompts_create import detect_step
+
+
+def build_nyctaxi_autopilot_session() -> AgentSession:
+    """Build a session matching the user's scenario: 1 nyctaxi table, auto-pilot,
+    describe_table + assess_data_quality + profile_table_usage all completed."""
+    session = AgentSession(session_id="test-nyctaxi")
+    tc_counter = [0]
+
+    def tc_id():
+        tc_counter[0] += 1
+        return f"call_{tc_counter[0]}"
+
+    session.history.append({
+        "role": "user",
+        "content": "autopilot make a space on nyctaxi\n\n[User selections: {\"auto_pilot\": true}]",
+    })
+
+    # discover_catalogs
+    cid = tc_id()
+    session.history.append({
+        "role": "assistant", "content": "Let me explore the catalogs.",
+        "tool_calls": [{"id": cid, "type": "function", "function": {"name": "discover_catalogs", "arguments": "{}"}}],
+    })
+    session.history.append({"role": "tool", "tool_call_id": cid, "content": json.dumps({"catalogs": [{"name": "samples"}]})})
+
+    # discover_schemas
+    cid = tc_id()
+    session.history.append({
+        "role": "assistant", "content": "Found the samples catalog.",
+        "tool_calls": [{"id": cid, "type": "function", "function": {"name": "discover_schemas", "arguments": json.dumps({"catalog": "samples"})}}],
+    })
+    session.history.append({"role": "tool", "tool_call_id": cid, "content": json.dumps({"schemas": [{"name": "nyctaxi"}]})})
+
+    # discover_tables
+    cid = tc_id()
+    session.history.append({
+        "role": "assistant", "content": "Found the nyctaxi schema.",
+        "tool_calls": [{"id": cid, "type": "function", "function": {"name": "discover_tables", "arguments": json.dumps({"catalog": "samples", "schema": "nyctaxi"})}}],
+    })
+    session.history.append({"role": "tool", "tool_call_id": cid, "content": json.dumps({"tables": [{"name": "trips"}]})})
+
+    # describe_table (trips)
+    cid = tc_id()
+    session.history.append({
+        "role": "assistant", "content": "Inspecting the trips table.",
+        "tool_calls": [{"id": cid, "type": "function", "function": {"name": "describe_table", "arguments": json.dumps({"catalog": "samples", "schema": "nyctaxi", "table": "trips"})}}],
+    })
+    session.history.append({"role": "tool", "tool_call_id": cid, "content": json.dumps({
+        "table_name": "samples.nyctaxi.trips",
+        "columns": [{"name": f"col_{j}", "type": "STRING"} for j in range(6)],
+        "row_count": 100000,
+    })})
+
+    # assess_data_quality + profile_table_usage (same round)
+    qa_id = tc_id()
+    usage_id = tc_id()
+    session.history.append({
+        "role": "assistant", "content": "Running quality checks and usage profiling.",
+        "tool_calls": [
+            {"id": qa_id, "type": "function", "function": {"name": "assess_data_quality", "arguments": json.dumps({"tables": ["samples.nyctaxi.trips"]})}},
+            {"id": usage_id, "type": "function", "function": {"name": "profile_table_usage", "arguments": json.dumps({"tables": ["samples.nyctaxi.trips"]})}},
+        ],
+    })
+    session.history.append({"role": "tool", "tool_call_id": qa_id, "content": json.dumps({
+        "tables": {"trips": {"quality_score": 95, "issues": []}}, "overall_assessment": "Good",
+    })})
+    session.history.append({"role": "tool", "tool_call_id": usage_id, "content": json.dumps({
+        "tables": {"samples.nyctaxi.trips": {"recent_queries": [{"query": "SELECT *", "executed_by": "user1"}], "lineage": {"downstream": ["gold_analytics"]}}},
+    })})
+
+    return session
+
+
+def validate_messages(messages: list[dict]) -> list[str]:
+    """Check for Claude API message structure violations."""
+    errors = []
+
+    if not messages:
+        errors.append("Empty messages array")
+        return errors
+
+    non_system = [m for m in messages if m["role"] != "system"]
+    if not non_system:
+        errors.append("No non-system messages")
+        return errors
+
+    if non_system[0]["role"] != "user":
+        errors.append(f"First non-system message should be 'user', got '{non_system[0]['role']}'")
+
+    # Check for consecutive assistant messages (no user/tool in between)
+    prev_role = None
+    prev_idx = -1
+    for i, msg in enumerate(messages):
+        role = msg["role"]
+        if role == "system":
+            continue
+        if role == "assistant" and prev_role == "assistant":
+            errors.append(f"Consecutive assistant messages at {prev_idx} and {i}")
+        prev_role = role
+        prev_idx = i
+
+    # Check last message is user
+    last = non_system[-1]
+    if last["role"] != "user":
+        errors.append(f"Last message should be 'user', got '{last['role']}'")
+
+    # Check for orphaned tool results
+    tc_ids_defined = set()
+    for msg in messages:
+        for tc in msg.get("tool_calls", []):
+            tc_ids_defined.add(tc["id"])
+
+    for msg in messages:
+        if msg["role"] == "tool":
+            tcid = msg.get("tool_call_id")
+            if tcid and tcid not in tc_ids_defined:
+                errors.append(f"Orphaned tool result: {tcid}")
+
+    # Check all tool_calls have results
+    tc_ids_with_results = {msg.get("tool_call_id") for msg in messages if msg["role"] == "tool"}
+    for msg in messages:
+        for tc in msg.get("tool_calls", []):
+            if tc["id"] not in tc_ids_with_results:
+                errors.append(f"Tool call without result: {tc['id']} ({tc['function']['name']})")
+
+    return errors
+
+
+def find_tool_calls_in_messages(messages: list[dict], tool_name: str) -> int:
+    """Count how many times a tool appears in the message list."""
+    count = 0
+    for msg in messages:
+        for tc in msg.get("tool_calls", []):
+            if tc.get("function", {}).get("name") == tool_name:
+                count += 1
+    return count
+
+
+def main():
+    agent = CreateGenieAgent()
+    session = build_nyctaxi_autopilot_session()
+
+    step = detect_step(session)
+    print(f"Step detection: {step}")
+    assert step == "plan", f"Expected 'plan', got '{step}'"
+    print("  ✓ detect_step correctly returns 'plan' after inspection")
+
+    messages = agent._build_messages(session)
+
+    print(f"\nMessage structure ({len(messages)} messages):")
+    for i, m in enumerate(messages):
+        role = m["role"]
+        has_tc = bool(m.get("tool_calls"))
+        tc_id = m.get("tool_call_id", "")
+        content_len = len(str(m.get("content", "") or ""))
+        if role == "system":
+            print(f"  [{i}] {role}: {content_len} chars")
+        elif has_tc:
+            tc_names = [tc["function"]["name"] for tc in m["tool_calls"]]
+            print(f"  [{i}] {role}: tool_calls=[{', '.join(tc_names)}], content={content_len}")
+        elif role == "tool":
+            name = m.get("name", "?")
+            print(f"  [{i}] {role}: {name} (tc_id={tc_id}), {content_len} chars")
+        else:
+            preview = str(m.get("content", ""))[:60]
+            print(f"  [{i}] {role}: {content_len} chars — {preview!r}")
+
+    # Verify inspection tool calls are PRESERVED (not compacted away)
+    desc_count = find_tool_calls_in_messages(messages, "describe_table")
+    assess_count = find_tool_calls_in_messages(messages, "assess_data_quality")
+    usage_count = find_tool_calls_in_messages(messages, "profile_table_usage")
+    print(f"\nInspection tool calls preserved in messages:")
+    print(f"  describe_table:      {desc_count}")
+    print(f"  assess_data_quality: {assess_count}")
+    print(f"  profile_table_usage: {usage_count}")
+    assert desc_count >= 1, "describe_table should be in messages!"
+    assert assess_count >= 1, "assess_data_quality should be in messages!"
+    assert usage_count >= 1, "profile_table_usage should be in messages!"
+    print("  ✓ All inspection tool calls preserved — LLM can see they already ran")
+
+    errors = validate_messages(messages)
+    print(f"\nMessage structure validation:")
+    if errors:
+        print(f"  FOUND {len(errors)} ERRORS:")
+        for e in errors:
+            print(f"    ✗ {e}")
+    else:
+        print("  ✓ Valid message structure (user-last, no consecutive assistants)")
+
+    total_chars = sum(len(json.dumps(m)) for m in messages)
+    print(f"\nTotal payload: ~{total_chars:,} chars (~{total_chars // 4:,} tokens)")
+
+    all_passed = step == "plan" and desc_count >= 1 and assess_count >= 1 and usage_count >= 1 and not errors
+    print(f"\n{'=' * 50}")
+    print(f"{'ALL CHECKS PASSED' if all_passed else 'SOME CHECKS FAILED'}")
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/tests/test_inspection_loop.py
+++ b/tests/test_inspection_loop.py
@@ -237,6 +237,48 @@ def test_concurrent_access():
     _sessions.pop("test-123", None)
 
 
+def test_partial_inspection():
+    """Test: describe_table only (no quality/usage) should stay in inspection."""
+    session = AgentSession(session_id="test-partial")
+    session.history.append({
+        "role": "user", "content": "Create a space",
+    })
+    session.history.append({
+        "role": "assistant",
+        "content": "Inspecting...",
+        "tool_calls": [{
+            "id": "call_desc_0", "type": "function",
+            "function": {"name": "describe_table", "arguments": "{}"},
+        }],
+    })
+    session.history.append({
+        "role": "tool", "tool_call_id": "call_desc_0",
+        "content": json.dumps({"table": "t1", "columns": [{"name": "a"}]}),
+    })
+    step = detect_step(session)
+    print(f"\n=== PARTIAL INSPECTION (describe_table only) ===")
+    print(f"Step: '{step}' — {'CORRECT (stays in inspection)' if step == 'inspection' else 'WRONG!'}")
+    return step == "inspection"
+
+
+def test_cancelled_results():
+    """Test: cancelled tool results should NOT count as completed."""
+    session = build_mock_session_after_inspection()
+    # Replace the assess_data_quality result with a cancelled one
+    for msg in session.history:
+        if msg.get("role") == "tool" and msg.get("tool_call_id") == "call_quality":
+            msg["content"] = json.dumps({"cancelled": True})
+    # Also replace profile_table_usage result
+    for msg in session.history:
+        if msg.get("role") == "tool" and msg.get("tool_call_id") == "call_usage":
+            msg["content"] = json.dumps({"cancelled": True})
+
+    step = detect_step(session)
+    print(f"\n=== CANCELLED RESULTS (both quality+usage cancelled) ===")
+    print(f"Step: '{step}' — {'CORRECT (stays in inspection)' if step == 'inspection' else 'WRONG!'}")
+    return step == "inspection"
+
+
 if __name__ == "__main__":
     print("=" * 60)
     print("DIAGNOSIS: Agent repeating inspection in auto-pilot mode")
@@ -247,35 +289,19 @@ if __name__ == "__main__":
     test_history_completeness()
     test_continuation_count_persistence()
     test_concurrent_access()
+    p1 = test_partial_inspection()
+    p2 = test_cancelled_results()
 
     print("\n" + "=" * 60)
-    print("DIAGNOSIS SUMMARY")
+    print("RESULTS")
     print("=" * 60)
-    if step == "inspection":
-        print("""
-PRIMARY ROOT CAUSE (Hypothesis B confirmed):
-  detect_step() returns 'inspection' even after ALL inspection tools
-  have completed. It only advances to 'plan' when present_plan or
-  generate_plan was called — but those tools are only suggested by
-  the PLAN step prompt, which the LLM never sees because it's stuck
-  in the INSPECTION step.
-
-  Result: The LLM receives the inspection prompt every continuation
-  round. The prompt says "Call describe_table on each selected table"
-  and the LLM follows the instruction, even though results already
-  exist in history.
-
-SECONDARY ISSUE (Hypothesis A):
-  No session locking. If the SSE proxy timeout kills a connection
-  mid-tool-execution and the frontend immediately continues, two
-  requests can mutate the same session simultaneously, causing
-  partial/duplicate history entries.
-
-PROPOSED FIX:
-  1. Improve detect_step() to recognize when inspection is COMPLETE
-     (describe_table + assess_data_quality/profile_table_usage all
-     have results) and advance to 'plan' automatically.
-  2. Add session locking to prevent concurrent mutations.
-""")
+    all_pass = (step == "plan") and p1 and p2
+    if all_pass:
+        print("ALL TESTS PASSED")
+        print("  - Full inspection → step='plan' (was: 'inspection' before fix)")
+        print("  - Partial inspection → stays in 'inspection'")
+        print("  - Cancelled results → stays in 'inspection'")
+        print("  - Session locking added via asyncio.Lock")
+        print("  - continuation_count is now a proper dataclass field")
     else:
-        print(f"Step is '{step}' — Hypothesis B NOT confirmed. Investigate further.")
+        print("SOME TESTS FAILED — review output above")

--- a/tests/test_inspection_loop.py
+++ b/tests/test_inspection_loop.py
@@ -1,0 +1,281 @@
+"""Diagnostic test: Why does the agent repeat inspection in auto-pilot mode?
+
+Hypotheses:
+  A) SSE timeout race condition — proxy kills connection, frontend sends continuation,
+     backend still executing tools → concurrent session mutation → partial history.
+  B) Step detection + prompt loop — detect_step returns "inspection" indefinitely because
+     it only advances to "plan" when present_plan/generate_plan is called. The inspection
+     prompt's imperative "Call describe_table on each table" causes the LLM to re-run them.
+  C) Session persistence gap — _continuation_count not persisted, session data lost.
+
+This script tests hypothesis B (the most likely) by simulating the session state after
+a full round of inspection and checking what the LLM would see.
+"""
+
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from backend.services.create_agent_session import AgentSession
+from backend.prompts_create import detect_step, assemble_system_prompt, STEP_ORDER
+
+
+def build_mock_session_after_inspection() -> AgentSession:
+    """Build a session that looks like round 1 completed:
+    - User message with auto_pilot: true
+    - Assistant called describe_table x6
+    - All 6 tool results present
+    - assess_data_quality + profile_table_usage also called and completed
+    """
+    session = AgentSession(session_id="test-123")
+
+    # User message with auto-pilot
+    session.history.append({
+        "role": "user",
+        "content": "Create a Genie Space for banking analytics\n\n[User selections: {\"auto_pilot\": true}]",
+    })
+
+    tables = [
+        ("transactions", 17), ("customers", 17), ("accounts", 11),
+        ("branches", 10), ("products", 10), ("service_requests", 12),
+    ]
+
+    # Assistant message with tool calls
+    tool_calls = []
+    for i, (name, _) in enumerate(tables):
+        tool_calls.append({
+            "id": f"call_desc_{i}",
+            "type": "function",
+            "function": {
+                "name": "describe_table",
+                "arguments": json.dumps({
+                    "catalog": "banking", "schema": "core", "table": name,
+                }),
+            },
+        })
+    tool_calls.append({
+        "id": "call_quality",
+        "type": "function",
+        "function": {
+            "name": "assess_data_quality",
+            "arguments": json.dumps({"tables": ["banking.core." + t[0] for t in tables]}),
+        },
+    })
+    tool_calls.append({
+        "id": "call_usage",
+        "type": "function",
+        "function": {
+            "name": "profile_table_usage",
+            "arguments": json.dumps({"tables": ["banking.core." + t[0] for t in tables]}),
+        },
+    })
+
+    session.history.append({
+        "role": "assistant",
+        "content": "Let me inspect everything in parallel.",
+        "tool_calls": tool_calls,
+    })
+
+    # Tool results for all describe_table calls
+    for i, (name, col_count) in enumerate(tables):
+        columns = [{"name": f"col_{j}", "type": "STRING"} for j in range(col_count)]
+        result = {
+            "table": f"banking.core.{name}",
+            "table_name": name,
+            "columns": columns,
+            "row_count": 10000,
+            "comment": f"The {name} table",
+        }
+        session.history.append({
+            "role": "tool",
+            "tool_call_id": f"call_desc_{i}",
+            "content": json.dumps(result),
+        })
+
+    # assess_data_quality result
+    session.history.append({
+        "role": "tool",
+        "tool_call_id": "call_quality",
+        "content": json.dumps({
+            "tables": {t[0]: {"quality_score": 85, "issues": []} for t in tables},
+            "overall_assessment": "Good quality",
+            "table_details": {},
+        }),
+    })
+
+    # profile_table_usage result
+    session.history.append({
+        "role": "tool",
+        "tool_call_id": "call_usage",
+        "content": json.dumps({
+            "tables": {
+                f"banking.core.{t[0]}": {"recent_queries": [], "lineage": {}}
+                for t in tables
+            },
+        }),
+    })
+
+    return session
+
+
+def test_step_detection():
+    """Test: What step does detect_step return after full inspection?"""
+    session = build_mock_session_after_inspection()
+    step = detect_step(session)
+    print(f"\n=== STEP DETECTION ===")
+    print(f"Step after full inspection: '{step}'")
+    print(f"Expected for plan: 'plan'")
+    print(f"ISSUE: Step is '{step}' — {'STUCK IN INSPECTION LOOP!' if step == 'inspection' else 'OK'}")
+    return step
+
+
+def test_prompt_content():
+    """Test: What prompt does the LLM see in the continuation round?"""
+    session = build_mock_session_after_inspection()
+    step = detect_step(session)
+
+    # We can't call assemble_system_prompt without the schema file, so just check the step
+    print(f"\n=== PROMPT ANALYSIS ===")
+    print(f"Detected step: '{step}'")
+    step_idx = STEP_ORDER.index(step) if step in STEP_ORDER else -1
+    print(f"Step index: {step_idx} (inspection=2, plan=3)")
+
+    if step == "inspection":
+        print("PROBLEM: The LLM will receive the inspection prompt which says:")
+        print('  "Call describe_table on each selected table"')
+        print("  This causes the LLM to re-run describe_table even though results exist!")
+        print()
+        print("The step detection only advances to 'plan' when present_plan or generate_plan")
+        print("was called. But you can't call generate_plan until you're IN the plan step.")
+        print("=> DEADLOCK: inspection step tells LLM to inspect, never advances to plan")
+
+
+def test_history_completeness():
+    """Test: Does the session history contain all tool results?"""
+    session = build_mock_session_after_inspection()
+    print(f"\n=== HISTORY COMPLETENESS ===")
+    print(f"Total history messages: {len(session.history)}")
+
+    # Count by role
+    roles = {}
+    for msg in session.history:
+        role = msg["role"]
+        roles[role] = roles.get(role, 0) + 1
+    print(f"By role: {roles}")
+
+    # Check tool_call_ids have matching results
+    call_ids = set()
+    result_ids = set()
+    for msg in session.history:
+        if msg.get("tool_calls"):
+            for tc in msg["tool_calls"]:
+                call_ids.add(tc["id"])
+        if msg["role"] == "tool":
+            result_ids.add(msg["tool_call_id"])
+
+    orphans = call_ids - result_ids
+    print(f"Tool call IDs: {len(call_ids)}")
+    print(f"Tool result IDs: {len(result_ids)}")
+    print(f"Orphaned (call without result): {orphans or 'none'}")
+
+    # Check which tools were called
+    tool_names = set()
+    for msg in session.history:
+        if msg.get("tool_calls"):
+            for tc in msg["tool_calls"]:
+                tool_names.add(tc["function"]["name"])
+    print(f"Tools called: {tool_names}")
+
+
+def test_continuation_count_persistence():
+    """Test: Is _continuation_count preserved between requests?"""
+    session = build_mock_session_after_inspection()
+    print(f"\n=== CONTINUATION COUNT ===")
+
+    # Simulate setting it
+    session._continuation_count = 3
+    print(f"Set _continuation_count = 3")
+
+    # Check if it's a dataclass field
+    import dataclasses
+    fields = {f.name for f in dataclasses.fields(session)}
+    print(f"Dataclass fields: {fields}")
+    print(f"'_continuation_count' is a field: {'_continuation_count' in fields}")
+    print(f"Persisted to Lakebase: {'_continuation_count' in fields}")
+
+    # Simulate what happens on session reload
+    has_attr = hasattr(session, "_continuation_count")
+    print(f"hasattr after set: {has_attr}")
+    val = getattr(session, "_continuation_count", 0)
+    print(f"getattr value: {val}")
+    print(f"NOTE: If session is loaded from Lakebase, _continuation_count defaults to 0")
+    print(f"  This means MAX_TOOL_ROUNDS limit would reset on session reload")
+
+
+def test_concurrent_access():
+    """Test: Can two requests access the same session simultaneously?"""
+    from backend.services.create_agent_session import _sessions
+    print(f"\n=== CONCURRENT ACCESS ===")
+
+    session = build_mock_session_after_inspection()
+    _sessions["test-123"] = session
+
+    # Two "requests" getting the same session
+    from backend.services.create_agent_session import get_session
+    s1 = get_session("test-123")
+    s2 = get_session("test-123")
+
+    print(f"s1 is s2: {s1 is s2}")
+    print(f"Same object: {id(s1) == id(s2)}")
+    print(f"ISSUE: No locking — concurrent requests mutate the SAME object!")
+    print(f"  If request 1 is still executing tools while request 2 starts,")
+    print(f"  request 2 reads partial history from request 1.")
+
+    # Cleanup
+    _sessions.pop("test-123", None)
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("DIAGNOSIS: Agent repeating inspection in auto-pilot mode")
+    print("=" * 60)
+
+    step = test_step_detection()
+    test_prompt_content()
+    test_history_completeness()
+    test_continuation_count_persistence()
+    test_concurrent_access()
+
+    print("\n" + "=" * 60)
+    print("DIAGNOSIS SUMMARY")
+    print("=" * 60)
+    if step == "inspection":
+        print("""
+PRIMARY ROOT CAUSE (Hypothesis B confirmed):
+  detect_step() returns 'inspection' even after ALL inspection tools
+  have completed. It only advances to 'plan' when present_plan or
+  generate_plan was called — but those tools are only suggested by
+  the PLAN step prompt, which the LLM never sees because it's stuck
+  in the INSPECTION step.
+
+  Result: The LLM receives the inspection prompt every continuation
+  round. The prompt says "Call describe_table on each selected table"
+  and the LLM follows the instruction, even though results already
+  exist in history.
+
+SECONDARY ISSUE (Hypothesis A):
+  No session locking. If the SSE proxy timeout kills a connection
+  mid-tool-execution and the frontend immediately continues, two
+  requests can mutate the same session simultaneously, causing
+  partial/duplicate history entries.
+
+PROPOSED FIX:
+  1. Improve detect_step() to recognize when inspection is COMPLETE
+     (describe_table + assess_data_quality/profile_table_usage all
+     have results) and advance to 'plan' automatically.
+  2. Add session locking to prevent concurrent mutations.
+""")
+    else:
+        print(f"Step is '{step}' — Hypothesis B NOT confirmed. Investigate further.")


### PR DESCRIPTION
## Summary

- **SSE proxy timeout fix**: Refactored the create agent from a multi-round SSE loop to single-round-per-request with auto-continuation. Each HTTP request does one LLM inference + one tool batch, then closes cleanly before the Databricks Apps 120s proxy timeout. The frontend transparently opens a new stream.
- **Agent inspection loop fix**: Removed message history compaction which was erasing evidence of completed inspection tools, causing the LLM to re-run `describe_table` indefinitely in auto-pilot mode. Full history is now always preserved (~8-10k tokens, well within Claude's 200k limit).
- **Parallel plan generation**: New `plan_builder.py` runs 4 concurrent LLM calls to generate all plan sections simultaneously (sample questions, text instructions, SQLs, benchmarks, joins, measures, filters, expressions), with parallel SQL validation. ~4x faster than sequential generation.
- **Plan approval checkpoint**: Agent now stops after `generate_plan`/`present_plan` and waits for explicit user action instead of auto-proceeding to space creation.

## Key changes

| File | What changed |
|---|---|
| `create_agent.py` | Single-round architecture, removed compaction, `_STOP_TOOLS` for plan/create, sparse `present_plan` → `generate_plan` redirect, better LLM error surfacing |
| `create_agent_session.py` | Added `asyncio.Lock` per session, `continuation_count` as proper field |
| `routers/create.py` | Session lock around streaming, keepalive handling |
| `plan_builder.py` | New — parallel LLM calls + SQL validation |
| `prompts_create/__init__.py` | `_inspection_complete()` for step detection, prevents inspection→plan deadlock |
| `prompts_create/_plan.py`, `_tools.py`, `_generate.py` | Updated to use `generate_plan` tool, auto-pilot stop rules |
| `create_agent_tools.py` | `generate_plan` tool definition, `type_hint` normalization for SQL params |
| `frontend/api.ts` | `onDone(needsContinuation)` for auto-continuation |
| `frontend/CreateAgentChat.tsx` | `sessionIdRef` for correct continuation, `generate_plan` tool rendering |

## Test plan

- [ ] Auto-pilot: "make a space on nyctaxi" — should discover → inspect → generate plan → **stop** (no repetition, no blank plan)
- [ ] Guided mode: walk through each step — plan should have all sections populated (questions, instructions, joins, expressions, SQLs, benchmarks)
- [ ] Approve & Create — agent waits for user click, doesn't auto-proceed
- [ ] Long-running inspection (8+ tables) — no "Connection interrupted" errors
- [ ] Verify `test_inspection_loop.py` and `test_compaction_400.py` pass locally