### PR TITLE
feat: Genie Space quality skill (AI Dev Kit Track 1)

### DIFF
--- a/docs/rfc-ai-dev-kit-integration.md
+++ b/docs/rfc-ai-dev-kit-integration.md
@@ -1,0 +1,184 @@
+# RFC: AI Dev Kit Integration
+
+**Status:** Draft — requesting feedback
+**Author:** Stuart Gano
+**Date:** 2026-03-13
+
+---
+
+## Context
+
+[AI Dev Kit](https://github.com/databricks-solutions/ai-dev-kit) (`databricks-solutions/ai-dev-kit`) is the Field Engineering toolkit for coding agents. It provides:
+
+- **`databricks-tools-core`** — Python library with high-level Databricks functions (SQL, Unity Catalog, Jobs, Genie, etc.)
+- **`databricks-mcp-server`** — 80+ MCP tools wrapping `databricks-tools-core` for Claude Code, Cursor, etc.
+- **`databricks-skills`** — Markdown skills teaching coding agents Databricks patterns
+- **Agent Bricks** — Patterns for building Knowledge Assistants, Genie Spaces, and Multi-Agent Supervisors
+
+Genie Workbench is a deployed Databricks App for scoring, analyzing, and optimizing Genie Spaces. It has its own hand-rolled implementations of Databricks API calls (Genie, UC, SQL) and its own LLM-driven agents (create, fix, analyze).
+
+**The gap:** These two projects serve overlapping audiences with duplicated implementations and no cross-pollination. A coding agent using ai-dev-kit can create a Genie Space but has no way to score or optimize it. The Workbench app hand-rolls SDK calls that `databricks-tools-core` already provides.
+
+---
+
+## Proposal
+
+Three integration tracks, from lowest to highest effort:
+
+### Track 1: Genie Space Quality Skill for AI Dev Kit
+
+**Effort:** Low (markdown + examples, no code changes to Workbench)
+**Value:** High — makes maturity knowledge available to all ai-dev-kit users
+
+Add a skill to `ai-dev-kit/.claude/skills/` that teaches coding agents how to assess and improve Genie Space quality. This skill would encode the maturity curve knowledge, scoring criteria, and optimization patterns that currently live only in the Workbench app.
+
+#### Skill content
+
+```
+ai-dev-kit/.claude/skills/databricks-genie-quality/
+  SKILL.md              # Main skill: when to use, maturity model, scoring criteria
+  optimization.md       # Deep dive: common findings and how to fix them
+  examples/
+    score-space.py      # Example: score a space using the Genie API
+    add-instructions.py # Example: programmatically add instructions
+    add-joins.py        # Example: add join specifications
+```
+
+#### What the skill teaches
+
+1. **Maturity model** — The 5-stage model (Nascent → Optimized) with scoring criteria
+2. **Assessment patterns** — How to fetch a serialized space and evaluate it against criteria
+3. **Optimization patterns** — Common findings and programmatic fixes:
+   - Missing table/column descriptions → pull from UC comments
+   - No join specs → infer from foreign keys
+   - Missing instructions → generate from table schemas
+   - No sample questions → generate from common query patterns
+4. **Genie API gotchas** — `serialized_space` retrieval (empty PATCH), table sorting requirement, `table_identifiers` being silently ignored
+
+#### What this enables
+
+A developer using Claude Code + ai-dev-kit could say:
+- "Score my Genie Space `sales_analytics` and tell me what to improve"
+- "Add column descriptions to all tables in my space from UC metadata"
+- "Generate sample SQL questions for my Genie Space"
+
+Without needing to deploy the Workbench app.
+
+---
+
+### Track 2: Replace Hand-Rolled SDK Calls with `databricks-tools-core`
+
+**Effort:** Medium (refactor backend services)
+**Value:** Medium — reduces maintenance burden, stays in sync with SDK improvements
+
+The Workbench backend has several services that duplicate what `databricks-tools-core` already provides:
+
+| Workbench service | What it does | `databricks-tools-core` equivalent |
+|---|---|---|
+| `genie_client.py` → `list_genie_spaces()` | Lists all Genie Spaces | `find_genie_by_name()` + list variant |
+| `genie_client.py` → `get_serialized_space()` | Fetches space config via empty PATCH | Genie tools (if available) |
+| `uc_client.py` → `list_catalogs/schemas/tables()` | UC browsing for create wizard | UC tools in `databricks-tools-core` |
+| `create_agent_tools.py` → `execute_sql()` | SQL execution for validation | `execute_sql()` |
+| `genie_client.py` → `query_genie()` | Sends questions to Genie | Genie query tools |
+
+#### Approach
+
+1. **Add `databricks-tools-core` as a dependency** to `pyproject.toml`
+2. **Audit overlap** — Map each Workbench SDK call to its `databricks-tools-core` equivalent
+3. **Replace incrementally** — Start with UC browsing and SQL execution (lowest risk), then move to Genie API calls
+4. **Keep Workbench-specific logic** — The scoring engine, LLM analysis, and config merge logic are unique to Workbench and don't belong in the shared library
+
+#### What NOT to replace
+
+- `scanner.py` — Scoring logic is Workbench-specific
+- `analyzer.py` / `optimizer.py` — LLM-driven analysis is Workbench-specific
+- `maturity_config.py` — Config management is Workbench-specific
+- `lakebase.py` — Persistence layer is Workbench-specific
+
+#### Open questions
+
+- Does `databricks-tools-core` handle OBO auth (ContextVar-based)? The Workbench uses `x-forwarded-access-token` from Databricks Apps. If the library only supports SP or PAT auth, we'd need to wrap it or contribute OBO support upstream.
+- Does the library expose `serialized_space` retrieval? This is the non-obvious empty-PATCH trick that the Workbench relies on heavily. If not, this stays hand-rolled or we contribute it.
+- Version pinning — How stable is `databricks-tools-core`? Is it safe to depend on in a deployed app, or is it still iterating fast?
+
+---
+
+### Track 3: Workbench MCP Server
+
+**Effort:** Medium-High (new API surface, deployment considerations)
+**Value:** High — makes Workbench capabilities available to any MCP client
+
+Expose Workbench-specific capabilities as MCP tools that coding agents can call. This is different from ai-dev-kit's MCP server which wraps raw Databricks APIs — the Workbench MCP server would expose higher-level operations.
+
+#### Proposed tools
+
+| Tool | Description | Input | Output |
+|---|---|---|---|
+| `scan_genie_space` | Score a space against the maturity model | `{space_id}` | Score, maturity stage, findings, next steps |
+| `get_maturity_config` | Get active scoring configuration | — | Config with stages, criteria, weights |
+| `get_space_history` | Get score history for a space | `{space_id, days?}` | Array of score data points |
+| `get_org_health` | Get org-wide space health stats | — | Avg score, distribution, critical count |
+| `analyze_space` | Run deep LLM analysis on a space | `{space_id}` | Section analyses, synthesis, recommendations |
+| `suggest_fixes` | Get specific fix suggestions for findings | `{space_id, findings}` | Actionable patches/instructions |
+
+#### Architecture options
+
+**Option A: Standalone MCP server (recommended for now)**
+- Runs as a separate process, talks to the Workbench API over HTTP
+- Easy to register in `.mcp.json` alongside ai-dev-kit's MCP server
+- Doesn't require Workbench internals — just calls the REST API
+- Works for any MCP client (Claude Code, Cursor, etc.)
+
+```
+Coding Agent → MCP Client → Workbench MCP Server → Workbench REST API → Databricks
+```
+
+**Option B: Contribute tools to ai-dev-kit's MCP server**
+- Add Workbench tools alongside existing Databricks tools
+- Requires the Workbench app to be deployed (tools call its API)
+- Tighter coupling but single MCP config for users
+
+**Option C: Embed MCP in the Workbench app**
+- FastMCP mounted directly in the FastAPI app (streamable HTTP transport)
+- No separate process, but only works when the app is running
+- This was the direction of the earlier `mcp_server.py` prototype
+
+#### Open questions
+
+- **Auth flow** — MCP tools running in Claude Code on a developer's laptop need to reach the deployed Workbench app. How does auth work? Service principal? User token forwarding?
+- **Latency** — `analyze_space` and `suggest_fixes` involve LLM calls (30-60s). MCP tools typically expect fast responses. Do we need async patterns or progress callbacks?
+- **Scope** — Should the MCP server also expose the create-space agent, or keep it UI-only?
+
+---
+
+## Sequencing
+
+```
+Track 1 (Skill)         ████░░░░░░  ← Start here, ships independently to ai-dev-kit
+Track 2 (tools-core)    ░░████░░░░  ← Refactor after skill validates the integration story
+Track 3 (MCP Server)    ░░░░░░████  ← Build after Tracks 1-2 establish patterns
+```
+
+**Track 1** can start immediately and doesn't require any code changes to the Workbench. It's a PR to `ai-dev-kit`, not this repo. The skill content comes directly from `docs/genie-space-maturity.md` and the patterns in `scanner.py`.
+
+**Track 2** requires auditing `databricks-tools-core`'s API surface and auth model. Could start in parallel with Track 1 if someone wants to spike on the OBO auth question.
+
+**Track 3** depends on having a stable Workbench API and a clear auth story. The `mcp_server.py` prototype exists but needs the auth and deployment model figured out first.
+
+---
+
+## Decision needed
+
+1. **Do we start with Track 1?** It's low-cost and tests the integration story without coupling the codebases.
+2. **Who owns the ai-dev-kit PR?** The skill content exists in this repo — do we author the PR here and open it against ai-dev-kit?
+3. **Track 2 auth question** — Can someone with `databricks-tools-core` context confirm whether OBO auth is supported?
+
+---
+
+## References
+
+- [AI Dev Kit repo](https://github.com/databricks-solutions/ai-dev-kit)
+- [databricks-tools-core](https://github.com/databricks-solutions/ai-dev-kit/tree/main/databricks-tools-core)
+- [AI Dev Kit skills](https://github.com/databricks-solutions/ai-dev-kit/tree/main/databricks-skills)
+- [Genie Space Maturity Curve](docs/genie-space-maturity.md) (this repo)
+- [Configurable Scoring RFC](https://github.com/databricks-solutions/databricks-genie-workbench/pull/18) (PR #18)

--- a/skills/databricks-genie-quality/SKILL.md
+++ b/skills/databricks-genie-quality/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: databricks-genie-quality
+description: "Assess and optimize Databricks Genie Space quality using a 5-stage maturity model. Use when scoring a Genie Space, identifying missing configuration, adding instructions/joins/descriptions, or improving Genie answer accuracy."
+---
+
+# Genie Space Quality Assessment
+
+Score, analyze, and optimize Genie Spaces using a structured maturity model. Complements the `databricks-genie` skill (which covers creation and querying) by adding quality assessment and optimization.
+
+## When to Use This Skill
+
+Use this skill when:
+- Scoring a Genie Space to understand its quality level
+- Identifying what's missing or misconfigured in a space
+- Adding instructions, join specs, column descriptions, or sample questions
+- Improving Genie answer accuracy for an existing space
+- Auditing multiple spaces across a workspace
+
+**Prerequisites:** The `databricks-genie` skill and its MCP tools (`get_genie`, `create_or_update_genie`, `ask_genie`, etc.) should be available for executing changes.
+
+## The Maturity Model
+
+Every Genie Space progresses through 5 stages. The score shows where a space is on the journey — not how well someone did.
+
+| Stage | Score | Key Question | What It Means |
+|-------|-------|-------------|---------------|
+| **Nascent** | 0–29 | Can Genie see my data? | Tables attached but minimal config. Answers are unpredictable. |
+| **Basic** | 30–49 | Does Genie understand my domain? | Some instructions and descriptions. Starting to understand context. |
+| **Developing** | 50–69 | Does Genie speak my language? | Instructions, sample questions, joins. Understands the domain. |
+| **Proficient** | 70–84 | Are answers consistent? | Trusted SQL, expressions. Reliable, metrics-accurate answers. |
+| **Optimized** | 85–100 | Is it ready for everyone? | Full SQL coverage, benchmarks, feedback loops. Production-grade. |
+
+## Scoring Criteria
+
+### Nascent (25 points possible)
+
+| Criterion | Type | Points | What to Check |
+|-----------|------|--------|---------------|
+| `tables_attached` | boolean | 10 | `data_sources.tables` has at least one entry |
+| `table_count` | scale | 0–10 | Number of tables (target: 5, max credit at 10) |
+| `columns_exist` | boolean | 5 | At least one table has columns defined |
+
+### Basic (15 points possible)
+
+| Criterion | Type | Points | What to Check |
+|-----------|------|--------|---------------|
+| `instructions_defined` | boolean | 5 | `instructions.text_instructions` is non-empty |
+| `table_descriptions` | boolean | 5 | At least one table has a description/comment |
+| `column_descriptions` | scale | 0–5 | Proportion of columns with descriptions (target: 80%) |
+
+### Developing (20 points possible)
+
+| Criterion | Type | Points | What to Check |
+|-----------|------|--------|---------------|
+| `instruction_quality` | scale | 0–5 | Instructions with meaningful content (>50 chars, target: 2) |
+| `sample_questions` | scale | 0–5 | Example SQL questions (target: 5) |
+| `joins_defined` | boolean | 5 | `instructions.join_specs` is non-empty |
+| `filter_snippets` | boolean | 5 | `instructions.sql_snippets.filters` is non-empty |
+
+### Proficient (22 points possible)
+
+| Criterion | Type | Points | What to Check |
+|-----------|------|--------|---------------|
+| `trusted_sql_queries` | scale | 0–10 | Example SQL queries (target: 10) |
+| `expressions_defined` | scale | 0–5 | SQL expressions + measures (target: 3) |
+| `unity_catalog` | boolean | 7 | All tables use 3-part names (`catalog.schema.table`) |
+
+### Optimized (18 points possible)
+
+| Criterion | Type | Points | What to Check |
+|-----------|------|--------|---------------|
+| `benchmark_questions` | scale | 0–8 | Benchmark questions for accuracy tracking (target: 10) |
+| `sql_coverage` | scale | 0–5 | Breadth of SQL examples (target: 15) |
+| `sql_functions` | boolean | 5 | Custom SQL functions defined |
+
+**Scale scoring:** `points = max_points × min(value / target, 1.0)`
+
+## Assessment Workflow
+
+### Step 1: Retrieve the Serialized Space
+
+The full space configuration lives in `serialized_space`, which is **not returned by GET**. Use an empty PATCH to retrieve it:
+
+```python
+import json, requests
+
+host = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().get()
+token = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiToken().get()
+
+# Empty PATCH returns the full serialized_space
+resp = requests.patch(
+    f"{host}/api/2.0/genie/spaces/{space_id}",
+    headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    json={}
+)
+space = resp.json()
+space_data = json.loads(space["serialized_space"])
+```
+
+Or with MCP tools: `get_genie(space_id=space_id)` — though this may not include `serialized_space` depending on the tool version.
+
+### Step 2: Evaluate Against Criteria
+
+Walk through each criterion and tally points. See [examples/score-space.py](examples/score-space.py) for a complete implementation.
+
+Key paths in `space_data`:
+- **Tables:** `data_sources.tables[]` — each has `identifier`, `columns[]`, `description`
+- **Instructions:** `instructions.text_instructions[]` — each has `content` (string or list)
+- **Sample questions:** `instructions.example_question_sqls[]`
+- **Joins:** `instructions.join_specs[]`
+- **Filters:** `instructions.sql_snippets.filters[]`
+- **Expressions:** `instructions.sql_snippets.expressions[]`
+- **Measures:** `instructions.sql_snippets.measures[]`
+- **SQL functions:** `instructions.sql_functions[]`
+- **Benchmarks:** `benchmarks.questions[]`
+
+### Step 3: Identify Gaps and Optimize
+
+Based on the score, prioritize fixes by stage (fix Nascent/Basic gaps before Developing/Proficient). See [optimization.md](optimization.md) for detailed patterns.
+
+## Quick Start: Score and Fix
+
+```
+User: "Score my Genie Space sales_analytics and tell me what to improve"
+
+Agent workflow:
+1. List spaces → find space_id for "sales_analytics"
+2. Empty PATCH → get serialized_space
+3. Evaluate 16 criteria → calculate score
+4. Report: "Score: 42/100 (Basic). Missing: join specs, sample questions,
+   column descriptions. Next: add join specs for your 3 tables."
+5. Offer to fix: "Want me to add join specs based on your table schemas?"
+```
+
+## Genie API Gotchas
+
+| Gotcha | Details |
+|--------|---------|
+| **`serialized_space` not in GET** | Must use an empty PATCH (`json={}`) to retrieve it |
+| **`table_identifiers` silently ignored** | PATCH body `table_identifiers` field is a no-op — modify tables via `serialized_space` |
+| **Tables must be sorted** | `data_sources.tables` must be sorted alphabetically by `identifier` or the API returns `INVALID_PARAMETER_VALUE` |
+| **Nested JSON escaping** | `serialized_space` is a JSON string inside JSON — use `curl` for PATCH updates (Databricks CLI has escaping issues with `--json`) |
+| **Instructions content format** | `text_instructions[].content` can be a string or list of strings — handle both |
+
+## Reference Files
+
+- [optimization.md](optimization.md) — Common findings and programmatic fixes
+- [examples/score-space.py](examples/score-space.py) — Score a space against the maturity model
+- [examples/add-instructions.py](examples/add-instructions.py) — Programmatically add instructions
+- [examples/add-joins.py](examples/add-joins.py) — Add join specifications from table schemas
+
+## Relationship to Other Skills
+
+| Skill | Role |
+|-------|------|
+| `databricks-genie` | Create spaces, ask questions (CRUD + query) |
+| **`databricks-genie-quality`** | Score spaces, identify gaps, optimize configuration |
+| `databricks-unity-catalog` | Browse catalogs/schemas/tables for metadata enrichment |

--- a/skills/databricks-genie-quality/examples/add-instructions.py
+++ b/skills/databricks-genie-quality/examples/add-instructions.py
@@ -1,0 +1,164 @@
+"""Add text instructions to a Genie Space from table metadata.
+
+Generates context-rich instructions by inspecting Unity Catalog table schemas
+and applying them to the space's serialized_space config.
+
+Usage:
+    python add-instructions.py <space_id>
+
+Requires: databricks-sdk, requests
+"""
+
+import json
+import sys
+import uuid
+
+import requests
+from databricks.sdk import WorkspaceClient
+
+
+def get_serialized_space(host: str, token: str, space_id: str) -> dict:
+    """Retrieve full space config via empty PATCH."""
+    resp = requests.patch(
+        f"{host}/api/2.0/genie/spaces/{space_id}",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json={},
+    )
+    resp.raise_for_status()
+    return json.loads(resp.json()["serialized_space"])
+
+
+def update_serialized_space(host: str, token: str, space_id: str, space_data: dict) -> None:
+    """Write updated space config back via PATCH. Tables must be sorted."""
+    space_data["data_sources"]["tables"] = sorted(
+        space_data["data_sources"]["tables"],
+        key=lambda t: t["identifier"],
+    )
+    resp = requests.patch(
+        f"{host}/api/2.0/genie/spaces/{space_id}",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json={"serialized_space": json.dumps(space_data)},
+    )
+    resp.raise_for_status()
+    print(f"Space {space_id} updated successfully.")
+
+
+def build_instructions_from_tables(w: WorkspaceClient, tables: list[dict]) -> str:
+    """Generate instruction text from Unity Catalog table metadata."""
+    lines = ["This space contains the following tables:\n\n"]
+
+    for table_entry in tables:
+        identifier = table_entry.get("identifier", "")
+        parts = identifier.split(".")
+        if len(parts) != 3:
+            lines.append(f"- {identifier}\n")
+            continue
+
+        catalog, schema, table_name = parts
+        lines.append(f"### {table_name}\n")
+
+        try:
+            uc_table = w.tables.get(f"{catalog}.{schema}.{table_name}")
+            if uc_table.comment:
+                lines.append(f"{uc_table.comment}\n\n")
+
+            # List key columns with descriptions
+            if uc_table.columns:
+                described = [c for c in uc_table.columns if c.comment]
+                if described:
+                    lines.append("Key columns:\n")
+                    for col in described[:10]:  # Cap at 10 to keep instructions readable
+                        lines.append(f"- **{col.name}**: {col.comment}\n")
+                    lines.append("\n")
+        except Exception as e:
+            lines.append(f"(Could not fetch metadata: {e})\n\n")
+
+    return "".join(lines)
+
+
+def apply_column_descriptions(w: WorkspaceClient, space_data: dict) -> int:
+    """Pull column descriptions from UC and apply to space config. Returns count added."""
+    count = 0
+    for table_entry in space_data.get("data_sources", {}).get("tables", []):
+        parts = table_entry.get("identifier", "").split(".")
+        if len(parts) != 3:
+            continue
+
+        catalog, schema, table_name = parts
+        try:
+            uc_table = w.tables.get(f"{catalog}.{schema}.{table_name}")
+            uc_col_map = {c.name: c.comment for c in (uc_table.columns or []) if c.comment}
+
+            for col in table_entry.get("columns", []):
+                if not col.get("description") and col.get("name") in uc_col_map:
+                    col["description"] = uc_col_map[col["name"]]
+                    count += 1
+        except Exception:
+            pass
+
+    return count
+
+
+def apply_table_descriptions(w: WorkspaceClient, space_data: dict) -> int:
+    """Pull table descriptions from UC and apply to space config. Returns count added."""
+    count = 0
+    for table_entry in space_data.get("data_sources", {}).get("tables", []):
+        if table_entry.get("description"):
+            continue
+
+        parts = table_entry.get("identifier", "").split(".")
+        if len(parts) != 3:
+            continue
+
+        catalog, schema, table_name = parts
+        try:
+            uc_table = w.tables.get(f"{catalog}.{schema}.{table_name}")
+            if uc_table.comment:
+                table_entry["description"] = uc_table.comment
+                count += 1
+        except Exception:
+            pass
+
+    return count
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python add-instructions.py <space_id>")
+        sys.exit(1)
+
+    import os
+
+    space_id = sys.argv[1]
+    host = os.environ.get("DATABRICKS_HOST", "").rstrip("/")
+    token = os.environ.get("DATABRICKS_TOKEN", "")
+
+    if not host or not token:
+        print("Error: Set DATABRICKS_HOST and DATABRICKS_TOKEN environment variables.")
+        sys.exit(1)
+
+    w = WorkspaceClient()
+    space_data = get_serialized_space(host, token, space_id)
+
+    tables = space_data.get("data_sources", {}).get("tables", [])
+    print(f"Space has {len(tables)} tables.")
+
+    # 1. Generate and add text instructions
+    instruction_text = build_instructions_from_tables(w, tables)
+    instruction = {
+        "id": str(uuid.uuid4()),
+        "content": instruction_text.split("\n"),
+    }
+    space_data.setdefault("instructions", {}).setdefault("text_instructions", []).append(instruction)
+    print(f"Added text instruction ({len(instruction_text)} chars).")
+
+    # 2. Pull table descriptions from UC
+    table_desc_count = apply_table_descriptions(w, space_data)
+    print(f"Added {table_desc_count} table descriptions from UC.")
+
+    # 3. Pull column descriptions from UC
+    col_desc_count = apply_column_descriptions(w, space_data)
+    print(f"Added {col_desc_count} column descriptions from UC.")
+
+    # 4. Write back
+    update_serialized_space(host, token, space_id, space_data)

--- a/skills/databricks-genie-quality/examples/add-joins.py
+++ b/skills/databricks-genie-quality/examples/add-joins.py
@@ -1,0 +1,188 @@
+"""Add join specifications to a Genie Space by inferring relationships.
+
+Inspects Unity Catalog table schemas to find foreign key relationships
+and common column naming patterns (_id suffixes, shared column names),
+then adds join_specs to the space config.
+
+Usage:
+    python add-joins.py <space_id>
+
+Requires: databricks-sdk, requests
+"""
+
+import json
+import sys
+from itertools import combinations
+
+import requests
+from databricks.sdk import WorkspaceClient
+
+
+def get_serialized_space(host: str, token: str, space_id: str) -> dict:
+    """Retrieve full space config via empty PATCH."""
+    resp = requests.patch(
+        f"{host}/api/2.0/genie/spaces/{space_id}",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json={},
+    )
+    resp.raise_for_status()
+    return json.loads(resp.json()["serialized_space"])
+
+
+def update_serialized_space(host: str, token: str, space_id: str, space_data: dict) -> None:
+    """Write updated space config back via PATCH. Tables must be sorted."""
+    space_data["data_sources"]["tables"] = sorted(
+        space_data["data_sources"]["tables"],
+        key=lambda t: t["identifier"],
+    )
+    resp = requests.patch(
+        f"{host}/api/2.0/genie/spaces/{space_id}",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json={"serialized_space": json.dumps(space_data)},
+    )
+    resp.raise_for_status()
+    print(f"Space {space_id} updated successfully.")
+
+
+def get_table_columns(w: WorkspaceClient, identifier: str) -> list[str]:
+    """Get column names from Unity Catalog."""
+    parts = identifier.split(".")
+    if len(parts) != 3:
+        return []
+    try:
+        table = w.tables.get(identifier)
+        return [c.name for c in (table.columns or [])]
+    except Exception:
+        return []
+
+
+def infer_joins(
+    w: WorkspaceClient,
+    tables: list[dict],
+) -> list[dict]:
+    """Infer join relationships between tables.
+
+    Strategies:
+    1. Foreign key pattern: table_a has column "table_b_id" and table_b has "id"
+    2. Shared ID columns: both tables have a column like "customer_id"
+    3. Explicit FK constraints from Unity Catalog (if available)
+    """
+    # Build column map: identifier -> set of column names
+    col_map: dict[str, set[str]] = {}
+    for table in tables:
+        ident = table.get("identifier", "")
+        cols = get_table_columns(w, ident)
+        if cols:
+            col_map[ident] = set(cols)
+
+    joins = []
+    seen = set()
+
+    for (id_a, cols_a), (id_b, cols_b) in combinations(col_map.items(), 2):
+        table_name_a = id_a.split(".")[-1]
+        table_name_b = id_b.split(".")[-1]
+
+        # Strategy 1: FK naming pattern (e.g., orders.customer_id -> customers.id)
+        for col in cols_a:
+            if col.endswith("_id"):
+                ref_name = col[:-3]  # "customer_id" -> "customer"
+                # Check if ref matches the other table name (singular or plural)
+                if (ref_name == table_name_b or
+                    ref_name + "s" == table_name_b or
+                    ref_name == table_name_b.rstrip("s")):
+                    if "id" in cols_b:
+                        key = tuple(sorted([id_a, id_b]))
+                        if key not in seen:
+                            seen.add(key)
+                            joins.append({
+                                "left_table": id_a,
+                                "right_table": id_b,
+                                "join_type": "INNER",
+                                "conditions": [{"left_column": col, "right_column": "id"}],
+                            })
+
+        # Check reverse direction
+        for col in cols_b:
+            if col.endswith("_id"):
+                ref_name = col[:-3]
+                if (ref_name == table_name_a or
+                    ref_name + "s" == table_name_a or
+                    ref_name == table_name_a.rstrip("s")):
+                    if "id" in cols_a:
+                        key = tuple(sorted([id_a, id_b]))
+                        if key not in seen:
+                            seen.add(key)
+                            joins.append({
+                                "left_table": id_b,
+                                "right_table": id_a,
+                                "join_type": "INNER",
+                                "conditions": [{"left_column": col, "right_column": "id"}],
+                            })
+
+        # Strategy 2: Shared ID columns (e.g., both have "customer_id")
+        shared_ids = {c for c in cols_a & cols_b if c.endswith("_id")}
+        for shared_col in shared_ids:
+            key = tuple(sorted([id_a, id_b]))
+            if key not in seen:
+                seen.add(key)
+                joins.append({
+                    "left_table": id_a,
+                    "right_table": id_b,
+                    "join_type": "INNER",
+                    "conditions": [{"left_column": shared_col, "right_column": shared_col}],
+                })
+
+    return joins
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python add-joins.py <space_id>")
+        sys.exit(1)
+
+    import os
+
+    space_id = sys.argv[1]
+    host = os.environ.get("DATABRICKS_HOST", "").rstrip("/")
+    token = os.environ.get("DATABRICKS_TOKEN", "")
+
+    if not host or not token:
+        print("Error: Set DATABRICKS_HOST and DATABRICKS_TOKEN environment variables.")
+        sys.exit(1)
+
+    w = WorkspaceClient()
+    space_data = get_serialized_space(host, token, space_id)
+
+    tables = space_data.get("data_sources", {}).get("tables", [])
+    print(f"Space has {len(tables)} tables.")
+
+    if len(tables) < 2:
+        print("Need at least 2 tables to infer joins.")
+        sys.exit(0)
+
+    # Check existing joins
+    existing = space_data.get("instructions", {}).get("join_specs", [])
+    if existing:
+        print(f"Space already has {len(existing)} join specs. Adding new ones only.")
+
+    # Infer joins
+    inferred = infer_joins(w, tables)
+
+    if not inferred:
+        print("No join relationships could be inferred from column patterns.")
+        print("You may need to add join specs manually based on your domain knowledge.")
+        sys.exit(0)
+
+    print(f"\nInferred {len(inferred)} join(s):")
+    for j in inferred:
+        conds = ", ".join(
+            f"{c['left_column']} = {c['right_column']}" for c in j["conditions"]
+        )
+        left_short = j["left_table"].split(".")[-1]
+        right_short = j["right_table"].split(".")[-1]
+        print(f"  {left_short} -> {right_short} ON {conds}")
+
+    # Apply
+    space_data.setdefault("instructions", {})["join_specs"] = existing + inferred
+    update_serialized_space(host, token, space_id, space_data)
+    print(f"\nAdded {len(inferred)} join specs to the space.")

--- a/skills/databricks-genie-quality/examples/score-space.py
+++ b/skills/databricks-genie-quality/examples/score-space.py
@@ -1,0 +1,302 @@
+"""Score a Genie Space against the maturity model.
+
+Usage (Databricks notebook or local with token):
+    python score-space.py <space_id>
+
+Retrieves the serialized space config via empty PATCH, evaluates 16 criteria,
+and prints a score report with maturity stage, breakdown, and next steps.
+"""
+
+import json
+import sys
+
+import requests
+
+
+# --- Configuration ---
+
+CRITERIA = [
+    # Nascent
+    {"id": "tables_attached", "stage": "Nascent", "type": "boolean", "points": 10,
+     "description": "At least one table attached"},
+    {"id": "table_count", "stage": "Nascent", "type": "count", "points": 10,
+     "description": "Number of tables (target: 5)",
+     "scale": {"target": 5, "max": 10}},
+    {"id": "columns_exist", "stage": "Nascent", "type": "boolean", "points": 5,
+     "description": "Tables have columns defined"},
+    # Basic
+    {"id": "instructions_defined", "stage": "Basic", "type": "boolean", "points": 5,
+     "description": "Text instructions are set"},
+    {"id": "table_descriptions", "stage": "Basic", "type": "boolean", "points": 5,
+     "description": "Tables have descriptions"},
+    {"id": "column_descriptions", "stage": "Basic", "type": "count", "points": 5,
+     "description": "Proportion of columns with descriptions (target: 80%)",
+     "scale": {"target": 0.8, "max": 1.0}},
+    # Developing
+    {"id": "instruction_quality", "stage": "Developing", "type": "count", "points": 5,
+     "description": "Instructions with meaningful content (target: 2)",
+     "scale": {"target": 2, "max": 5}},
+    {"id": "sample_questions", "stage": "Developing", "type": "count", "points": 5,
+     "description": "Example SQL questions (target: 5)",
+     "scale": {"target": 5, "max": 10}},
+    {"id": "joins_defined", "stage": "Developing", "type": "boolean", "points": 5,
+     "description": "Join specifications configured"},
+    {"id": "filter_snippets", "stage": "Developing", "type": "boolean", "points": 5,
+     "description": "Filter snippets defined"},
+    # Proficient
+    {"id": "trusted_sql_queries", "stage": "Proficient", "type": "count", "points": 10,
+     "description": "Example SQL queries (target: 10)",
+     "scale": {"target": 10, "max": 20}},
+    {"id": "expressions_defined", "stage": "Proficient", "type": "count", "points": 5,
+     "description": "SQL expressions and measures (target: 3)",
+     "scale": {"target": 3, "max": 10}},
+    {"id": "unity_catalog", "stage": "Proficient", "type": "boolean", "points": 7,
+     "description": "All tables use 3-part UC names"},
+    # Optimized
+    {"id": "benchmark_questions", "stage": "Optimized", "type": "count", "points": 8,
+     "description": "Benchmark questions (target: 10)",
+     "scale": {"target": 10, "max": 20}},
+    {"id": "sql_coverage", "stage": "Optimized", "type": "count", "points": 5,
+     "description": "SQL example breadth (target: 15)",
+     "scale": {"target": 15, "max": 30}},
+    {"id": "sql_functions", "stage": "Optimized", "type": "boolean", "points": 5,
+     "description": "Custom SQL functions defined"},
+]
+
+STAGES = [
+    {"name": "Nascent", "range": [0, 29]},
+    {"name": "Basic", "range": [30, 49]},
+    {"name": "Developing", "range": [50, 69]},
+    {"name": "Proficient", "range": [70, 84]},
+    {"name": "Optimized", "range": [85, 100]},
+]
+
+
+# --- Check functions ---
+
+def check_tables_attached(space: dict) -> bool:
+    return len(space.get("data_sources", {}).get("tables", [])) > 0
+
+
+def check_table_count(space: dict) -> float:
+    return float(len(space.get("data_sources", {}).get("tables", [])))
+
+
+def check_columns_exist(space: dict) -> bool:
+    tables = space.get("data_sources", {}).get("tables", [])
+    return any(len(t.get("columns", [])) > 0 for t in tables)
+
+
+def check_instructions_defined(space: dict) -> bool:
+    return len(space.get("instructions", {}).get("text_instructions", [])) > 0
+
+
+def check_table_descriptions(space: dict) -> bool:
+    tables = space.get("data_sources", {}).get("tables", [])
+    return any(t.get("description") or t.get("comment") for t in tables)
+
+
+def check_column_descriptions(space: dict) -> float:
+    tables = space.get("data_sources", {}).get("tables", [])
+    total, described = 0, 0
+    for t in tables:
+        for col in t.get("columns", []):
+            total += 1
+            if col.get("description") or col.get("comment"):
+                described += 1
+    return described / total if total > 0 else 0.0
+
+
+def check_instruction_quality(space: dict) -> float:
+    texts = space.get("instructions", {}).get("text_instructions", [])
+    count = 0
+    for t in texts:
+        content = t.get("content", "")
+        if isinstance(content, list):
+            content = "".join(content)
+        if len(content) > 50:
+            count += 1
+    return float(count)
+
+
+def check_sample_questions(space: dict) -> float:
+    return float(len(space.get("instructions", {}).get("example_question_sqls", [])))
+
+
+def check_joins_defined(space: dict) -> bool:
+    return len(space.get("instructions", {}).get("join_specs", [])) > 0
+
+
+def check_filter_snippets(space: dict) -> bool:
+    return len(space.get("instructions", {}).get("sql_snippets", {}).get("filters", [])) > 0
+
+
+def check_trusted_sql_queries(space: dict) -> float:
+    return float(len(space.get("instructions", {}).get("example_question_sqls", [])))
+
+
+def check_expressions_defined(space: dict) -> float:
+    snippets = space.get("instructions", {}).get("sql_snippets", {})
+    return float(len(snippets.get("expressions", [])) + len(snippets.get("measures", [])))
+
+
+def check_unity_catalog(space: dict) -> bool:
+    tables = space.get("data_sources", {}).get("tables", [])
+    if not tables:
+        return False
+    return all(len(t.get("identifier", "").split(".")) == 3 for t in tables)
+
+
+def check_benchmark_questions(space: dict) -> float:
+    return float(len(space.get("benchmarks", {}).get("questions", [])))
+
+
+def check_sql_coverage(space: dict) -> float:
+    return float(len(space.get("instructions", {}).get("example_question_sqls", [])))
+
+
+def check_sql_functions(space: dict) -> bool:
+    return len(space.get("instructions", {}).get("sql_functions", [])) > 0
+
+
+CHECKS = {
+    "tables_attached": check_tables_attached,
+    "table_count": check_table_count,
+    "columns_exist": check_columns_exist,
+    "instructions_defined": check_instructions_defined,
+    "table_descriptions": check_table_descriptions,
+    "column_descriptions": check_column_descriptions,
+    "instruction_quality": check_instruction_quality,
+    "sample_questions": check_sample_questions,
+    "joins_defined": check_joins_defined,
+    "filter_snippets": check_filter_snippets,
+    "trusted_sql_queries": check_trusted_sql_queries,
+    "expressions_defined": check_expressions_defined,
+    "unity_catalog": check_unity_catalog,
+    "benchmark_questions": check_benchmark_questions,
+    "sql_coverage": check_sql_coverage,
+    "sql_functions": check_sql_functions,
+}
+
+
+# --- Scoring engine ---
+
+def get_maturity_stage(score: int) -> str:
+    for stage in reversed(STAGES):
+        if score >= stage["range"][0]:
+            return stage["name"]
+    return "Nascent"
+
+
+def score_space(space_data: dict) -> dict:
+    """Score a space against the maturity model. Returns score report."""
+    stage_points = {s["name"]: 0 for s in STAGES}
+    findings = []
+    results = []
+
+    for criterion in CRITERIA:
+        cid = criterion["id"]
+        check_fn = CHECKS.get(cid)
+        if not check_fn:
+            continue
+
+        result = check_fn(space_data)
+
+        if criterion["type"] == "boolean":
+            passed = bool(result)
+            points = criterion["points"] if passed else 0
+            if not passed:
+                findings.append(f"Missing: {criterion['description']}")
+        else:
+            raw = float(result)
+            target = criterion.get("scale", {}).get("target", 1)
+            ratio = min(raw / target, 1.0) if target > 0 else (1.0 if raw > 0 else 0.0)
+            points = round(criterion["points"] * ratio)
+            passed = points > 0
+            if ratio < 1.0:
+                findings.append(f"Below target: {criterion['description']} ({raw:.0f}/{target})")
+
+        stage_points[criterion["stage"]] += points
+        results.append({
+            "id": cid, "stage": criterion["stage"],
+            "points": points, "max": criterion["points"],
+            "passed": passed, "description": criterion["description"],
+        })
+
+    total = min(sum(stage_points.values()), 100)
+    maturity = get_maturity_stage(total)
+
+    return {
+        "score": total,
+        "maturity": maturity,
+        "breakdown": stage_points,
+        "criteria": results,
+        "findings": findings,
+    }
+
+
+# --- API helpers ---
+
+def get_serialized_space(host: str, token: str, space_id: str) -> dict:
+    """Retrieve full space config via empty PATCH (GET doesn't return serialized_space)."""
+    resp = requests.patch(
+        f"{host}/api/2.0/genie/spaces/{space_id}",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        json={},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return json.loads(data["serialized_space"])
+
+
+def print_report(report: dict) -> None:
+    """Print a formatted score report."""
+    print(f"\n{'=' * 50}")
+    print(f"  Score: {report['score']}/100  |  Stage: {report['maturity']}")
+    print(f"{'=' * 50}\n")
+
+    print("Breakdown by stage:")
+    for stage_name, points in report["breakdown"].items():
+        max_pts = sum(c["points"] for c in CRITERIA if c["stage"] == stage_name)
+        bar = "█" * (points * 20 // max(max_pts, 1)) + "░" * (20 - points * 20 // max(max_pts, 1))
+        print(f"  {stage_name:<12} {bar} {points}/{max_pts}")
+
+    print(f"\nCriteria ({sum(1 for c in report['criteria'] if c['passed'])}/{len(report['criteria'])} passing):")
+    for c in report["criteria"]:
+        icon = "✓" if c["passed"] else "✗"
+        print(f"  {icon} {c['description']:<50} {c['points']}/{c['max']}")
+
+    if report["findings"]:
+        print(f"\nTop findings:")
+        for i, f in enumerate(report["findings"][:5], 1):
+            print(f"  {i}. {f}")
+
+    print()
+
+
+# --- Main ---
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python score-space.py <space_id>")
+        print("\nSet DATABRICKS_HOST and DATABRICKS_TOKEN environment variables,")
+        print("or run inside a Databricks notebook (uses dbutils automatically).")
+        sys.exit(1)
+
+    space_id = sys.argv[1]
+
+    # Try dbutils first (Databricks notebook), then env vars
+    try:
+        import os
+        host = os.environ.get("DATABRICKS_HOST", "").rstrip("/")
+        token = os.environ.get("DATABRICKS_TOKEN", "")
+        if not host or not token:
+            raise ValueError("Set DATABRICKS_HOST and DATABRICKS_TOKEN")
+    except ValueError:
+        print("Error: Set DATABRICKS_HOST and DATABRICKS_TOKEN environment variables.")
+        sys.exit(1)
+
+    print(f"Scoring space: {space_id}")
+    space_data = get_serialized_space(host, token, space_id)
+    report = score_space(space_data)
+    print_report(report)

--- a/skills/databricks-genie-quality/optimization.md
+++ b/skills/databricks-genie-quality/optimization.md
@@ -1,0 +1,321 @@
+# Genie Space Optimization Patterns
+
+Common findings from scoring, organized by maturity stage, with programmatic fixes.
+
+## Priority Order
+
+Fix gaps **bottom-up by stage**. A space stuck at Nascent won't benefit from Optimized-stage work.
+
+```
+Nascent → Basic → Developing → Proficient → Optimized
+ (fix)    (fix)    (fix)         (fix)        (polish)
+```
+
+---
+
+## Nascent Stage Fixes
+
+### Finding: No tables attached
+
+**Cause:** Space was created without specifying tables, or tables were removed.
+
+**Fix:** Add tables via `serialized_space`. Tables must be sorted alphabetically by `identifier`.
+
+```python
+space_data["data_sources"]["tables"] = sorted(
+    [
+        {"identifier": "catalog.schema.customers"},
+        {"identifier": "catalog.schema.orders"},
+        {"identifier": "catalog.schema.products"},
+    ],
+    key=lambda t: t["identifier"]
+)
+```
+
+### Finding: Tables have no columns
+
+**Cause:** Columns aren't populated automatically — they come from UC metadata or manual definition.
+
+**Fix:** Usually resolves itself after the first query. If columns are still missing, verify the tables exist in Unity Catalog and the warehouse can access them.
+
+---
+
+## Basic Stage Fixes
+
+### Finding: No text instructions
+
+**Cause:** Space was created without guidance for Genie.
+
+**Fix:** Generate instructions from table schemas. Good instructions describe:
+- What the data represents (domain context)
+- Key terminology and abbreviations
+- Date ranges and data freshness
+- Common business rules
+
+```python
+import uuid
+
+instruction = {
+    "id": str(uuid.uuid4()),
+    "content": [
+        "This space contains retail sales data.\n",
+        "Key tables:\n",
+        "- customers: Customer demographics with region and segment\n",
+        "- orders: Transaction history with amounts and dates\n",
+        "- products: Product catalog with categories and pricing\n",
+        "\n",
+        "Business rules:\n",
+        "- 'Active' customers have placed an order in the last 90 days\n",
+        "- Revenue = order total_amount (not including returns)\n",
+        "- Fiscal year starts April 1\n",
+    ]
+}
+
+if "text_instructions" not in space_data.get("instructions", {}):
+    space_data.setdefault("instructions", {})["text_instructions"] = []
+space_data["instructions"]["text_instructions"].append(instruction)
+```
+
+### Finding: Missing table descriptions
+
+**Cause:** Tables lack descriptions in the Genie Space config.
+
+**Fix:** Pull descriptions from Unity Catalog comments and apply to the space config:
+
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+
+for table in space_data["data_sources"]["tables"]:
+    parts = table["identifier"].split(".")
+    if len(parts) == 3:
+        catalog, schema, table_name = parts
+        try:
+            uc_table = w.tables.get(f"{catalog}.{schema}.{table_name}")
+            if uc_table.comment:
+                table["description"] = uc_table.comment
+        except Exception:
+            pass  # Table may not be accessible
+```
+
+### Finding: Missing column descriptions
+
+**Cause:** Columns exist but lack descriptions, reducing Genie's ability to understand the data.
+
+**Fix:** Pull column comments from Unity Catalog:
+
+```python
+for table in space_data["data_sources"]["tables"]:
+    parts = table["identifier"].split(".")
+    if len(parts) != 3:
+        continue
+    catalog, schema, table_name = parts
+    try:
+        uc_table = w.tables.get(f"{catalog}.{schema}.{table_name}")
+        uc_col_map = {c.name: c.comment for c in (uc_table.columns or []) if c.comment}
+        for col in table.get("columns", []):
+            if not col.get("description") and col.get("name") in uc_col_map:
+                col["description"] = uc_col_map[col["name"]]
+    except Exception:
+        pass
+```
+
+---
+
+## Developing Stage Fixes
+
+### Finding: No sample questions
+
+**Cause:** Space has no example SQL questions to guide users and train Genie.
+
+**Fix:** Generate questions from the table schemas. Good sample questions:
+- Cover common use cases (aggregations, filters, joins)
+- Reference actual column and table names
+- Use natural language (not SQL syntax)
+- Include time-based queries if date columns exist
+
+```python
+# Generate from schema inspection
+questions = [
+    {
+        "question": "What were total sales last month?",
+        "sql": "SELECT SUM(total_amount) FROM catalog.schema.orders WHERE order_date >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL 1 MONTH)"
+    },
+    {
+        "question": "Who are our top 10 customers by revenue?",
+        "sql": "SELECT c.name, SUM(o.total_amount) as revenue FROM catalog.schema.customers c JOIN catalog.schema.orders o ON c.id = o.customer_id GROUP BY c.name ORDER BY revenue DESC LIMIT 10"
+    },
+]
+
+space_data.setdefault("instructions", {})["example_question_sqls"] = questions
+```
+
+### Finding: No join specifications
+
+**Cause:** Multi-table spaces don't tell Genie how tables relate.
+
+**Fix:** Infer joins from foreign key relationships or column naming conventions. See [examples/add-joins.py](examples/add-joins.py) for a complete implementation.
+
+```python
+join_spec = {
+    "left_table": "catalog.schema.orders",
+    "right_table": "catalog.schema.customers",
+    "join_type": "INNER",
+    "conditions": [
+        {
+            "left_column": "customer_id",
+            "right_column": "id"
+        }
+    ]
+}
+
+space_data.setdefault("instructions", {})["join_specs"] = [join_spec]
+```
+
+### Finding: No filter snippets
+
+**Cause:** No predefined filters for common business segments.
+
+**Fix:** Add filters for frequently-used dimensions:
+
+```python
+filters = [
+    {
+        "name": "active_customers",
+        "description": "Customers who ordered in the last 90 days",
+        "sql": "order_date >= CURRENT_DATE - INTERVAL 90 DAY"
+    },
+    {
+        "name": "current_quarter",
+        "description": "Current fiscal quarter",
+        "sql": "order_date >= DATE_TRUNC('quarter', CURRENT_DATE)"
+    }
+]
+
+space_data.setdefault("instructions", {}).setdefault("sql_snippets", {})["filters"] = filters
+```
+
+---
+
+## Proficient Stage Fixes
+
+### Finding: Few trusted SQL queries
+
+**Cause:** Not enough example SQL to guide Genie's query generation.
+
+**Fix:** Add more `example_question_sqls` covering diverse patterns:
+- Simple aggregations (COUNT, SUM, AVG)
+- Group-by with filters
+- Multi-table joins
+- Date ranges and window functions
+- CASE expressions
+
+Target: 10+ example queries covering the most common business questions.
+
+### Finding: No SQL expressions or measures
+
+**Cause:** No reusable business metrics defined.
+
+**Fix:** Define expressions for key business metrics:
+
+```python
+expressions = [
+    {
+        "name": "customer_lifetime_value",
+        "description": "Total revenue from a customer across all orders",
+        "sql": "SUM(total_amount)"
+    },
+    {
+        "name": "avg_order_value",
+        "description": "Average order amount",
+        "sql": "AVG(total_amount)"
+    }
+]
+
+space_data.setdefault("instructions", {}).setdefault("sql_snippets", {})["expressions"] = expressions
+```
+
+### Finding: Tables not using Unity Catalog 3-part names
+
+**Cause:** Tables referenced with 2-part names or aliases instead of `catalog.schema.table`.
+
+**Fix:** Update table identifiers to fully-qualified 3-part names:
+
+```python
+for table in space_data["data_sources"]["tables"]:
+    parts = table["identifier"].split(".")
+    if len(parts) == 2:
+        # Assume default catalog
+        table["identifier"] = f"main.{table['identifier']}"
+```
+
+---
+
+## Optimized Stage Fixes
+
+### Finding: No benchmark questions
+
+**Cause:** No questions defined for tracking answer accuracy over time.
+
+**Fix:** Create benchmark questions with known-correct SQL. These serve as regression tests when the space configuration changes.
+
+### Finding: Low SQL coverage
+
+**Cause:** Example SQL queries don't cover enough query patterns.
+
+**Fix:** Audit existing examples and add queries that cover:
+- Different aggregation types
+- Various join patterns
+- Subqueries and CTEs
+- Window functions
+- String and date manipulation
+
+### Finding: No SQL functions
+
+**Cause:** No custom SQL functions for complex business logic.
+
+**Fix:** Define functions for calculations that Genie shouldn't invent:
+
+```python
+sql_functions = [
+    {
+        "name": "fiscal_quarter",
+        "description": "Convert a date to fiscal quarter (FY starts April 1)",
+        "sql": "CASE WHEN MONTH(date_col) >= 4 THEN CONCAT('Q', CEILING((MONTH(date_col) - 3) / 3.0)) ELSE CONCAT('Q', CEILING((MONTH(date_col) + 9) / 3.0)) END"
+    }
+]
+
+space_data.setdefault("instructions", {})["sql_functions"] = sql_functions
+```
+
+---
+
+## Applying Changes
+
+After modifying `space_data`, write it back via PATCH:
+
+```python
+import json, requests
+
+# CRITICAL: Sort tables alphabetically before writing
+space_data["data_sources"]["tables"] = sorted(
+    space_data["data_sources"]["tables"],
+    key=lambda t: t["identifier"]
+)
+
+serialized = json.dumps(space_data)
+
+resp = requests.patch(
+    f"{host}/api/2.0/genie/spaces/{space_id}",
+    headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    json={"serialized_space": serialized}
+)
+
+if resp.status_code != 200:
+    print(f"Error: {resp.status_code} - {resp.text}")
+else:
+    print("Space updated successfully")
+```
+
+**Remember:** Use `curl` or `requests` for the PATCH — the Databricks CLI has issues with nested JSON escaping.


### PR DESCRIPTION
## Summary

- Adds a coding agent skill for scoring and optimizing Genie Spaces using a 5-stage maturity model (Nascent → Optimized) with 16 criteria
- Includes standalone example scripts for scoring spaces, adding instructions from UC metadata, and inferring join specs
- This is **Track 1** from the [AI Dev Kit integration RFC](https://github.com/databricks-solutions/databricks-genie-workbench/pull/20) — makes maturity knowledge available to coding agents without deploying the Workbench app

## What's included

| File | Lines | Purpose |
|------|-------|---------|
| `skills/.../SKILL.md` | 158 | Main skill — maturity model, criteria tables, assessment workflow, API gotchas |
| `skills/.../optimization.md` | 321 | Stage-by-stage optimization patterns with code examples |
| `skills/.../examples/score-space.py` | 302 | Standalone scorer — fetches space via API, evaluates 16 criteria, prints report |
| `skills/.../examples/add-instructions.py` | 164 | Generates instructions from UC table metadata, applies descriptions |
| `skills/.../examples/add-joins.py` | 188 | Infers join specs from FK naming patterns and shared columns |

## What it enables

A developer using Claude Code could say:
- "Score my Genie Space `sales_analytics` and tell me what to improve"
- "Add column descriptions to all tables in my space from UC metadata"
- "Add join specs for my multi-table Genie Space"

Without needing to deploy the Workbench app.

## Test plan

- [ ] Verify SKILL.md renders correctly on GitHub
- [ ] Run `score-space.py` against a real Genie Space
- [ ] Run `add-instructions.py` against a space with UC tables
- [ ] Run `add-joins.py` against a multi-table space
- [ ] Verify skill is picked up by Claude Code when working in this repo

## Note

The same skill content also exists locally on a branch in the ai-dev-kit repo (`feat/genie-quality-skill`), ready to push as a PR when that repo accepts contributions.