### PR TITLE
RFC: Configurable maturity scoring system

### DIFF
--- a/CUJ.md
+++ b/CUJ.md
@@ -20,7 +20,7 @@
 **CUJ 1: Quick Health Check (2 min)**
 > "Is my Genie Space in good shape?"
 
-Space List → click space → "Run IQ Scan" → see score (0-100), maturity label (Nascent / Basic / Developing / Proficient / Optimized), 4-dimension score breakdown, findings, and ranked next steps.
+Space List → click space → "Run IQ Scan" → see score (0-100), maturity level (Nascent / Basic / Developing / Proficient / Optimized), per-stage score breakdown, criteria results, and ranked next steps.
 
 **CUJ 2: Deep Analysis (5-15 min)**
 > "What specifically is wrong and why?"

--- a/backend/maturity_config_default.yaml
+++ b/backend/maturity_config_default.yaml
@@ -1,0 +1,188 @@
+# Genie Space Maturity Curve — Default Configuration
+#
+# This is the default scoring config shipped with the Workbench.
+# Admins can override any part via the Admin Settings UI.
+# See docs/genie-space-maturity.md for the full framework.
+#
+# How it works:
+#   - Each criterion has a registered check function in the scanner (keyed by id).
+#   - Admins can adjust: enabled, points, scale thresholds, and stage ranges.
+#   - Adding new check functions requires a code change in scanner.py.
+
+version: 1
+
+stages:
+  - name: Nascent
+    range: [0, 29]
+    key_question: "Can Genie see my data?"
+    description: "Tables attached but minimal configuration. Answers are unpredictable."
+
+  - name: Basic
+    range: [30, 49]
+    key_question: "Does Genie understand my domain?"
+    description: "Some instructions and table descriptions. Genie is starting to understand context."
+
+  - name: Developing
+    range: [50, 69]
+    key_question: "Does Genie speak my language?"
+    description: "Instructions, sample questions, and joins defined. Genie understands the domain."
+
+  - name: Proficient
+    range: [70, 84]
+    key_question: "Are Genie's answers consistent?"
+    description: "Trusted SQL queries and expressions added. Reliable, metrics-accurate answers."
+
+  - name: Optimized
+    range: [85, 100]
+    key_question: "Is Genie ready for everyone?"
+    description: "Full SQL coverage, benchmarks, and feedback loops. Production-grade self-service."
+
+criteria:
+  # --- Nascent stage ---
+  - id: tables_attached
+    stage: Nascent
+    type: boolean
+    points: 10
+    enabled: true
+    description: "At least one table is attached to the space"
+
+  - id: table_count
+    stage: Nascent
+    type: count
+    points: 10
+    enabled: true
+    description: "Number of tables attached (2-10 ideal range)"
+    scale:
+      min: 1
+      target: 5
+      max: 10
+
+  - id: columns_exist
+    stage: Nascent
+    type: boolean
+    points: 5
+    enabled: true
+    description: "Tables have columns defined"
+
+  # --- Basic stage ---
+  - id: instructions_defined
+    stage: Basic
+    type: boolean
+    points: 5
+    enabled: true
+    description: "General text instructions are set for the space"
+
+  - id: table_descriptions
+    stage: Basic
+    type: boolean
+    points: 5
+    enabled: true
+    description: "Tables have descriptions or comments"
+
+  - id: column_descriptions
+    stage: Basic
+    type: count
+    points: 5
+    enabled: true
+    description: "Proportion of columns with descriptions"
+    scale:
+      min: 0.0
+      target: 0.8
+      max: 1.0
+
+  # --- Developing stage ---
+  - id: instruction_quality
+    stage: Developing
+    type: count
+    points: 5
+    enabled: true
+    description: "Text instructions have meaningful content (>50 chars)"
+    scale:
+      min: 0
+      target: 2
+      max: 5
+
+  - id: sample_questions
+    stage: Developing
+    type: count
+    points: 5
+    enabled: true
+    description: "Number of example SQL questions defined"
+    scale:
+      min: 0
+      target: 5
+      max: 10
+
+  - id: joins_defined
+    stage: Developing
+    type: boolean
+    points: 5
+    enabled: true
+    description: "Join specifications configured for multi-table spaces"
+
+  - id: filter_snippets
+    stage: Developing
+    type: boolean
+    points: 5
+    enabled: true
+    description: "Filter snippets defined for common business segments"
+
+  # --- Proficient stage ---
+  - id: trusted_sql_queries
+    stage: Proficient
+    type: count
+    points: 10
+    enabled: true
+    description: "Number of example SQL queries"
+    scale:
+      min: 0
+      target: 10
+      max: 20
+
+  - id: expressions_defined
+    stage: Proficient
+    type: count
+    points: 5
+    enabled: true
+    description: "SQL expressions and measures for business metrics"
+    scale:
+      min: 0
+      target: 3
+      max: 10
+
+  - id: unity_catalog
+    stage: Proficient
+    type: boolean
+    points: 7
+    enabled: true
+    description: "All tables use fully-qualified Unity Catalog names"
+
+  # --- Optimized stage ---
+  - id: benchmark_questions
+    stage: Optimized
+    type: count
+    points: 8
+    enabled: true
+    description: "Benchmark questions for accuracy tracking"
+    scale:
+      min: 0
+      target: 10
+      max: 20
+
+  - id: sql_coverage
+    stage: Optimized
+    type: count
+    points: 5
+    enabled: true
+    description: "Breadth of SQL examples covering diverse patterns"
+    scale:
+      min: 0
+      target: 15
+      max: 30
+
+  - id: sql_functions
+    stage: Optimized
+    type: boolean
+    points: 5
+    enabled: true
+    description: "Custom SQL functions for complex business logic"

--- a/backend/models.py
+++ b/backend/models.py
@@ -177,8 +177,8 @@ class GenieCreateResponse(BaseModel):
 
 # ===== GenieIQ Models =====
 
-class MaturityLevel(str, Enum):
-    """Maturity level for a Genie Space."""
+class MaturityStage(str, Enum):
+    """Maturity stage for a Genie Space."""
     OPTIMIZED = "Optimized"
     PROFICIENT = "Proficient"
     DEVELOPING = "Developing"
@@ -186,20 +186,33 @@ class MaturityLevel(str, Enum):
     NASCENT = "Nascent"
 
 
+class CriterionResult(BaseModel):
+    """Result of evaluating a single maturity criterion."""
+    id: str
+    stage: str
+    description: str
+    passed: bool
+    value: float | None = None
+    points_earned: int = 0
+    points_possible: int = 0
+
+
 class ScoreBreakdown(BaseModel):
-    """Score breakdown by dimension."""
-    foundation: int = Field(0, ge=0, le=30, description="Foundation score (0-30)")
-    data_setup: int = Field(0, ge=0, le=25, description="Data Setup score (0-25)")
-    sql_assets: int = Field(0, ge=0, le=25, description="SQL Assets score (0-25)")
-    optimization: int = Field(0, ge=0, le=20, description="Optimization score (0-20)")
+    """Score breakdown by maturity stage."""
+    nascent: int = Field(0, ge=0, description="Nascent stage score")
+    basic: int = Field(0, ge=0, description="Basic stage score")
+    developing: int = Field(0, ge=0, description="Developing stage score")
+    proficient: int = Field(0, ge=0, description="Proficient stage score")
+    optimized: int = Field(0, ge=0, description="Optimized stage score")
 
 
 class ScanResult(BaseModel):
     """IQ scan result for a Genie Space."""
     space_id: str
     score: int = Field(..., ge=0, le=100)
-    maturity: MaturityLevel
+    maturity: str  # Stage name from config (e.g., "Nascent", "Developing", "Optimized")
     breakdown: ScoreBreakdown
+    criteria_results: list[CriterionResult] = Field(default_factory=list)
     findings: list[str] = Field(default_factory=list)
     next_steps: list[str] = Field(default_factory=list)
     scanned_at: str  # ISO datetime string

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,11 +1,13 @@
-"""Admin router - org-wide statistics, leaderboard, and alerts."""
+"""Admin router - org-wide statistics, leaderboard, alerts, and maturity config."""
 
 import logging
 
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
 
 from backend.services.lakebase import get_all_scan_summaries
 from backend.services.genie_client import list_genie_spaces
+from backend.services.maturity_config import get_active_config, get_default_config, save_admin_overrides
 from backend.models import AdminDashboardStats, LeaderboardEntry, AlertItem
 
 logger = logging.getLogger(__name__)
@@ -124,3 +126,54 @@ async def get_alerts(score_threshold: int = 40) -> list[AlertItem]:
     except Exception as e:
         logger.exception(f"Failed to get alerts: {e}")
         raise HTTPException(status_code=500, detail="Failed to get alerts")
+
+
+# ===== Maturity Config =====
+
+
+class MaturityConfigUpdate(BaseModel):
+    """Request body for updating the maturity config."""
+    config: dict
+
+
+@router.get("/maturity-config")
+async def get_maturity_config() -> dict:
+    """Get the active maturity config (default + admin overrides)."""
+    try:
+        config = await get_active_config()
+        default = get_default_config()
+        return {
+            "active": config,
+            "default": default,
+        }
+    except Exception as e:
+        logger.exception(f"Failed to get maturity config: {e}")
+        raise HTTPException(status_code=500, detail="Failed to get maturity config")
+
+
+@router.put("/maturity-config")
+async def update_maturity_config(request: MaturityConfigUpdate) -> dict:
+    """Update admin overrides for the maturity config.
+
+    The request body contains partial overrides that are merged with
+    the default config. Send only the fields you want to change.
+    """
+    try:
+        await save_admin_overrides(request.config)
+        active = await get_active_config()
+        return {"status": "saved", "active": active}
+    except Exception as e:
+        logger.exception(f"Failed to update maturity config: {e}")
+        raise HTTPException(status_code=500, detail="Failed to update maturity config")
+
+
+@router.post("/maturity-config/reset")
+async def reset_maturity_config() -> dict:
+    """Reset maturity config to defaults (remove all admin overrides)."""
+    try:
+        await save_admin_overrides({})
+        default = get_default_config()
+        return {"status": "reset", "active": default}
+    except Exception as e:
+        logger.exception(f"Failed to reset maturity config: {e}")
+        raise HTTPException(status_code=500, detail="Failed to reset maturity config")

--- a/backend/routers/spaces.py
+++ b/backend/routers/spaces.py
@@ -23,6 +23,7 @@ from backend.models import (
     StarToggleRequest,
     ScanResult,
     ScoreBreakdown,
+    CriterionResult,
     FixRequest,
 )
 
@@ -154,6 +155,7 @@ async def trigger_scan(space_id: str) -> ScanResult:
             score=scan_data["score"],
             maturity=scan_data["maturity"],
             breakdown=ScoreBreakdown(**scan_data["breakdown"]),
+            criteria_results=[CriterionResult(**cr) for cr in scan_data.get("criteria_results", [])],
             findings=scan_data.get("findings", []),
             next_steps=scan_data.get("next_steps", []),
             scanned_at=scan_data["scanned_at"],

--- a/backend/services/maturity_config.py
+++ b/backend/services/maturity_config.py
@@ -1,0 +1,122 @@
+"""Maturity config loader — default YAML + admin overrides from Lakebase."""
+
+import copy
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_YAML = Path(__file__).resolve().parent.parent / "maturity_config_default.yaml"
+
+# Cached default config (loaded once at import time)
+_default_config: dict | None = None
+
+
+def _load_default() -> dict:
+    """Load the default maturity config from the bundled YAML file."""
+    global _default_config
+    if _default_config is None:
+        with open(_CONFIG_YAML) as f:
+            _default_config = yaml.safe_load(f)
+        logger.info("Loaded default maturity config (version %s)", _default_config.get("version"))
+    return _default_config
+
+
+def get_default_config() -> dict:
+    """Return a deep copy of the default config."""
+    return copy.deepcopy(_load_default())
+
+
+def merge_config(base: dict, overrides: dict) -> dict:
+    """Merge admin overrides into the base config.
+
+    Override rules:
+      - stages: replaced wholesale if present in overrides
+      - criteria: merged by id — override fields win, new ids are appended
+      - version: overrides win
+    """
+    merged = copy.deepcopy(base)
+
+    if "version" in overrides:
+        merged["version"] = overrides["version"]
+
+    if "stages" in overrides:
+        merged["stages"] = overrides["stages"]
+
+    if "criteria" in overrides:
+        # Build lookup from base
+        base_by_id = {c["id"]: c for c in merged.get("criteria", [])}
+
+        for override_criterion in overrides["criteria"]:
+            cid = override_criterion["id"]
+            if cid in base_by_id:
+                # Merge fields — override wins
+                base_by_id[cid].update(override_criterion)
+            else:
+                # New criterion from admin
+                base_by_id[cid] = override_criterion
+
+        merged["criteria"] = list(base_by_id.values())
+
+    return merged
+
+
+async def get_active_config() -> dict:
+    """Get the active maturity config (default + admin overrides).
+
+    Tries to load admin overrides from Lakebase. Falls back to default
+    if Lakebase is unavailable or no overrides are stored.
+    """
+    base = get_default_config()
+
+    try:
+        overrides = await _load_admin_overrides()
+        if overrides:
+            return merge_config(base, overrides)
+    except Exception as e:
+        logger.warning("Failed to load admin config overrides: %s", e)
+
+    return base
+
+
+async def save_admin_overrides(overrides: dict) -> None:
+    """Persist admin config overrides to Lakebase."""
+    from backend.services.lakebase import _pool, _lakebase_available, _memory_store
+
+    config_json = json.dumps(overrides)
+
+    if not _lakebase_available or _pool is None:
+        _memory_store.setdefault("maturity_config", {})
+        _memory_store["maturity_config"]["overrides"] = overrides
+        logger.info("Saved maturity config overrides (in-memory)")
+        return
+
+    async with _pool.acquire() as conn:
+        await conn.execute("""
+            INSERT INTO maturity_config (id, config_json, updated_at)
+            VALUES ('active', $1, NOW())
+            ON CONFLICT (id) DO UPDATE SET
+                config_json = EXCLUDED.config_json,
+                updated_at = NOW()
+        """, config_json)
+    logger.info("Saved maturity config overrides to Lakebase")
+
+
+async def _load_admin_overrides() -> Optional[dict]:
+    """Load admin config overrides from Lakebase."""
+    from backend.services.lakebase import _pool, _lakebase_available, _memory_store
+
+    if not _lakebase_available or _pool is None:
+        return _memory_store.get("maturity_config", {}).get("overrides")
+
+    async with _pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT config_json FROM maturity_config WHERE id = 'active'"
+        )
+        if row:
+            return json.loads(row["config_json"])
+    return None

--- a/backend/services/scanner.py
+++ b/backend/services/scanner.py
@@ -1,199 +1,297 @@
-"""IQ scoring engine for Genie Space configurations."""
+"""Config-driven scoring engine for Genie Space maturity.
+
+Criteria check functions are registered by ID. The maturity config
+(YAML default + admin overrides) controls which criteria are active,
+their point weights, and stage thresholds.
+"""
 
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Callable, Optional
 
-from backend.services.genie_client import get_genie_space, get_serialized_space
-from backend.services.lakebase import save_scan_result, get_latest_score
+from backend.services.genie_client import get_serialized_space
+from backend.services.lakebase import save_scan_result
+from backend.services.maturity_config import get_active_config
 
 logger = logging.getLogger(__name__)
 
-# Maturity levels based on score
-MATURITY_LEVELS = [
-    (85, "Optimized"),
-    (70, "Proficient"),
-    (50, "Developing"),
-    (30, "Basic"),
-    (0, "Nascent"),
-]
+# Type for a criterion check function.
+# Takes space_data dict, returns:
+#   - bool for boolean criteria (pass/fail)
+#   - float for count criteria (raw value, scaled by config)
+CheckFn = Callable[[dict], bool | float]
+
+# --- Criterion check functions (keyed by criterion id) ---
+
+_CHECKS: dict[str, CheckFn] = {}
 
 
-def get_maturity_label(score: int) -> str:
-    """Return maturity label for a given score (0-100)."""
-    for threshold, label in MATURITY_LEVELS:
-        if score >= threshold:
-            return label
-    return "Nascent"
+def _register(criterion_id: str):
+    """Decorator to register a check function for a criterion ID."""
+    def decorator(fn: CheckFn) -> CheckFn:
+        _CHECKS[criterion_id] = fn
+        return fn
+    return decorator
 
 
-def calculate_score(space_data: dict) -> dict:
-    """Calculate IQ score for a Genie Space configuration.
+# Nascent stage checks
 
-    Returns a dict with:
-        - score: int (0-100)
-        - maturity: str
-        - breakdown: dict with dimension scores
-        - findings: list of finding strings
-        - next_steps: list of recommended actions
+@_register("tables_attached")
+def _tables_attached(space: dict) -> bool:
+    return len(space.get("data_sources", {}).get("tables", [])) > 0
+
+
+@_register("table_count")
+def _table_count(space: dict) -> float:
+    return float(len(space.get("data_sources", {}).get("tables", [])))
+
+
+@_register("columns_exist")
+def _columns_exist(space: dict) -> bool:
+    tables = space.get("data_sources", {}).get("tables", [])
+    return any(len(t.get("columns", [])) > 0 for t in tables)
+
+
+# Basic / Developing stage checks
+
+@_register("instructions_defined")
+def _instructions_defined(space: dict) -> bool:
+    return len(space.get("instructions", {}).get("text_instructions", [])) > 0
+
+
+@_register("instruction_quality")
+def _instruction_quality(space: dict) -> float:
+    texts = space.get("instructions", {}).get("text_instructions", [])
+    return float(sum(1 for t in texts if len(t.get("content", "")) > 50))
+
+
+@_register("sample_questions")
+def _sample_questions(space: dict) -> float:
+    return float(len(space.get("instructions", {}).get("example_question_sqls", [])))
+
+
+@_register("joins_defined")
+def _joins_defined(space: dict) -> bool:
+    return len(space.get("instructions", {}).get("join_specs", [])) > 0
+
+
+@_register("column_descriptions")
+def _column_descriptions(space: dict) -> float:
+    tables = space.get("data_sources", {}).get("tables", [])
+    total_cols = 0
+    described_cols = 0
+    for t in tables:
+        for col in t.get("columns", []):
+            total_cols += 1
+            if col.get("description") or col.get("comment"):
+                described_cols += 1
+    return described_cols / total_cols if total_cols > 0 else 0.0
+
+
+# Proficient stage checks
+
+@_register("trusted_sql_queries")
+def _trusted_sql_queries(space: dict) -> float:
+    return float(len(space.get("instructions", {}).get("example_question_sqls", [])))
+
+
+@_register("filter_snippets")
+def _filter_snippets(space: dict) -> bool:
+    return len(space.get("instructions", {}).get("sql_snippets", {}).get("filters", [])) > 0
+
+
+@_register("expressions_defined")
+def _expressions_defined(space: dict) -> float:
+    snippets = space.get("instructions", {}).get("sql_snippets", {})
+    return float(
+        len(snippets.get("expressions", []))
+        + len(snippets.get("measures", []))
+    )
+
+
+@_register("table_descriptions")
+def _table_descriptions(space: dict) -> bool:
+    tables = space.get("data_sources", {}).get("tables", [])
+    return any(t.get("description") or t.get("comment") for t in tables)
+
+
+# Optimized stage checks
+
+@_register("benchmark_questions")
+def _benchmark_questions(space: dict) -> float:
+    return float(len(space.get("benchmarks", {}).get("questions", [])))
+
+
+@_register("sql_coverage")
+def _sql_coverage(space: dict) -> float:
+    return float(len(space.get("instructions", {}).get("example_question_sqls", [])))
+
+
+@_register("unity_catalog")
+def _unity_catalog(space: dict) -> bool:
+    tables = space.get("data_sources", {}).get("tables", [])
+    if not tables:
+        return False
+    return all(
+        len(t.get("table_name", "").split(".")) == 3 or t.get("catalog")
+        for t in tables
+    )
+
+
+@_register("sql_functions")
+def _sql_functions(space: dict) -> bool:
+    return len(space.get("instructions", {}).get("sql_functions", [])) > 0
+
+
+# --- Scoring engine ---
+
+
+def _scale_count(value: float, scale: dict) -> float:
+    """Scale a count value to 0.0-1.0 based on config scale thresholds."""
+    target = scale.get("target", 1)
+    if target <= 0:
+        return 1.0 if value > 0 else 0.0
+    return min(value / target, 1.0)
+
+
+def get_maturity_stage(score: int, stages: list[dict]) -> str:
+    """Return the maturity stage name for a given score."""
+    for stage in reversed(stages):
+        low = stage["range"][0]
+        if score >= low:
+            return stage["name"]
+    return stages[0]["name"] if stages else "Unknown"
+
+
+def calculate_score(space_data: dict, config: dict) -> dict:
+    """Calculate maturity score using the provided config.
+
+    Returns a dict with score, maturity stage, breakdown by stage,
+    per-criterion results, findings, and next_steps.
     """
-    breakdown = {
-        "foundation": 0,
-        "data_setup": 0,
-        "sql_assets": 0,
-        "optimization": 0,
-    }
+    stages = config.get("stages", [])
+    criteria = config.get("criteria", [])
+
+    # Track points by stage
+    stage_points: dict[str, int] = {}
+    for stage in stages:
+        stage_points[stage["name"]] = 0
+
+    criteria_results = []
     findings = []
     next_steps = []
 
-    # --- Foundation (30 pts) ---
-    tables = space_data.get("data_sources", {}).get("tables", [])
+    for criterion in criteria:
+        if not criterion.get("enabled", True):
+            continue
 
-    if tables:
-        breakdown["foundation"] += 15
-    else:
-        findings.append("No tables configured")
-        next_steps.append("Add at least one table to your Genie Space")
+        cid = criterion["id"]
+        stage = criterion["stage"]
+        ctype = criterion["type"]
+        max_points = criterion["points"]
+        description = criterion["description"]
 
-    if tables:
-        tables_with_desc = [t for t in tables if t.get("description") or t.get("comment")]
-        if tables_with_desc:
-            breakdown["foundation"] += 10
+        check_fn = _CHECKS.get(cid)
+        if check_fn is None:
+            logger.warning("No check function registered for criterion: %s", cid)
+            continue
+
+        try:
+            result = check_fn(space_data)
+        except Exception as e:
+            logger.warning("Check %s failed: %s", cid, e)
+            result = False if ctype == "boolean" else 0.0
+
+        if ctype == "boolean":
+            passed = bool(result)
+            points = max_points if passed else 0
+            criteria_results.append({
+                "id": cid,
+                "stage": stage,
+                "description": description,
+                "passed": passed,
+                "value": None,
+                "points_earned": points,
+                "points_possible": max_points,
+            })
+            if not passed:
+                findings.append(f"Missing: {description}")
+                next_steps.append(description)
         else:
-            findings.append("Tables have no descriptions")
-            next_steps.append("Add descriptions to your tables to help Genie understand context")
+            # Count type — scale value
+            raw_value = float(result)
+            scale = criterion.get("scale", {"target": 1})
+            ratio = _scale_count(raw_value, scale)
+            points = round(max_points * ratio)
+            passed = points > 0
+            criteria_results.append({
+                "id": cid,
+                "stage": stage,
+                "description": description,
+                "passed": passed,
+                "value": raw_value,
+                "points_earned": points,
+                "points_possible": max_points,
+            })
+            if ratio < 1.0:
+                target = scale.get("target", 1)
+                findings.append(f"Below target: {description} ({raw_value:.0f}/{target})")
+                next_steps.append(f"Improve: {description}")
 
-        # Check column descriptions
-        has_col_descs = any(
-            any(col.get("description") or col.get("comment")
-                for col in t.get("columns", []))
-            for t in tables
-        )
-        if has_col_descs:
-            breakdown["foundation"] += 5
-        else:
-            findings.append("Columns have no descriptions")
-            next_steps.append("Add column descriptions to improve query accuracy")
+        if stage in stage_points:
+            stage_points[stage] += points
 
-    # --- Data Setup (25 pts) ---
-    # Unity Catalog check (catalog.schema.table format)
-    if tables:
-        uc_tables = [t for t in tables if len(t.get("table_name", "").split(".")) == 3
-                     or t.get("catalog")]
-        if uc_tables:
-            breakdown["data_setup"] += 10
-        else:
-            findings.append("Tables may not be using Unity Catalog")
-            next_steps.append("Use fully-qualified Unity Catalog table names (catalog.schema.table)")
+    total_score = sum(stage_points.values())
+    # Cap at 100
+    total_score = min(total_score, 100)
 
-        table_count = len(tables)
-        if 2 <= table_count <= 10:
-            breakdown["data_setup"] += 8
-        elif table_count == 1:
-            findings.append("Only 1 table configured - consider adding related tables")
-            next_steps.append("Add 2-5 related tables for better cross-table query capability")
-        elif table_count > 10:
-            findings.append("More than 10 tables may reduce Genie accuracy")
-            next_steps.append("Consider reducing to the most relevant 5-10 tables")
+    maturity = get_maturity_stage(total_score, stages)
 
-    filter_snippets = space_data.get("instructions", {}).get("sql_snippets", {}).get("filters", [])
-    if filter_snippets:
-        breakdown["data_setup"] += 7
-    else:
-        findings.append("No filter snippets defined")
-        next_steps.append("Add filter snippets for common time ranges and business segments")
-
-    # --- SQL Assets (25 pts) ---
-    example_sqls = space_data.get("instructions", {}).get("example_question_sqls", [])
-    if example_sqls:
-        breakdown["sql_assets"] += 10
-        if len(example_sqls) >= 3:
-            breakdown["sql_assets"] += 8
-        else:
-            findings.append(f"Only {len(example_sqls)} SQL example(s) - add at least 3")
-            next_steps.append("Add at least 3 example SQL questions covering diverse query patterns")
-    else:
-        findings.append("No example SQL questions configured")
-        next_steps.append("Add example SQL questions to teach Genie complex query patterns")
-
-    sql_functions = space_data.get("instructions", {}).get("sql_functions", [])
-    expressions = space_data.get("instructions", {}).get("sql_snippets", {}).get("expressions", [])
-    measures = space_data.get("instructions", {}).get("sql_snippets", {}).get("measures", [])
-
-    if sql_functions or expressions or measures:
-        breakdown["sql_assets"] += 7
-    else:
-        findings.append("No SQL functions, expressions, or measures configured")
-        next_steps.append("Add SQL functions or expression snippets for complex business logic")
-
-    # --- Optimization (20 pts) ---
-    benchmarks = space_data.get("benchmarks", {}).get("questions", [])
-    if benchmarks:
-        breakdown["optimization"] += 8
-    else:
-        findings.append("No benchmark questions configured")
-        next_steps.append("Add benchmark questions to measure and track Genie accuracy")
-
-    text_instructions = space_data.get("instructions", {}).get("text_instructions", [])
-    if text_instructions:
-        # Check if they have meaningful content
-        meaningful = [t for t in text_instructions if len(t.get("content", "")) > 50]
-        if meaningful:
-            breakdown["optimization"] += 7
-        else:
-            findings.append("Text instructions are too brief")
-            next_steps.append("Expand text instructions with business context and terminology")
-    else:
-        findings.append("No text instructions configured")
-        next_steps.append("Add text instructions to explain business context and terminology")
-
-    join_specs = space_data.get("instructions", {}).get("join_specs", [])
-    if join_specs:
-        breakdown["optimization"] += 5
-    else:
-        if len(tables) > 1:
-            findings.append("No join specifications for multi-table space")
-            next_steps.append("Add join specifications to help Genie correctly join your tables")
-
-    total_score = sum(breakdown.values())
-    maturity = get_maturity_label(total_score)
+    breakdown = {
+        "nascent": stage_points.get("Nascent", 0),
+        "basic": stage_points.get("Basic", 0),
+        "developing": stage_points.get("Developing", 0),
+        "proficient": stage_points.get("Proficient", 0),
+        "optimized": stage_points.get("Optimized", 0),
+    }
 
     return {
         "score": total_score,
         "maturity": maturity,
         "breakdown": breakdown,
-        "findings": findings[:5],  # Top 5 findings
-        "next_steps": next_steps[:5],  # Top 5 next steps
+        "criteria_results": criteria_results,
+        "findings": findings[:5],
+        "next_steps": next_steps[:5],
         "scanned_at": datetime.utcnow().isoformat(),
     }
 
 
 async def scan_space(space_id: str, user_token: Optional[str] = None) -> dict:
-    """Fetch space config, calculate IQ score, and persist to Lakebase.
+    """Fetch space config, calculate score using active maturity config, persist.
 
     Args:
         space_id: The Genie Space ID
-        user_token: Optional user token for OBO auth (not used directly, SDK handles this)
+        user_token: Optional user token for OBO auth
 
     Returns:
-        ScanResult dict with score, maturity, breakdown, findings, next_steps
+        Scan result dict with score, maturity, breakdown, criteria_results, findings, next_steps
     """
-    logger.info(f"Scanning space: {space_id}")
+    logger.info("Scanning space: %s", space_id)
 
     try:
         space_data = get_serialized_space(space_id)
     except Exception as e:
-        logger.error(f"Failed to fetch space {space_id}: {e}")
+        logger.error("Failed to fetch space %s: %s", space_id, e)
         raise ValueError(f"Cannot scan space {space_id}: {e}")
 
-    scan_result = calculate_score(space_data)
+    config = await get_active_config()
+    scan_result = calculate_score(space_data, config)
     scan_result["space_id"] = space_id
 
-    # Persist to Lakebase
     try:
         await save_scan_result(space_id, scan_result)
-        logger.info(f"Scan result saved for {space_id}: score={scan_result['score']}")
+        logger.info("Scan result saved for %s: score=%s", space_id, scan_result["score"])
     except Exception as e:
-        logger.warning(f"Failed to persist scan result for {space_id}: {e}")
+        logger.warning("Failed to persist scan result for %s: %s", space_id, e)
 
     return scan_result

--- a/docs/genie-space-maturity.md
+++ b/docs/genie-space-maturity.md
@@ -1,0 +1,140 @@
+# Genie Space Maturity Curve
+
+> Every Genie Space starts at Nascent. Your score shows where you are on the journey — not how well you did.
+
+## Configuration
+
+The maturity scoring is **configurable by workspace admins**.
+
+- **Default config:** [`backend/maturity_config_default.yaml`](../backend/maturity_config_default.yaml) — shipped with the app
+- **Admin overrides:** Applied via the Admin Settings UI (`/api/admin/maturity-config`)
+- **How it works:** Each criterion has a registered check function in the scanner. Admins can adjust point weights, enable/disable criteria, change stage thresholds, and add custom criteria IDs (which require a corresponding check function in code).
+
+## Stages
+
+### 1. Nascent | Score: 0–29
+
+**Key Question:** Can Genie see my data?
+
+Tables attached but minimal configuration. Answers are unpredictable.
+
+| Criteria | Type | Points | Description |
+|----------|------|--------|-------------|
+| tables_attached | boolean | 10 | At least one table is attached to the space |
+| table_count | count | 0–10 | Number of tables attached (2-10 ideal range) |
+| columns_exist | boolean | 5 | Tables have columns defined |
+
+### 2. Basic | Score: 30–49
+
+**Key Question:** Does Genie understand my domain?
+
+Some instructions and table descriptions. Genie is starting to understand context.
+
+| Criteria | Type | Points | Description |
+|----------|------|--------|-------------|
+| instructions_defined | boolean | 5 | General text instructions are set for the space |
+| table_descriptions | boolean | 5 | Tables have descriptions or comments |
+| column_descriptions | count | 0–5 | Proportion of columns with descriptions |
+
+### 3. Developing | Score: 50–69
+
+**Key Question:** Does Genie speak my language?
+
+Instructions, sample questions, and joins defined. Genie understands the domain.
+
+| Criteria | Type | Points | Description |
+|----------|------|--------|-------------|
+| instruction_quality | count | 0–5 | Text instructions have meaningful content (>50 chars) |
+| sample_questions | count | 0–5 | Number of example SQL questions defined |
+| joins_defined | boolean | 5 | Join specifications configured for multi-table spaces |
+| filter_snippets | boolean | 5 | Filter snippets defined for common business segments |
+
+### 4. Proficient | Score: 70–84
+
+**Key Question:** Are Genie's answers consistent?
+
+Trusted SQL queries and expressions added. Reliable, metrics-accurate answers.
+
+| Criteria | Type | Points | Description |
+|----------|------|--------|-------------|
+| trusted_sql_queries | count | 0–10 | Number of example SQL queries |
+| expressions_defined | count | 0–5 | SQL expressions and measures for business metrics |
+| unity_catalog | boolean | 7 | All tables use fully-qualified Unity Catalog names |
+
+### 5. Optimized | Score: 85–100
+
+**Key Question:** Is Genie ready for everyone?
+
+Full SQL coverage, benchmarks, and feedback loops. Production-grade self-service.
+
+| Criteria | Type | Points | Description |
+|----------|------|--------|-------------|
+| benchmark_questions | count | 0–8 | Benchmark questions for accuracy tracking |
+| sql_coverage | count | 0–5 | Breadth of SQL examples covering diverse patterns |
+| sql_functions | boolean | 5 | Custom SQL functions for complex business logic |
+
+## Scoring Summary
+
+| Stage | Score Range | Key Signal |
+|-------|------------|------------|
+| Nascent | 0–29 | Tables attached |
+| Basic | 30–49 | Instructions + table descriptions |
+| Developing | 50–69 | Sample questions + joins + filters |
+| Proficient | 70–84 | Trusted SQL queries + expressions + UC compliance |
+| Optimized | 85–100 | Benchmarks + full SQL coverage + functions |
+
+## Admin Configuration API
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/admin/maturity-config` | GET | Get active config (default + overrides) |
+| `/api/admin/maturity-config` | PUT | Save admin overrides (partial merge) |
+| `/api/admin/maturity-config/reset` | POST | Reset to defaults |
+
+### Example: Adjust a criterion's weight
+
+```json
+PUT /api/admin/maturity-config
+{
+  "config": {
+    "criteria": [
+      { "id": "tables_attached", "points": 15 }
+    ]
+  }
+}
+```
+
+### Example: Disable a criterion
+
+```json
+PUT /api/admin/maturity-config
+{
+  "config": {
+    "criteria": [
+      { "id": "sql_functions", "enabled": false }
+    ]
+  }
+}
+```
+
+### Example: Change stage thresholds
+
+```json
+PUT /api/admin/maturity-config
+{
+  "config": {
+    "stages": [
+      { "name": "Nascent", "range": [0, 24], "key_question": "Can Genie see my data?", "description": "..." },
+      { "name": "Basic", "range": [25, 44], "key_question": "Does Genie understand my domain?", "description": "..." },
+      { "name": "Developing", "range": [45, 64], "key_question": "Does Genie speak my language?", "description": "..." },
+      { "name": "Proficient", "range": [65, 84], "key_question": "Are Genie's answers consistent?", "description": "..." },
+      { "name": "Optimized", "range": [85, 100], "key_question": "Is Genie ready for everyone?", "description": "..." }
+    ]
+  }
+}
+```
+
+## Axes
+
+- **X-axis:** Genie Space Maturity (stage progression)
+- **Y-axis:** Business User Confidence (exponential growth with maturity)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -31,6 +31,7 @@ import type {
   UcTable,
   ValidateConfigResponse,
   CreateWizardSpaceResponse,
+  MaturityConfig,
 } from "@/types"
 
 const API_BASE = "/api"
@@ -694,6 +695,26 @@ export function streamAgentChat(
     })
 
   return () => abortController.abort()
+}
+
+// ── Maturity Config ──────────────────────────────────────────────────────────
+
+export async function getMaturityConfig(): Promise<{ active: MaturityConfig; default: MaturityConfig }> {
+  return fetchWithTimeout(`${API_BASE}/admin/maturity-config`, {}, DEFAULT_TIMEOUT)
+}
+
+export async function updateMaturityConfig(config: Record<string, unknown>): Promise<{ status: string; active: MaturityConfig }> {
+  return fetchWithTimeout(`${API_BASE}/admin/maturity-config`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ config }),
+  }, DEFAULT_TIMEOUT)
+}
+
+export async function resetMaturityConfig(): Promise<{ status: string; active: MaturityConfig }> {
+  return fetchWithTimeout(`${API_BASE}/admin/maturity-config/reset`, {
+    method: "POST",
+  }, DEFAULT_TIMEOUT)
 }
 
 export { ApiError }

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -2,10 +2,13 @@
  * AdminDashboard - Org-wide statistics, leaderboard, and critical alerts.
  */
 import { useState, useEffect } from "react"
-import { TrendingUp, TrendingDown, AlertTriangle, Award, BarChart2, RefreshCw } from "lucide-react"
+import { TrendingUp, TrendingDown, AlertTriangle, Award, BarChart2, RefreshCw, Settings } from "lucide-react"
 import { getAdminDashboard, getLeaderboard, getAlerts } from "@/lib/api"
 import { getScoreColor } from "@/lib/utils"
+import { MaturityConfigEditor } from "@/pages/MaturityConfigEditor"
 import type { AdminDashboardStats, LeaderboardEntry, AlertItem } from "@/types"
+
+type AdminTab = "overview" | "config"
 
 interface AdminDashboardProps {
   onSelectSpace?: (spaceId: string, displayName: string) => void
@@ -29,6 +32,7 @@ function ScoreBadge({ score }: { score: number }) {
 }
 
 export function AdminDashboard({ onSelectSpace }: AdminDashboardProps) {
+  const [tab, setTab] = useState<AdminTab>("overview")
   const [stats, setStats] = useState<AdminDashboardStats | null>(null)
   const [leaderboard, setLeaderboard] = useState<{ top: LeaderboardEntry[]; bottom: LeaderboardEntry[] } | null>(null)
   const [alerts, setAlerts] = useState<AlertItem[]>([])
@@ -84,14 +88,47 @@ export function AdminDashboard({ onSelectSpace }: AdminDashboardProps) {
           <h2 className="text-2xl font-display font-bold text-primary">Admin Dashboard</h2>
           <p className="text-muted mt-1">Org-wide Genie Space health</p>
         </div>
-        <button onClick={loadData} className="flex items-center gap-2 px-3 py-2 rounded-lg border border-default bg-surface hover:bg-surface-secondary text-sm text-secondary transition-colors">
-          <RefreshCw className="w-4 h-4" />
-          Refresh
+        <div className="flex items-center gap-2">
+          {tab === "overview" && (
+            <button onClick={loadData} className="flex items-center gap-2 px-3 py-2 rounded-lg border border-default bg-surface hover:bg-surface-secondary text-sm text-secondary transition-colors">
+              <RefreshCw className="w-4 h-4" />
+              Refresh
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex items-center gap-1 border-b border-default">
+        <button
+          onClick={() => setTab("overview")}
+          className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+            tab === "overview"
+              ? "border-accent text-accent"
+              : "border-transparent text-muted hover:text-secondary"
+          }`}
+        >
+          <BarChart2 className="w-4 h-4" />
+          Overview
+        </button>
+        <button
+          onClick={() => setTab("config")}
+          className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+            tab === "config"
+              ? "border-accent text-accent"
+              : "border-transparent text-muted hover:text-secondary"
+          }`}
+        >
+          <Settings className="w-4 h-4" />
+          Scoring Config
         </button>
       </div>
 
-      {/* Stats */}
-      {stats && (
+      {/* Config tab */}
+      {tab === "config" && <MaturityConfigEditor />}
+
+      {/* Overview tab - Stats */}
+      {tab === "overview" && stats && (
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
           <StatCard label="Total Spaces" value={stats.total_spaces} icon={<BarChart2 className="w-4 h-4" />} />
           <StatCard label="Scanned" value={stats.scanned_spaces} sub={`${stats.total_spaces > 0 ? Math.round(stats.scanned_spaces / stats.total_spaces * 100) : 0}% coverage`} icon={<BarChart2 className="w-4 h-4" />} />
@@ -101,7 +138,7 @@ export function AdminDashboard({ onSelectSpace }: AdminDashboardProps) {
       )}
 
       {/* Maturity distribution */}
-      {stats && Object.keys(stats.maturity_distribution).length > 0 && (
+      {tab === "overview" && stats && Object.keys(stats.maturity_distribution).length > 0 && (
         <div className="bg-surface border border-default rounded-xl p-5">
           <h3 className="text-sm font-semibold text-secondary uppercase tracking-wide mb-4">Maturity Distribution</h3>
           <div className="space-y-2">
@@ -124,7 +161,7 @@ export function AdminDashboard({ onSelectSpace }: AdminDashboardProps) {
         </div>
       )}
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {tab === "overview" && <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Leaderboard */}
         {leaderboard && (
           <div className="bg-surface border border-default rounded-xl p-5">
@@ -195,7 +232,7 @@ export function AdminDashboard({ onSelectSpace }: AdminDashboardProps) {
             </div>
           </div>
         )}
-      </div>
+      </div>}
     </div>
   )
 }

--- a/frontend/src/pages/IQScoreTab.tsx
+++ b/frontend/src/pages/IQScoreTab.tsx
@@ -63,10 +63,11 @@ export function IQScoreTab({ scanResult, onScan, isScanning, spaceId, spaceConfi
       <div className="bg-surface border border-default rounded-xl p-5">
         <h3 className="text-sm font-semibold text-secondary uppercase tracking-wide mb-4">Score Breakdown</h3>
         <div className="space-y-4">
-          <DimensionBar label="Foundation" score={breakdown.foundation} max={30} color="bg-blue-500" />
-          <DimensionBar label="Data Setup" score={breakdown.data_setup} max={25} color="bg-emerald-500" />
-          <DimensionBar label="SQL Assets" score={breakdown.sql_assets} max={25} color="bg-purple-500" />
-          <DimensionBar label="Optimization" score={breakdown.optimization} max={20} color="bg-amber-500" />
+          <DimensionBar label="Nascent" score={breakdown.nascent} max={25} color="bg-red-500" />
+          <DimensionBar label="Basic" score={breakdown.basic} max={15} color="bg-orange-500" />
+          <DimensionBar label="Developing" score={breakdown.developing} max={20} color="bg-yellow-500" />
+          <DimensionBar label="Proficient" score={breakdown.proficient} max={22} color="bg-blue-500" />
+          <DimensionBar label="Optimized" score={breakdown.optimized} max={18} color="bg-emerald-500" />
         </div>
       </div>
 

--- a/frontend/src/pages/MaturityConfigEditor.tsx
+++ b/frontend/src/pages/MaturityConfigEditor.tsx
@@ -1,0 +1,376 @@
+/**
+ * MaturityConfigEditor - Admin UI for configuring maturity scoring.
+ *
+ * Lets admins adjust point weights, enable/disable criteria, modify stage
+ * thresholds, and reset to defaults. Only sends changed fields as overrides.
+ */
+import { useState, useEffect, useMemo } from "react"
+import { Save, RotateCcw, AlertTriangle, Check, ChevronDown, ChevronRight } from "lucide-react"
+import { getMaturityConfig, updateMaturityConfig, resetMaturityConfig } from "@/lib/api"
+import type { MaturityConfig, MaturityConfigCriterion, MaturityConfigStage } from "@/types"
+
+const STAGE_COLORS: Record<string, string> = {
+  Nascent: "border-red-500/30 bg-red-500/5",
+  Basic: "border-orange-500/30 bg-orange-500/5",
+  Developing: "border-yellow-500/30 bg-yellow-500/5",
+  Proficient: "border-blue-500/30 bg-blue-500/5",
+  Optimized: "border-emerald-500/30 bg-emerald-500/5",
+}
+
+const STAGE_DOT_COLORS: Record<string, string> = {
+  Nascent: "bg-red-500",
+  Basic: "bg-orange-500",
+  Developing: "bg-yellow-500",
+  Proficient: "bg-blue-500",
+  Optimized: "bg-emerald-500",
+}
+
+export function MaturityConfigEditor() {
+  const [activeConfig, setActiveConfig] = useState<MaturityConfig | null>(null)
+  const [defaultConfig, setDefaultConfig] = useState<MaturityConfig | null>(null)
+  const [editedStages, setEditedStages] = useState<MaturityConfigStage[]>([])
+  const [editedCriteria, setEditedCriteria] = useState<MaturityConfigCriterion[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [expandedStages, setExpandedStages] = useState<Set<string>>(new Set())
+
+  const loadConfig = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await getMaturityConfig()
+      setActiveConfig(data.active)
+      setDefaultConfig(data.default)
+      setEditedStages(structuredClone(data.active.stages))
+      setEditedCriteria(structuredClone(data.active.criteria))
+      // Expand all stages initially
+      setExpandedStages(new Set(data.active.stages.map(s => s.name)))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load config")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { loadConfig() }, [])
+
+  // Clear success message after 3s
+  useEffect(() => {
+    if (success) {
+      const t = setTimeout(() => setSuccess(null), 3000)
+      return () => clearTimeout(t)
+    }
+  }, [success])
+
+  // Group criteria by stage
+  const criteriaByStage = useMemo(() => {
+    const grouped: Record<string, MaturityConfigCriterion[]> = {}
+    for (const c of editedCriteria) {
+      if (!grouped[c.stage]) grouped[c.stage] = []
+      grouped[c.stage].push(c)
+    }
+    return grouped
+  }, [editedCriteria])
+
+  // Detect if anything has changed from active config
+  const hasChanges = useMemo(() => {
+    if (!activeConfig) return false
+    return (
+      JSON.stringify(editedStages) !== JSON.stringify(activeConfig.stages) ||
+      JSON.stringify(editedCriteria) !== JSON.stringify(activeConfig.criteria)
+    )
+  }, [editedStages, editedCriteria, activeConfig])
+
+  // Build minimal overrides (only fields that differ from default)
+  const buildOverrides = (): Record<string, unknown> => {
+    if (!defaultConfig) return {}
+    const overrides: Record<string, unknown> = {}
+
+    // Check if stages differ from default
+    if (JSON.stringify(editedStages) !== JSON.stringify(defaultConfig.stages)) {
+      overrides.stages = editedStages
+    }
+
+    // Build criteria overrides (only changed fields per criterion)
+    const criteriaOverrides: Record<string, unknown>[] = []
+    for (const edited of editedCriteria) {
+      const def = defaultConfig.criteria.find(c => c.id === edited.id)
+      if (!def) continue
+      const diff: Record<string, unknown> = { id: edited.id }
+      let changed = false
+      if (edited.points !== def.points) { diff.points = edited.points; changed = true }
+      if (edited.enabled !== def.enabled) { diff.enabled = edited.enabled; changed = true }
+      if (changed) criteriaOverrides.push(diff)
+    }
+    if (criteriaOverrides.length > 0) {
+      overrides.criteria = criteriaOverrides
+    }
+
+    return overrides
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const overrides = buildOverrides()
+      const result = await updateMaturityConfig(overrides)
+      setActiveConfig(result.active)
+      setEditedStages(structuredClone(result.active.stages))
+      setEditedCriteria(structuredClone(result.active.criteria))
+      setSuccess("Configuration saved")
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleReset = async () => {
+    if (!confirm("Reset all maturity scoring to defaults? This removes all admin overrides.")) return
+    setSaving(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const result = await resetMaturityConfig()
+      setActiveConfig(result.active)
+      setEditedStages(structuredClone(result.active.stages))
+      setEditedCriteria(structuredClone(result.active.criteria))
+      setSuccess("Reset to defaults")
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to reset")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const updateCriterion = (id: string, field: string, value: unknown) => {
+    setEditedCriteria(prev =>
+      prev.map(c => c.id === id ? { ...c, [field]: value } : c)
+    )
+  }
+
+  const updateStageRange = (index: number, bound: 0 | 1, value: number) => {
+    setEditedStages(prev => {
+      const next = structuredClone(prev)
+      next[index].range[bound] = value
+      return next
+    })
+  }
+
+  const toggleStageExpanded = (name: string) => {
+    setExpandedStages(prev => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+
+  // Check if a criterion differs from default
+  const isModified = (criterion: MaturityConfigCriterion): boolean => {
+    if (!defaultConfig) return false
+    const def = defaultConfig.criteria.find(c => c.id === criterion.id)
+    if (!def) return false
+    return criterion.points !== def.points || criterion.enabled !== def.enabled
+  }
+
+  // Calculate total possible points
+  const totalPoints = useMemo(() =>
+    editedCriteria.filter(c => c.enabled).reduce((sum, c) => sum + c.points, 0),
+    [editedCriteria]
+  )
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="bg-surface border border-default rounded-xl p-4 animate-pulse h-20" />
+        ))}
+      </div>
+    )
+  }
+
+  if (error && !activeConfig) {
+    return (
+      <div className="flex items-center gap-3 p-4 bg-red-500/10 border border-red-500/20 rounded-xl text-red-400">
+        <AlertTriangle className="w-5 h-5" />
+        <span>{error}</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-primary">Maturity Scoring Configuration</h3>
+          <p className="text-sm text-muted mt-1">
+            Adjust stage thresholds, point weights, and enable/disable criteria.
+            Total points: <span className={`font-medium ${totalPoints === 100 ? "text-emerald-400" : "text-amber-400"}`}>{totalPoints}</span>/100
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleReset}
+            disabled={saving}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-lg border border-default bg-surface hover:bg-surface-secondary text-sm text-muted hover:text-secondary transition-colors disabled:opacity-50"
+          >
+            <RotateCcw className="w-3.5 h-3.5" />
+            Reset Defaults
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || !hasChanges}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors disabled:opacity-50"
+          >
+            {saving ? (
+              <RotateCcw className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <Save className="w-3.5 h-3.5" />
+            )}
+            {saving ? "Saving..." : "Save Changes"}
+          </button>
+        </div>
+      </div>
+
+      {/* Status messages */}
+      {error && (
+        <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">
+          <AlertTriangle className="w-4 h-4 flex-shrink-0" />
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="flex items-center gap-2 p-3 bg-emerald-500/10 border border-emerald-500/20 rounded-lg text-emerald-400 text-sm">
+          <Check className="w-4 h-4 flex-shrink-0" />
+          {success}
+        </div>
+      )}
+
+      {/* Stage thresholds */}
+      <div className="bg-surface border border-default rounded-xl p-5">
+        <h4 className="text-sm font-semibold text-secondary uppercase tracking-wide mb-4">Stage Thresholds</h4>
+        <div className="grid grid-cols-5 gap-3">
+          {editedStages.map((stage, i) => (
+            <div key={stage.name} className={`rounded-lg border p-3 ${STAGE_COLORS[stage.name] || "border-default"}`}>
+              <div className="flex items-center gap-2 mb-2">
+                <div className={`w-2 h-2 rounded-full ${STAGE_DOT_COLORS[stage.name] || "bg-gray-500"}`} />
+                <span className="text-xs font-semibold text-secondary">{stage.name}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={stage.range[0]}
+                  onChange={e => updateStageRange(i, 0, parseInt(e.target.value) || 0)}
+                  className="w-14 px-1.5 py-1 rounded border border-default bg-background text-primary text-xs text-center focus:outline-none focus:ring-1 focus:ring-accent/50"
+                />
+                <span className="text-xs text-muted">–</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={stage.range[1]}
+                  onChange={e => updateStageRange(i, 1, parseInt(e.target.value) || 0)}
+                  className="w-14 px-1.5 py-1 rounded border border-default bg-background text-primary text-xs text-center focus:outline-none focus:ring-1 focus:ring-accent/50"
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Criteria by stage */}
+      {editedStages.map(stage => {
+        const criteria = criteriaByStage[stage.name] || []
+        const isExpanded = expandedStages.has(stage.name)
+        const stagePoints = criteria.filter(c => c.enabled).reduce((s, c) => s + c.points, 0)
+
+        return (
+          <div key={stage.name} className={`border rounded-xl overflow-hidden ${STAGE_COLORS[stage.name] || "border-default"}`}>
+            {/* Stage header */}
+            <button
+              onClick={() => toggleStageExpanded(stage.name)}
+              className="w-full flex items-center justify-between p-4 hover:bg-surface-secondary/30 transition-colors"
+            >
+              <div className="flex items-center gap-3">
+                {isExpanded ? <ChevronDown className="w-4 h-4 text-muted" /> : <ChevronRight className="w-4 h-4 text-muted" />}
+                <div className={`w-2.5 h-2.5 rounded-full ${STAGE_DOT_COLORS[stage.name] || "bg-gray-500"}`} />
+                <span className="font-semibold text-primary">{stage.name}</span>
+                <span className="text-xs text-muted">({stage.range[0]}–{stage.range[1]})</span>
+              </div>
+              <span className="text-sm text-muted">{stagePoints} pts</span>
+            </button>
+
+            {/* Criteria table */}
+            {isExpanded && criteria.length > 0 && (
+              <div className="border-t border-default">
+                <table className="w-full">
+                  <thead>
+                    <tr className="text-xs text-muted uppercase tracking-wide">
+                      <th className="text-left pl-12 pr-3 py-2 font-medium">Criterion</th>
+                      <th className="text-left px-3 py-2 font-medium w-20">Type</th>
+                      <th className="text-left px-3 py-2 font-medium w-24">Points</th>
+                      <th className="text-center px-3 py-2 font-medium w-20">Enabled</th>
+                      <th className="text-right pr-4 py-2 font-medium w-20"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {criteria.map(c => {
+                      const modified = isModified(c)
+                      return (
+                        <tr
+                          key={c.id}
+                          className={`border-t border-default/50 ${modified ? "bg-accent/5" : ""}`}
+                        >
+                          <td className="pl-12 pr-3 py-3">
+                            <div className="text-sm text-primary">{c.description}</div>
+                            <div className="text-xs text-muted font-mono mt-0.5">{c.id}</div>
+                          </td>
+                          <td className="px-3 py-3">
+                            <span className={`text-xs px-1.5 py-0.5 rounded ${c.type === "boolean" ? "bg-purple-500/20 text-purple-400" : "bg-cyan-500/20 text-cyan-400"}`}>
+                              {c.type}
+                            </span>
+                          </td>
+                          <td className="px-3 py-3">
+                            <input
+                              type="number"
+                              min={0}
+                              max={50}
+                              value={c.points}
+                              onChange={e => updateCriterion(c.id, "points", parseInt(e.target.value) || 0)}
+                              className="w-16 px-2 py-1 rounded border border-default bg-background text-primary text-sm text-center focus:outline-none focus:ring-1 focus:ring-accent/50"
+                            />
+                          </td>
+                          <td className="px-3 py-3 text-center">
+                            <button
+                              onClick={() => updateCriterion(c.id, "enabled", !c.enabled)}
+                              className={`w-8 h-5 rounded-full transition-colors relative ${c.enabled ? "bg-emerald-500" : "bg-surface-secondary"}`}
+                            >
+                              <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${c.enabled ? "left-3.5" : "left-0.5"}`} />
+                            </button>
+                          </td>
+                          <td className="pr-4 py-3 text-right">
+                            {modified && (
+                              <span className="text-[10px] text-accent font-medium uppercase">Modified</span>
+                            )}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -161,20 +161,32 @@ export type OptimizeView = "benchmarks" | "labeling" | "feedback" | "optimizatio
 
 // ===== GenieIQ / Workbench Types =====
 
-export type MaturityLevel = "Optimized" | "Proficient" | "Developing" | "Basic" | "Nascent"
+export type MaturityStage = "Optimized" | "Proficient" | "Developing" | "Basic" | "Nascent"
+
+export interface CriterionResult {
+  id: string
+  stage: string
+  description: string
+  passed: boolean
+  value: number | null
+  points_earned: number
+  points_possible: number
+}
 
 export interface ScoreBreakdown {
-  foundation: number    // 0-30
-  data_setup: number    // 0-25
-  sql_assets: number    // 0-25
-  optimization: number  // 0-20
+  nascent: number
+  basic: number
+  developing: number
+  proficient: number
+  optimized: number
 }
 
 export interface ScanResult {
   space_id: string
   score: number
-  maturity: MaturityLevel
+  maturity: string
   breakdown: ScoreBreakdown
+  criteria_results: CriterionResult[]
   findings: string[]
   next_steps: string[]
   scanned_at: string
@@ -184,10 +196,33 @@ export interface SpaceListItem {
   space_id: string
   display_name: string
   score: number | null
-  maturity: MaturityLevel | null
+  maturity: string | null
   is_starred: boolean
   last_scanned: string | null
   space_url: string | null
+}
+
+export interface MaturityConfigStage {
+  name: string
+  range: [number, number]
+  key_question: string
+  description: string
+}
+
+export interface MaturityConfigCriterion {
+  id: string
+  stage: string
+  type: "boolean" | "count"
+  points: number
+  enabled: boolean
+  description: string
+  scale?: { min: number; target: number; max: number }
+}
+
+export interface MaturityConfig {
+  version: number
+  stages: MaturityConfigStage[]
+  criteria: MaturityConfigCriterion[]
 }
 
 export interface StarToggleRequest {
@@ -229,7 +264,7 @@ export interface LeaderboardEntry {
   space_id: string
   display_name: string
   score: number
-  maturity: MaturityLevel
+  maturity: string
   last_scanned: string | null
 }
 
@@ -242,7 +277,7 @@ export interface AlertItem {
 
 export interface ScoreHistoryPoint {
   score: number
-  maturity: MaturityLevel
+  maturity: string
   scanned_at: string
 }
 

--- a/jobs/score_all_spaces.py
+++ b/jobs/score_all_spaces.py
@@ -1,0 +1,334 @@
+# Databricks notebook source
+"""Scheduled job: score all Genie Spaces and persist results to Lakebase.
+
+Self-contained — uses Databricks SDK and psycopg2 directly so it can run
+as a notebook task without depending on the app's source tree.
+
+Scoring uses the 5-level Maturity Curve:
+  Nascent (0-29) → Basic (30-49) → Developing (50-69) → Proficient (70-84) → Optimized (85-100)
+"""
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Configuration
+
+# COMMAND ----------
+
+import json
+import logging
+from datetime import datetime
+
+from databricks.sdk import WorkspaceClient
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("score_all_spaces")
+
+LAKEBASE_INSTANCE_NAME = "genie-workbench-sz"
+LAKEBASE_HOST = "instance-e5f92571-9961-4b1a-a11d-2a6eda65244d.database.cloud.databricks.com"
+LAKEBASE_PORT = 5432
+LAKEBASE_DATABASE = "databricks_postgres"
+ALERT_THRESHOLD = 40
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Maturity Curve Stages
+
+# COMMAND ----------
+
+MATURITY_LEVELS = [
+    (85, "Optimized"),
+    (70, "Proficient"),
+    (50, "Developing"),
+    (30, "Basic"),
+    (0, "Nascent"),
+]
+
+
+def get_maturity_label(score: int) -> str:
+    for threshold, label in MATURITY_LEVELS:
+        if score >= threshold:
+            return label
+    return "Nascent"
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Scoring Logic
+# MAGIC
+# MAGIC Mirrors `backend/services/scanner.py` — criteria checks by stage.
+
+# COMMAND ----------
+
+
+def calculate_score(space_data: dict) -> dict:
+    """Calculate maturity score for a Genie Space configuration."""
+    breakdown = {"nascent": 0, "basic": 0, "developing": 0, "proficient": 0, "optimized": 0}
+    findings = []
+    next_steps = []
+
+    tables = space_data.get("data_sources", {}).get("tables", [])
+    instructions = space_data.get("instructions", {})
+    snippets = instructions.get("sql_snippets", {})
+
+    # --- Nascent (25 pts max) ---
+    if tables:
+        breakdown["nascent"] += 10  # tables_attached
+    else:
+        findings.append("No tables configured")
+        next_steps.append("Add at least one table to your Genie Space")
+
+    # table_count (10 pts, scaled to target=5)
+    table_count = len(tables)
+    breakdown["nascent"] += min(round(10 * min(table_count / 5, 1.0)), 10)
+
+    # columns_exist (5 pts)
+    if tables and any(len(t.get("columns", [])) > 0 for t in tables):
+        breakdown["nascent"] += 5
+    elif tables:
+        findings.append("Tables have no columns defined")
+        next_steps.append("Ensure tables have columns defined")
+
+    # --- Basic (15 pts max) ---
+    text_instructions = instructions.get("text_instructions", [])
+    if text_instructions:
+        breakdown["basic"] += 5  # instructions_defined
+    else:
+        findings.append("No text instructions configured")
+        next_steps.append("Add text instructions to explain business context")
+
+    # table_descriptions (5 pts)
+    if tables and any(t.get("description") or t.get("comment") for t in tables):
+        breakdown["basic"] += 5
+    elif tables:
+        findings.append("Tables have no descriptions")
+        next_steps.append("Add descriptions to tables to help Genie understand context")
+
+    # column_descriptions (5 pts, scaled to target=0.8)
+    total_cols = sum(len(t.get("columns", [])) for t in tables)
+    desc_cols = sum(
+        1 for t in tables for col in t.get("columns", [])
+        if col.get("description") or col.get("comment")
+    )
+    col_ratio = desc_cols / total_cols if total_cols > 0 else 0.0
+    breakdown["basic"] += min(round(5 * min(col_ratio / 0.8, 1.0)), 5)
+
+    # --- Developing (20 pts max) ---
+    example_sqls = instructions.get("example_question_sqls", [])
+
+    # instruction_quality (5 pts, scaled to target=2)
+    meaningful = sum(1 for t in text_instructions if len(t.get("content", "")) > 50)
+    breakdown["developing"] += min(round(5 * min(meaningful / 2, 1.0)), 5)
+
+    # sample_questions (5 pts, scaled to target=5)
+    breakdown["developing"] += min(round(5 * min(len(example_sqls) / 5, 1.0)), 5)
+
+    # joins_defined (5 pts)
+    if instructions.get("join_specs"):
+        breakdown["developing"] += 5
+    elif table_count > 1:
+        findings.append("No join specifications for multi-table space")
+        next_steps.append("Add join specifications to help Genie join tables correctly")
+
+    # filter_snippets (5 pts)
+    if snippets.get("filters"):
+        breakdown["developing"] += 5
+    else:
+        findings.append("No filter snippets defined")
+        next_steps.append("Add filter snippets for common time ranges and business segments")
+
+    # --- Proficient (22 pts max) ---
+    # trusted_sql_queries (10 pts, scaled to target=10)
+    breakdown["proficient"] += min(round(10 * min(len(example_sqls) / 10, 1.0)), 10)
+
+    # expressions_defined (5 pts, scaled to target=3)
+    expr_count = len(snippets.get("expressions", [])) + len(snippets.get("measures", []))
+    breakdown["proficient"] += min(round(5 * min(expr_count / 3, 1.0)), 5)
+
+    # unity_catalog (7 pts)
+    if tables and all(
+        len(t.get("table_name", "").split(".")) == 3 or t.get("catalog")
+        for t in tables
+    ):
+        breakdown["proficient"] += 7
+    elif tables:
+        findings.append("Tables may not be using Unity Catalog")
+        next_steps.append("Use fully-qualified Unity Catalog table names (catalog.schema.table)")
+
+    # --- Optimized (18 pts max) ---
+    # benchmark_questions (8 pts, scaled to target=10)
+    benchmarks = space_data.get("benchmarks", {}).get("questions", [])
+    breakdown["optimized"] += min(round(8 * min(len(benchmarks) / 10, 1.0)), 8)
+    if not benchmarks:
+        findings.append("No benchmark questions configured")
+        next_steps.append("Add benchmark questions to measure Genie accuracy")
+
+    # sql_coverage (5 pts, scaled to target=15)
+    breakdown["optimized"] += min(round(5 * min(len(example_sqls) / 15, 1.0)), 5)
+
+    # sql_functions (5 pts)
+    if instructions.get("sql_functions"):
+        breakdown["optimized"] += 5
+
+    total_score = min(sum(breakdown.values()), 100)
+    maturity = get_maturity_label(total_score)
+
+    return {
+        "score": total_score,
+        "maturity": maturity,
+        "breakdown": breakdown,
+        "findings": findings[:5],
+        "next_steps": next_steps[:5],
+        "scanned_at": datetime.utcnow().isoformat(),
+    }
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Discover and Score All Spaces
+
+# COMMAND ----------
+
+w = WorkspaceClient()
+
+# List all Genie Spaces
+logger.info("Listing Genie Spaces...")
+spaces = []
+page_token = None
+while True:
+    params = {"page_size": 100}
+    if page_token:
+        params["page_token"] = page_token
+    resp = w.api_client.do(method="GET", path="/api/2.0/genie/spaces", query=params)
+    spaces.extend(resp.get("spaces", []))
+    page_token = resp.get("next_page_token")
+    if not page_token:
+        break
+
+logger.info(f"Found {len(spaces)} Genie Space(s)")
+
+# Score each space
+results = []
+failed = 0
+
+for space in spaces:
+    space_id = space.get("id", "")
+    display_name = space.get("display_name", "Unknown")
+    if not space_id:
+        continue
+
+    try:
+        raw = w.api_client.do(
+            method="GET",
+            path=f"/api/2.0/genie/spaces/{space_id}",
+            query={"include_serialized_space": "true"},
+        )
+        space_data = json.loads(raw.get("serialized_space", "{}"))
+        result = calculate_score(space_data)
+        result["space_id"] = space_id
+        result["display_name"] = display_name
+        results.append(result)
+        logger.info(f"  {display_name}: {result['score']}/100 ({result['maturity']})")
+    except Exception as e:
+        logger.warning(f"  {display_name}: FAILED - {e}")
+        failed += 1
+
+logger.info(f"Scored {len(results)}, failed {failed}")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Persist to Lakebase
+
+# COMMAND ----------
+
+import psycopg2
+
+# Generate Lakebase credential
+cred_resp = w.api_client.do(
+    method="POST",
+    path="/api/2.0/database/credentials",
+    body={"request_id": "score-job", "instance_names": [LAKEBASE_INSTANCE_NAME]},
+)
+lb_token = cred_resp["token"]
+lb_user = w.current_user.me().user_name
+
+conn = psycopg2.connect(
+    host=LAKEBASE_HOST,
+    port=LAKEBASE_PORT,
+    dbname=LAKEBASE_DATABASE,
+    user=lb_user,
+    password=lb_token,
+    sslmode="require",
+)
+conn.autocommit = True
+cur = conn.cursor()
+
+# Ensure table exists
+cur.execute("""
+    CREATE TABLE IF NOT EXISTS scan_results (
+        space_id TEXT NOT NULL,
+        score INTEGER NOT NULL,
+        maturity TEXT,
+        breakdown JSONB,
+        findings JSONB,
+        next_steps JSONB,
+        scanned_at TIMESTAMPTZ NOT NULL,
+        UNIQUE (space_id, scanned_at)
+    )
+""")
+
+# Insert results
+for r in results:
+    cur.execute("""
+        INSERT INTO scan_results (space_id, score, maturity, breakdown, findings, next_steps, scanned_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (space_id, scanned_at) DO UPDATE SET
+            score = EXCLUDED.score,
+            maturity = EXCLUDED.maturity,
+            breakdown = EXCLUDED.breakdown,
+            findings = EXCLUDED.findings,
+            next_steps = EXCLUDED.next_steps
+    """, (
+        r["space_id"],
+        r["score"],
+        r["maturity"],
+        json.dumps(r["breakdown"]),
+        json.dumps(r["findings"]),
+        json.dumps(r["next_steps"]),
+        datetime.fromisoformat(r["scanned_at"]),
+    ))
+
+cur.close()
+conn.close()
+logger.info(f"Persisted {len(results)} results to Lakebase")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Summary
+
+# COMMAND ----------
+
+alerts = [r for r in results if r["score"] < ALERT_THRESHOLD]
+
+summary = {
+    "timestamp": datetime.utcnow().isoformat(),
+    "total_spaces": len(spaces),
+    "scored": len(results),
+    "failed": failed,
+    "alerts": [
+        {"space_id": a["space_id"], "display_name": a["display_name"],
+         "score": a["score"], "maturity": a["maturity"],
+         "top_finding": a["findings"][0] if a["findings"] else None}
+        for a in alerts
+    ],
+}
+
+if alerts:
+    logger.warning(f"{len(alerts)} space(s) below threshold ({ALERT_THRESHOLD}):")
+    for a in alerts:
+        logger.warning(f"  {a['display_name']}: {a['score']}/100")
+
+print(json.dumps(summary, indent=2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "streamlit>=1.40.0",
     "asyncpg>=0.29",
     "psycopg2-binary",
+    "mcp>=1.26.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ requests>=2.31.0
 streamlit>=1.40.0
 asyncpg>=0.29
 psycopg2-binary
+mcp>=1.9.0
+pyyaml>=6.0

--- a/tests/test_maturity_config.py
+++ b/tests/test_maturity_config.py
@@ -1,0 +1,116 @@
+"""Tests for maturity config loading and merging logic."""
+
+import pytest
+from backend.services.maturity_config import get_default_config, merge_config
+
+
+@pytest.fixture
+def default_config():
+    return get_default_config()
+
+
+class TestDefaultConfig:
+    def test_loads_successfully(self, default_config):
+        assert default_config is not None
+
+    def test_has_version(self, default_config):
+        assert "version" in default_config
+
+    def test_has_five_stages(self, default_config):
+        assert len(default_config["stages"]) == 5
+
+    def test_stage_names(self, default_config):
+        names = [s["name"] for s in default_config["stages"]]
+        assert names == ["Nascent", "Basic", "Developing", "Proficient", "Optimized"]
+
+    def test_stages_cover_0_to_100(self, default_config):
+        stages = default_config["stages"]
+        assert stages[0]["range"][0] == 0
+        assert stages[-1]["range"][1] == 100
+
+    def test_stages_contiguous(self, default_config):
+        """Each stage's low bound should be previous stage's high bound + 1."""
+        stages = default_config["stages"]
+        for i in range(1, len(stages)):
+            assert stages[i]["range"][0] == stages[i - 1]["range"][1] + 1, (
+                f"Gap between {stages[i-1]['name']} and {stages[i]['name']}"
+            )
+
+    def test_has_criteria(self, default_config):
+        assert len(default_config["criteria"]) > 0
+
+    def test_criteria_have_required_fields(self, default_config):
+        required = {"id", "stage", "type", "points", "enabled", "description"}
+        for c in default_config["criteria"]:
+            missing = required - set(c.keys())
+            assert not missing, f"Criterion {c['id']} missing fields: {missing}"
+
+    def test_criteria_types_valid(self, default_config):
+        for c in default_config["criteria"]:
+            assert c["type"] in ("boolean", "count"), f"{c['id']} has invalid type: {c['type']}"
+
+    def test_total_points_is_100(self, default_config):
+        total = sum(c["points"] for c in default_config["criteria"] if c["enabled"])
+        assert total == 100, f"Total points should be 100, got {total}"
+
+    def test_deep_copy_isolation(self):
+        """Modifications to one copy shouldn't affect another."""
+        a = get_default_config()
+        b = get_default_config()
+        a["stages"][0]["name"] = "MODIFIED"
+        assert b["stages"][0]["name"] == "Nascent"
+
+
+class TestMergeConfig:
+    def test_empty_overrides_returns_base(self, default_config):
+        merged = merge_config(default_config, {})
+        assert merged == default_config
+
+    def test_override_version(self, default_config):
+        merged = merge_config(default_config, {"version": 99})
+        assert merged["version"] == 99
+
+    def test_override_stages_replaces_wholesale(self, default_config):
+        new_stages = [{"name": "Low", "range": [0, 50]}, {"name": "High", "range": [51, 100]}]
+        merged = merge_config(default_config, {"stages": new_stages})
+        assert len(merged["stages"]) == 2
+        assert merged["stages"][0]["name"] == "Low"
+
+    def test_override_criterion_points(self, default_config):
+        merged = merge_config(default_config, {
+            "criteria": [{"id": "tables_attached", "points": 20}],
+        })
+        tables = next(c for c in merged["criteria"] if c["id"] == "tables_attached")
+        assert tables["points"] == 20
+        # Other fields preserved
+        assert tables["type"] == "boolean"
+        assert tables["stage"] == "Nascent"
+
+    def test_override_criterion_enabled(self, default_config):
+        merged = merge_config(default_config, {
+            "criteria": [{"id": "sql_functions", "enabled": False}],
+        })
+        sf = next(c for c in merged["criteria"] if c["id"] == "sql_functions")
+        assert sf["enabled"] is False
+
+    def test_override_preserves_unmodified_criteria(self, default_config):
+        original_count = len(default_config["criteria"])
+        merged = merge_config(default_config, {
+            "criteria": [{"id": "tables_attached", "points": 20}],
+        })
+        assert len(merged["criteria"]) == original_count
+
+    def test_new_criterion_appended(self, default_config):
+        original_count = len(default_config["criteria"])
+        merged = merge_config(default_config, {
+            "criteria": [{"id": "custom_check", "stage": "Basic", "type": "boolean", "points": 5, "enabled": True, "description": "Custom"}],
+        })
+        assert len(merged["criteria"]) == original_count + 1
+        custom = next(c for c in merged["criteria"] if c["id"] == "custom_check")
+        assert custom["points"] == 5
+
+    def test_merge_does_not_mutate_base(self, default_config):
+        import copy
+        original = copy.deepcopy(default_config)
+        merge_config(default_config, {"criteria": [{"id": "tables_attached", "points": 99}]})
+        assert default_config == original

--- a/tests/test_maturity_scoring.py
+++ b/tests/test_maturity_scoring.py
@@ -1,0 +1,313 @@
+"""Tests for the config-driven maturity scoring engine.
+
+Covers: calculate_score, get_maturity_stage, _scale_count, and all
+registered check functions against known space data fixtures.
+"""
+
+import pytest
+from backend.services.scanner import (
+    calculate_score,
+    get_maturity_stage,
+    _scale_count,
+    _CHECKS,
+)
+from backend.services.maturity_config import get_default_config
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def default_config():
+    return get_default_config()
+
+
+@pytest.fixture
+def empty_space():
+    """A space with no tables, no instructions, nothing."""
+    return {"data_sources": {"tables": []}, "instructions": {}}
+
+
+@pytest.fixture
+def nascent_space():
+    """Minimal space — just tables attached."""
+    return {
+        "data_sources": {
+            "tables": [
+                {"identifier": "cat.schema.orders", "table_name": "cat.schema.orders", "columns": [{"name": "id"}]},
+            ],
+        },
+        "instructions": {},
+    }
+
+
+@pytest.fixture
+def developing_space():
+    """A reasonably configured space hitting Developing stage."""
+    return {
+        "data_sources": {
+            "tables": [
+                {
+                    "identifier": "cat.schema.orders",
+                    "table_name": "cat.schema.orders",
+                    "description": "Customer orders",
+                    "catalog": "cat",
+                    "columns": [
+                        {"name": "id", "description": "Primary key"},
+                        {"name": "amount", "description": "Order amount"},
+                        {"name": "status", "comment": "Order status"},
+                    ],
+                },
+                {
+                    "identifier": "cat.schema.customers",
+                    "table_name": "cat.schema.customers",
+                    "description": "Customer records",
+                    "catalog": "cat",
+                    "columns": [
+                        {"name": "id", "description": "Primary key"},
+                        {"name": "name", "description": "Full name"},
+                    ],
+                },
+            ],
+        },
+        "instructions": {
+            "text_instructions": [
+                {"content": "This space answers questions about customer orders and revenue metrics for the sales team."},
+                {"content": "Use the orders table as the primary fact table. Join to customers on customer_id."},
+            ],
+            "example_question_sqls": [
+                {"question": "Total revenue", "sql": "SELECT SUM(amount) FROM orders"},
+                {"question": "Orders by status", "sql": "SELECT status, COUNT(*) FROM orders GROUP BY 1"},
+                {"question": "Top customers", "sql": "SELECT name, SUM(amount) FROM orders JOIN customers USING(id) GROUP BY 1 ORDER BY 2 DESC"},
+            ],
+            "join_specs": [{"left": "orders", "right": "customers", "on": "customer_id"}],
+            "sql_snippets": {
+                "filters": [{"name": "last_30d", "sql": "date >= CURRENT_DATE - 30"}],
+            },
+        },
+    }
+
+
+@pytest.fixture
+def optimized_space(developing_space):
+    """A fully configured space that should hit Optimized."""
+    space = developing_space.copy()
+    space["instructions"] = {
+        **developing_space["instructions"],
+        "example_question_sqls": [
+            {"question": f"Q{i}", "sql": f"SELECT {i}"} for i in range(15)
+        ],
+        "sql_snippets": {
+            **developing_space["instructions"]["sql_snippets"],
+            "expressions": [{"name": "aov", "sql": "SUM(amount)/COUNT(*)"}],
+            "measures": [{"name": "total_rev", "sql": "SUM(amount)"}, {"name": "order_count", "sql": "COUNT(*)"}],
+        },
+        "sql_functions": [{"name": "fiscal_quarter", "sql": "..."}],
+    }
+    space["benchmarks"] = {
+        "questions": [{"question": f"BQ{i}"} for i in range(10)],
+    }
+    return space
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: helpers
+# ---------------------------------------------------------------------------
+
+class TestScaleCount:
+    def test_zero_value(self):
+        assert _scale_count(0.0, {"target": 5}) == 0.0
+
+    def test_at_target(self):
+        assert _scale_count(5.0, {"target": 5}) == 1.0
+
+    def test_above_target_capped(self):
+        assert _scale_count(10.0, {"target": 5}) == 1.0
+
+    def test_half_target(self):
+        assert _scale_count(2.5, {"target": 5}) == 0.5
+
+    def test_zero_target(self):
+        assert _scale_count(0.0, {"target": 0}) == 0.0
+        assert _scale_count(1.0, {"target": 0}) == 1.0
+
+
+class TestGetMaturityStage:
+    @pytest.fixture
+    def stages(self):
+        return [
+            {"name": "Nascent", "range": [0, 29]},
+            {"name": "Basic", "range": [30, 49]},
+            {"name": "Developing", "range": [50, 69]},
+            {"name": "Proficient", "range": [70, 84]},
+            {"name": "Optimized", "range": [85, 100]},
+        ]
+
+    def test_zero_is_nascent(self, stages):
+        assert get_maturity_stage(0, stages) == "Nascent"
+
+    def test_boundary_29_is_nascent(self, stages):
+        assert get_maturity_stage(29, stages) == "Nascent"
+
+    def test_boundary_30_is_basic(self, stages):
+        assert get_maturity_stage(30, stages) == "Basic"
+
+    def test_boundary_50_is_developing(self, stages):
+        assert get_maturity_stage(50, stages) == "Developing"
+
+    def test_boundary_70_is_proficient(self, stages):
+        assert get_maturity_stage(70, stages) == "Proficient"
+
+    def test_boundary_85_is_optimized(self, stages):
+        assert get_maturity_stage(85, stages) == "Optimized"
+
+    def test_100_is_optimized(self, stages):
+        assert get_maturity_stage(100, stages) == "Optimized"
+
+    def test_empty_stages(self):
+        assert get_maturity_stage(50, []) == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: registered check functions
+# ---------------------------------------------------------------------------
+
+class TestCheckFunctions:
+    def test_all_criteria_have_checks(self, default_config):
+        """Every criterion in the default config must have a registered check."""
+        for criterion in default_config["criteria"]:
+            assert criterion["id"] in _CHECKS, f"No check registered for: {criterion['id']}"
+
+    def test_tables_attached_empty(self, empty_space):
+        assert _CHECKS["tables_attached"](empty_space) is False
+
+    def test_tables_attached_with_table(self, nascent_space):
+        assert _CHECKS["tables_attached"](nascent_space) is True
+
+    def test_table_count(self, developing_space):
+        assert _CHECKS["table_count"](developing_space) == 2.0
+
+    def test_columns_exist_empty(self, empty_space):
+        assert _CHECKS["columns_exist"](empty_space) is False
+
+    def test_columns_exist(self, nascent_space):
+        assert _CHECKS["columns_exist"](nascent_space) is True
+
+    def test_instructions_defined_empty(self, empty_space):
+        assert _CHECKS["instructions_defined"](empty_space) is False
+
+    def test_instructions_defined(self, developing_space):
+        assert _CHECKS["instructions_defined"](developing_space) is True
+
+    def test_column_descriptions_full(self, developing_space):
+        # All 5 columns have descriptions
+        result = _CHECKS["column_descriptions"](developing_space)
+        assert result == 1.0
+
+    def test_column_descriptions_empty(self, nascent_space):
+        # 1 column, no description
+        result = _CHECKS["column_descriptions"](nascent_space)
+        assert result == 0.0
+
+    def test_joins_defined(self, developing_space):
+        assert _CHECKS["joins_defined"](developing_space) is True
+
+    def test_joins_not_defined(self, nascent_space):
+        assert _CHECKS["joins_defined"](nascent_space) is False
+
+    def test_sample_questions(self, developing_space):
+        assert _CHECKS["sample_questions"](developing_space) == 3.0
+
+    def test_filter_snippets(self, developing_space):
+        assert _CHECKS["filter_snippets"](developing_space) is True
+
+    def test_unity_catalog(self, developing_space):
+        assert _CHECKS["unity_catalog"](developing_space) is True
+
+    def test_unity_catalog_no_tables(self, empty_space):
+        assert _CHECKS["unity_catalog"](empty_space) is False
+
+    def test_benchmark_questions_none(self, developing_space):
+        assert _CHECKS["benchmark_questions"](developing_space) == 0.0
+
+    def test_benchmark_questions(self, optimized_space):
+        assert _CHECKS["benchmark_questions"](optimized_space) == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Integration: calculate_score with default config
+# ---------------------------------------------------------------------------
+
+class TestCalculateScore:
+    def test_empty_space_scores_zero(self, empty_space, default_config):
+        result = calculate_score(empty_space, default_config)
+        assert result["score"] == 0
+        assert result["maturity"] == "Nascent"
+        assert len(result["findings"]) > 0
+
+    def test_nascent_space(self, nascent_space, default_config):
+        result = calculate_score(nascent_space, default_config)
+        # Should get tables_attached (10) + table_count (2 for 1 table) + columns_exist (5) = 17
+        assert result["score"] > 0
+        assert result["score"] < 30
+        assert result["maturity"] == "Nascent"
+
+    def test_developing_space(self, developing_space, default_config):
+        result = calculate_score(developing_space, default_config)
+        assert result["score"] >= 50
+        assert result["maturity"] in ("Developing", "Proficient")
+
+    def test_optimized_space(self, optimized_space, default_config):
+        result = calculate_score(optimized_space, default_config)
+        assert result["score"] >= 85
+        assert result["maturity"] == "Optimized"
+
+    def test_score_capped_at_100(self, optimized_space, default_config):
+        result = calculate_score(optimized_space, default_config)
+        assert result["score"] <= 100
+
+    def test_result_structure(self, nascent_space, default_config):
+        result = calculate_score(nascent_space, default_config)
+        assert "score" in result
+        assert "maturity" in result
+        assert "breakdown" in result
+        assert "criteria_results" in result
+        assert "findings" in result
+        assert "next_steps" in result
+        assert "scanned_at" in result
+
+    def test_breakdown_has_all_stages(self, nascent_space, default_config):
+        result = calculate_score(nascent_space, default_config)
+        for key in ("nascent", "basic", "developing", "proficient", "optimized"):
+            assert key in result["breakdown"]
+
+    def test_criteria_results_match_enabled(self, nascent_space, default_config):
+        """Each enabled criterion should produce a result."""
+        result = calculate_score(nascent_space, default_config)
+        enabled_ids = {c["id"] for c in default_config["criteria"] if c.get("enabled", True)}
+        result_ids = {r["id"] for r in result["criteria_results"]}
+        assert result_ids == enabled_ids
+
+    def test_disabled_criterion_excluded(self, nascent_space, default_config):
+        """Disabling a criterion should exclude it from results."""
+        config = default_config.copy()
+        config["criteria"] = [
+            {**c, "enabled": False} if c["id"] == "tables_attached" else c
+            for c in config["criteria"]
+        ]
+        result = calculate_score(nascent_space, config)
+        result_ids = {r["id"] for r in result["criteria_results"]}
+        assert "tables_attached" not in result_ids
+
+    def test_adjusted_points(self, nascent_space, default_config):
+        """Changing a criterion's points should affect the score."""
+        normal = calculate_score(nascent_space, default_config)
+
+        boosted_config = default_config.copy()
+        boosted_config["criteria"] = [
+            {**c, "points": 50} if c["id"] == "tables_attached" else c
+            for c in boosted_config["criteria"]
+        ]
+        boosted = calculate_score(nascent_space, boosted_config)
+        assert boosted["score"] > normal["score"]


### PR DESCRIPTION
# RFC: Configurable Maturity Scoring System

**Status:** Draft — requesting feedback  
**Author:** Stuart Gano  
**Branch:** `configurable-maturity-scoring`

---

## Problem

The maturity scoring logic is hardcoded in `scanner.py` and `score_all_spaces.py`. If an admin wants to adjust scoring weights, disable a criterion, or change stage thresholds, it requires a code change and redeployment. Different workspaces may have different priorities (e.g., some care more about Unity Catalog compliance, others about SQL coverage).

## Proposal

Make the maturity scoring system **fully configurable by workspace admins** through:

1. **YAML default config** (`maturity_config_default.yaml`) — ships with the app, defines the 5-stage model with 16 criteria, point weights, and stage thresholds
2. **Lakebase admin overrides** — partial overrides stored in Lakebase, merged at scoring time
3. **Admin UI** — new "Scoring Config" tab in Admin Dashboard for editing without touching code
4. **Registered check functions** — Python functions keyed by criterion ID, decoupled from config

### Architecture

```
maturity_config_default.yaml    ← Source of truth (shipped)
        │
        ▼
  get_default_config()          ← Loads YAML once, deep copies
        │
        ├──► merge_config()     ← Merges with Lakebase overrides
        │         │
        ▼         ▼
  get_active_config()           ← Returns merged config
        │
        ▼
  calculate_score(space, config) ← Iterates criteria, runs _CHECKS[id]
        │
        ▼
  { score, maturity, breakdown, criteria_results, findings, next_steps }
```

### Merge Strategy

- **Stages**: Replaced wholesale if overridden (they're a coherent set)
- **Criteria**: Merged by `id` — override fields win, unmentioned fields preserved, new IDs appended
- **Empty overrides** = use defaults (reset path)

### What Admins Can Configure

| Setting | How | Example |
|---------|-----|---------|
| Point weights | Change `points` per criterion | `tables_attached: 10 → 15` |
| Enable/disable | Toggle `enabled` flag | Disable `sql_functions` |
| Stage thresholds | Change `range` bounds | Basic starts at 25 instead of 30 |
| Custom criteria | Add new criterion ID | Requires matching `@_register` in code |

### Security

Check functions are **registered Python functions**, not eval'd expressions. The YAML config only contains metadata (IDs, points, descriptions). Adding a new custom criterion ID requires a corresponding `@_register("id")` decorator in `scanner.py` — there's no arbitrary code execution path.

## Changes

### Backend
| File | Change |
|------|--------|
| `maturity_config_default.yaml` | **New** — 5 stages, 16 criteria with weights/types/descriptions |
| `services/maturity_config.py` | **New** — Config loader, merge logic, Lakebase persistence |
| `services/scanner.py` | **Rewritten** — Config-driven engine with `@_register` check functions |
| `models.py` | Added `CriterionResult`, updated `ScoreBreakdown` to 5-stage keys |
| `routers/admin.py` | Added `GET/PUT /maturity-config`, `POST /maturity-config/reset` |

### Frontend
| File | Change |
|------|--------|
| `MaturityConfigEditor.tsx` | **New** — Full config editor with stage thresholds, criteria table, save/reset |
| `AdminDashboard.tsx` | Added tab navigation (Overview / Scoring Config) |
| `IQScoreTab.tsx` | Updated breakdown bars to 5-stage model |
| `types/index.ts` | Added `MaturityConfig`, `MaturityConfigStage`, `MaturityConfigCriterion` |
| `lib/api.ts` | Added `getMaturityConfig`, `updateMaturityConfig`, `resetMaturityConfig` |

### Other
| File | Change |
|------|--------|
| `jobs/score_all_spaces.py` | **New** — Standalone batch scoring notebook |
| `docs/genie-space-maturity.md` | **New** — Documents stages, criteria, admin API |
| `tests/test_maturity_scoring.py` | **New** — 41 tests: scoring engine, checks, integration |
| `tests/test_maturity_config.py` | **New** — 19 tests: YAML integrity, merge logic |

## Open Questions

1. **Stage threshold validation** — Currently the UI lets you set non-contiguous ranges (e.g., Nascent 0-25, Basic 30-49 leaving a gap). Should we enforce contiguous ranges in the UI, the API, or both?

2. **Custom criteria workflow** — An admin can add a new criterion ID in the UI, but it won't score anything until a `@_register` function is added in code. Should we surface a warning for unregistered criterion IDs? Or is this an acceptable admin-only footgun?

3. **Score history after config change** — If an admin changes weights, historical scores become stale. Should we re-score all spaces on config change? Add a "config version" to scan results? Or just let the next scan pick up the new config?

4. **Batch job config** — `score_all_spaces.py` currently has its own inline scoring logic (mirrors scanner.py). Should it import from the app's scanner instead, or stay self-contained for notebook portability?

## Test Plan

- [x] `uv run pytest tests/test_maturity_scoring.py tests/test_maturity_config.py` — 60/60 passing
- [x] `npm run build` — frontend compiles clean
- [ ] Manual: Admin Dashboard → Scoring Config tab loads config
- [ ] Manual: Adjust criterion points → Save → re-scan → score reflects change
- [ ] Manual: Reset Defaults → config returns to original
- [ ] Manual: Disable a criterion → re-scan → criterion excluded from results