### PR TITLE
Add comprehensive documentation, permissions guide, and in-app How It Works page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,19 @@ Python dependencies use `uv sync` on the platform (because `requirements.txt` is
 - All API routes prefixed with `/api`
 - Pydantic models in `backend/models.py`, TypeScript mirrors in `frontend/src/types/index.ts` — keep in sync
 
+## Documentation
+
+Comprehensive documentation lives in the `docs/` folder:
+
+- `docs/00-index.md` — Documentation hub and table of contents
+- `docs/03-authentication-and-permissions.md` — Deep dive on OBO + SP dual auth model
+- `docs/04-create-agent.md` — Create Agent: multi-turn tool-calling flow
+- `docs/07-auto-optimize.md` — GSO optimization pipeline (6-stage DAG)
+- `docs/appendices/A-api-reference.md` — All API endpoints with auth identity
+
+See `docs/00-index.md` for the full listing. When modifying auth, agents, or
+optimization code, consult the relevant doc for design rationale.
+
 ## References
 
 **Before modifying any Genie Space configuration, schema handling, or space creation/optimization code, you MUST `WebFetch` and read the relevant references below.**

--- a/README.md
+++ b/README.md
@@ -14,6 +14,51 @@ Genie Workbench is a unified developer tool for creating, scoring, and optimizin
 
 The app is a FastAPI backend serving a React/Vite frontend, deployed as a [Databricks App](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/). User identity flows via OBO (On-Behalf-Of) auth so each user operates under their own Databricks permissions. Score history and session state are persisted in Lakebase (PostgreSQL).
 
+## Permissions & Authentication Model
+
+Genie Workbench uses a **dual-identity model**: the signed-in user's token for interactive operations and the app's Service Principal for background jobs. This section summarizes how each identity is used and why.
+
+> For a full deep dive with code references, sequence diagrams, and GRANT statements, see [docs/03-authentication-and-permissions.md](docs/03-authentication-and-permissions.md).
+
+### OBO (On-Behalf-Of) Auth
+
+All interactive API calls use the signed-in user's identity. The Databricks Apps platform forwards the user's access token via the `x-forwarded-access-token` header. Middleware in `backend/main.py` stores a per-request `WorkspaceClient` in a Python `ContextVar`, so every downstream service call — browsing Unity Catalog, listing Genie Spaces, executing SQL, creating spaces — runs under the user's permissions. Users only see what they have access to.
+
+### Service Principal Fallback for Genie API
+
+Some user OAuth tokens lack the `dashboards.genie` scope. When the app detects a scope error (via `_is_scope_error()` in `backend/services/genie_client.py`), it transparently retries the call with the app's Service Principal. For this fallback to work, the SP must have **CAN_MANAGE** on each Genie Space.
+
+### Service Principal for Optimization Jobs
+
+The Auto-Optimize (GSO) pipeline runs as a **Lakeflow Job** — a long-running, multi-task DAG that can take minutes to complete. Lakeflow Jobs execute in a separate environment with a fixed `run_as` identity; there is no mechanism to forward the user's short-lived OAuth token into a background job. Therefore the optimization job runs as the app's Service Principal.
+
+Security is preserved because:
+
+1. **Authorization at trigger time** — the app verifies the user has `CAN_EDIT` or `CAN_MANAGE` on the Genie Space (via OBO) before submitting the job.
+2. **SP entitlement validated** — the app confirms the SP has `CAN_MANAGE` on the space before job submission.
+3. **Minimum-privilege SP** — the SP only needs read access to referenced data schemas and manage access to the optimization state schema.
+
+### SP Permissions Required
+
+| Scope | Permission | Purpose |
+|-------|-----------|---------|
+| Each Genie Space | `CAN_MANAGE` | API fallback + optimization patches |
+| Referenced data schemas | `SELECT`, `USE_SCHEMA`, `USE_CATALOG` | Data access during optimization benchmarks |
+| GSO optimizer schema | `USE_CATALOG`, `USE_SCHEMA`, `SELECT`, `MODIFY`, `CREATE_TABLE`, `CREATE_FUNCTION`, `CREATE_MODEL`, `CREATE_VOLUME`, `EXECUTE`, `MANAGE` | Optimizer state tables, MLflow models, prompt registry |
+
+### Permission Boundary Summary
+
+| Operation | Identity | Rationale |
+|-----------|----------|-----------|
+| Browse Genie Spaces, UC catalogs/schemas/tables | OBO (user) | User sees only what they have access to |
+| Genie API (fetch/list spaces) | OBO, SP fallback on scope error | User token may lack `dashboards.genie` scope |
+| Create Agent (tools, SQL, space creation) | OBO (user) | Space created under user's identity |
+| Fix Agent (generate + apply patches) | OBO (user) | Patches applied as the user |
+| Trigger optimization (permission check) | OBO (user) | Verifies user has CAN_EDIT/CAN_MANAGE |
+| Optimization job execution (6-task DAG) | SP | Lakeflow Jobs have no OBO; SP runs the pipeline |
+| GSO Delta table reads/writes | SP | Optimizer state tables owned by SP |
+| Lakebase persistence | SP | App-level storage, not user-scoped |
+
 ## Prerequisites
 
 * [Databricks CLI](https://docs.databricks.com/dev-tools/cli/install.html) (v0.239.0+ required)
@@ -177,6 +222,8 @@ The Auto-Optimize optimization job is created automatically during deploy. The d
 If the job already exists (from a previous deploy), it is reused. To force recreation, delete the job in the Databricks UI and re-run `./scripts/deploy.sh --update`.
 
 ## Post-Deploy: Genie Space Access
+
+> For a full explanation of when OBO vs SP auth is used, see [Permissions & Authentication Model](#permissions--authentication-model) above.
 
 The app uses On-Behalf-Of (OBO) auth — users see only Genie Spaces they have permission to manage. The app's service principal also needs access for fallback operations:
 

--- a/docs/00-index.md
+++ b/docs/00-index.md
@@ -1,0 +1,47 @@
+# Genie Workbench Documentation
+
+Genie Workbench is a unified developer tool for creating, scoring, and optimizing Databricks Genie Spaces. It is deployed as a Databricks App (FastAPI backend + React/Vite frontend) with On-Behalf-Of authentication, Lakebase persistence, and a benchmark-driven optimization pipeline.
+
+## Table of Contents
+
+| # | Document | Description |
+|---|----------|-------------|
+| 01 | [Introduction](01-introduction.md) | What Genie Workbench is, who it's for, key concepts, feature overview |
+| 02 | [Architecture Overview](02-architecture-overview.md) | Backend, frontend, GSO package, data flows, SSE streaming |
+| 03 | [Authentication & Permissions](03-authentication-and-permissions.md) | OBO vs SP dual auth model, trigger flow, GRANT statements |
+| 04 | [Create Agent](04-create-agent.md) | Multi-turn LLM agent for building Genie Spaces from scratch |
+| 05 | [IQ Scanner](05-iq-scanner.md) | Rule-based quality scoring: 12 checks, 3 maturity tiers |
+| 06 | [Fix Agent](06-fix-agent.md) | Scan-to-patch pipeline: findings to JSON patches to Genie API |
+| 07 | [Auto-Optimize (GSO)](07-auto-optimize.md) | Benchmark-driven optimization: 6-stage DAG, levers, gates |
+| 08 | [Deployment Guide](08-deployment-guide.md) | install.sh, deploy.sh, Lakebase setup, configuration reference |
+| 09 | [Operations Guide](09-operations-guide.md) | Lakebase management, MLflow, monitoring, GSO job ops |
+
+### Appendices
+
+| # | Document | Description |
+|---|----------|-------------|
+| A | [API Reference](appendices/A-api-reference.md) | All API endpoints with auth identity and purpose |
+| B | [Troubleshooting](appendices/B-troubleshooting.md) | Common issues, causes, and fixes |
+| C | [Environment Variables](appendices/C-environment-variables.md) | Full reference for app.yaml and .env.deploy variables |
+
+## Quick Reference
+
+```bash
+# Deploy (first time)
+./scripts/install.sh
+
+# Deploy (subsequent)
+./scripts/deploy.sh
+
+# Code-only update
+./scripts/deploy.sh --update
+
+# Tear down
+./scripts/deploy.sh --destroy
+```
+
+## Start Here
+
+- **Genie Space developer** — Read [Introduction](01-introduction.md), then [Create Agent](04-create-agent.md) and [IQ Scanner](05-iq-scanner.md)
+- **Workspace admin** — Read [Deployment Guide](08-deployment-guide.md), then [Authentication & Permissions](03-authentication-and-permissions.md)
+- **Contributor** — Read [Architecture Overview](02-architecture-overview.md), then the feature doc for the area you're modifying

--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -1,0 +1,62 @@
+# Introduction
+
+## What is Genie Workbench?
+
+Genie Workbench is a developer tool for Databricks Genie Spaces — the natural-language-to-SQL interface for business users. It addresses the gap between creating a Genie Space and having one that reliably produces correct SQL: most spaces start with incomplete metadata, missing instructions, and no benchmarks, leading to poor user experiences.
+
+Genie Workbench provides five capabilities that form a continuous improvement loop:
+
+1. **Create** — An AI agent that walks you from business requirements through data discovery, inspection, and plan generation to a fully configured Genie Space.
+2. **Score** — A rule-based IQ Scanner that evaluates space quality across 12 checks and assigns a maturity tier.
+3. **Fix** — An AI agent that reads scan findings and generates targeted JSON patches to fix configuration gaps.
+4. **Optimize** — A benchmark-driven pipeline (Auto-Optimize / GSO) that measures real accuracy, diagnoses failures, and iteratively improves the space configuration.
+5. **Track** — Persistent history of every scan, optimization run, and configuration change, stored in Lakebase.
+
+## Target Audience
+
+- **Genie Space developers** building and maintaining spaces for their organizations
+- **Data platform teams** managing quality across multiple Genie Spaces
+- **Workspace administrators** deploying and operating the Workbench app
+
+## Key Concepts
+
+| Term | Definition |
+|------|-----------|
+| **Genie Space** | A Databricks resource that lets business users ask data questions in natural language. Configured with tables, instructions, example SQL, and benchmarks. |
+| **`serialized_space`** | The JSON configuration of a Genie Space, accessed via the Genie Conversation API. Contains `data_sources`, `instructions`, `config`, and `benchmarks` sections. |
+| **IQ Score** | A 0–12 score based on 12 binary checks. Each check evaluates one aspect of space configuration quality. |
+| **Maturity Tier** | One of three labels derived from the IQ Score: **Not Ready**, **Ready to Optimize**, or **Trusted**. |
+| **Finding** | A specific configuration gap identified by the IQ Scanner (e.g., "No join specifications for multi-table space"). Findings feed the Fix Agent. |
+| **Benchmark** | A question-answer pair used to measure Genie accuracy. The expected SQL is compared against Genie's generated SQL by specialized judges. |
+| **Lever** | An optimization strategy category in Auto-Optimize. Five lever types: tables/columns, metric views, TVFs, join specs, and instructions/example SQL. |
+| **Patch** | A targeted change to the `serialized_space` configuration, represented as a `field_path` + `new_value` pair. |
+| **OBO (On-Behalf-Of)** | Authentication model where the app acts on behalf of the signed-in user. See [Authentication & Permissions](03-authentication-and-permissions.md). |
+| **SP (Service Principal)** | The app's own identity, used for background jobs and API fallback. See [Authentication & Permissions](03-authentication-and-permissions.md). |
+| **GSO (Genie Space Optimizer)** | The Auto-Optimize engine package that runs the benchmark-driven optimization pipeline. |
+
+## Feature Workflow
+
+The features form a lifecycle that can be entered at any point and repeated as the space evolves:
+
+```
+┌──────────┐     ┌──────────┐     ┌──────────┐     ┌──────────────┐     ┌──────────┐
+│  Create   │────▶│ IQ Scan  │────▶│   Fix    │────▶│ Auto-Optimize│────▶│  Track   │
+│  Agent    │     │ (Score)  │     │  Agent   │     │   (GSO)      │     │ (History)│
+└──────────┘     └──────────┘     └──────────┘     └──────────────┘     └──────────┘
+                       ▲                                                       │
+                       └───────────────────────────────────────────────────────┘
+                                        continuous improvement
+```
+
+- **Create Agent** builds a new space from scratch (or updates an existing one).
+- **IQ Scanner** evaluates the space and produces findings.
+- **Fix Agent** applies targeted patches based on those findings.
+- **Auto-Optimize** runs a deeper benchmark-driven pipeline for accuracy improvement.
+- **Track** persists all results to Lakebase so you can see progress over time.
+- The cycle repeats: after optimization, re-scan to see the updated score.
+
+## Next Steps
+
+- [Architecture Overview](02-architecture-overview.md) — understand how the app is built
+- [Authentication & Permissions](03-authentication-and-permissions.md) — understand the security model
+- [Deployment Guide](08-deployment-guide.md) — deploy the app to your workspace

--- a/docs/02-architecture-overview.md
+++ b/docs/02-architecture-overview.md
@@ -1,0 +1,166 @@
+# Architecture Overview
+
+Genie Workbench is a full-stack application deployed as a [Databricks App](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/). This document describes the major components, their interactions, and the data flows between them.
+
+## High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Databricks Apps Platform                │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │                 Reverse Proxy (OBO)                    │  │
+│  │          x-forwarded-access-token injection            │  │
+│  └───────────────────┬───────────────────────────────────┘  │
+│                      │                                       │
+│  ┌───────────────────▼───────────────────────────────────┐  │
+│  │              FastAPI Backend (uvicorn)                  │  │
+│  │  ┌──────────┐  ┌──────────┐  ┌────────────────────┐   │  │
+│  │  │ Routers  │  │ Services │  │ Static File Server │   │  │
+│  │  │ /api/*   │  │ (auth,   │  │ frontend/dist/     │   │  │
+│  │  │          │  │  genie,  │  │                    │   │  │
+│  │  │          │  │  llm,    │  │                    │   │  │
+│  │  │          │  │  lakebase│  │                    │   │  │
+│  │  │          │  │  scanner)│  │                    │   │  │
+│  │  └──────────┘  └──────────┘  └────────────────────┘   │  │
+│  └───────────────────────────────────────────────────────┘  │
+│                      │                                       │
+│  ┌───────────────────▼───────────────────────────────────┐  │
+│  │              External Services                         │  │
+│  │  ┌──────────┐ ┌──────┐ ┌────────┐ ┌──────────────┐   │  │
+│  │  │ Genie API│ │  UC  │ │ SQL WH │ │Model Serving │   │  │
+│  │  └──────────┘ └──────┘ └────────┘ └──────────────┘   │  │
+│  │  ┌──────────┐ ┌──────────┐ ┌─────────────────────┐   │  │
+│  │  │ Lakebase │ │  MLflow  │ │ Delta (GSO state)   │   │  │
+│  │  └──────────┘ └──────────┘ └─────────────────────┘   │  │
+│  └───────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Backend Structure
+
+The backend is a FastAPI application (`backend/main.py`) that provides REST API endpoints and serves the built React frontend as static files.
+
+### Entry Point (`backend/main.py`)
+
+- Registers `OBOAuthMiddleware` for user identity on all `/api/*` routes
+- Mounts routers with their prefixes
+- Serves `frontend/dist/` as static files (SPA with fallback to `index.html`)
+- On startup, ensures the GSO job's `run_as` matches the app's SP via `_ensure_gso_job_run_as()`
+
+### Routers
+
+| Router | Prefix | Purpose |
+|--------|--------|---------|
+| `analysis.py` | `/api` | Space fetch/parse, app settings, debug auth |
+| `spaces.py` | `/api` | Space listing, scanning, history, starring, fix agent |
+| `admin.py` | `/api/admin` | Org-wide dashboard, leaderboard, alerts |
+| `auth.py` | `/api/auth` | Current user info, health check |
+| `create.py` | `/api/create` | Create agent chat, UC discovery, wizard, session management |
+| `auto_optimize.py` | `/api/auto-optimize` | GSO trigger, run management, results, patches, suggestions |
+
+See [Appendix A: API Reference](appendices/A-api-reference.md) for the complete endpoint list.
+
+### Services
+
+| Service | File | Purpose |
+|---------|------|---------|
+| Auth | `services/auth.py` | OBO `ContextVar` management, SP singleton, `WorkspaceClient` factory |
+| Genie Client | `services/genie_client.py` | Genie API: fetch space, list spaces, SP fallback on scope error |
+| Scanner | `services/scanner.py` | Rule-based IQ scoring (12 checks, 3 maturity tiers) |
+| Fix Agent | `services/fix_agent.py` | LLM-driven patch generation and Genie API application |
+| Create Agent | `services/create_agent.py` | Multi-turn tool-calling LLM agent for space creation |
+| Create Agent Tools | `services/create_agent_tools.py` | Tool definitions: UC discovery, SQL, config generation |
+| Create Agent Session | `services/create_agent_session.py` | Session persistence (L1 in-memory + L2 Lakebase) |
+| Plan Builder | `services/plan_builder.py` | Parallel LLM plan generation across 5 sections |
+| LLM Utils | `services/llm_utils.py` | OpenAI-compatible LLM client via Databricks model serving |
+| UC Client | `services/uc_client.py` | Unity Catalog browsing (catalogs, schemas, tables) |
+| Lakebase | `services/lakebase.py` | PostgreSQL persistence with in-memory fallback |
+| GSO Lakebase | `services/gso_lakebase.py` | GSO synced table reads from Lakebase |
+
+### Prompt Templates
+
+- `backend/prompts/` — templates for analysis and fix agent
+- `backend/prompts_create/` — modular templates for the create agent (step detection, system prompts, tool instructions)
+- `backend/references/schema.md` — Genie Space JSON schema reference (needed at runtime)
+
+## Frontend Structure
+
+The frontend is a React 19 + TypeScript + Tailwind CSS v4 application built with Vite.
+
+### Navigation
+
+`App.tsx` uses React state (not a router library) to switch between four views:
+
+| View | Component | Description |
+|------|-----------|-------------|
+| `list` | `SpaceList` | Browse and search Genie Spaces with IQ scores |
+| `detail` | `SpaceDetail` | Space detail with tabs: Score, Optimize, History |
+| `admin` | `AdminDashboard` | Org-wide stats, leaderboard, alerts |
+| `create` | `CreateAgentChat` | Conversational agent for building new spaces |
+
+### Component Organization
+
+- `components/ui/` — design system primitives (button, card, badge, etc.) using `class-variance-authority`
+- `components/auto-optimize/` — 24 components for the GSO optimization UI
+- `pages/` — `SpaceList`, `SpaceDetail`, `AdminDashboard`, `HistoryTab`, `IQScoreTab`
+- `hooks/` — `useAnalysis`, `useTheme`
+- `lib/api.ts` — all API calls and SSE streaming helpers
+- `types/index.ts` — TypeScript mirrors of backend Pydantic models
+
+### Design System
+
+- **Primary accent**: Electric Indigo (`#4F46E5`)
+- **Secondary accent**: Cyan (`#06B6D4`)
+- **Themes**: Light and dark mode via CSS variables on `:root` / `.dark`, toggled by `useTheme()` hook
+- **Fonts**: Cabinet Grotesk (display), General Sans (body), JetBrains Mono (code)
+
+## GSO Package
+
+The `packages/genie-space-optimizer/` directory contains a separate Python package with its own frontend:
+
+- **Python backend** — optimization pipeline, job notebooks, FastAPI service
+- **React frontend** — built with Bun (not npm), includes a "How It Works" walkthrough UI
+- **Deployed as** — a wheel installed into the app's Python environment + a Databricks Job for the optimization DAG
+- **Has its own** — `pyproject.toml`, `uv.lock`, `package.json`, `bun.lock`
+
+The main Workbench app proxies GSO functionality through `backend/routers/auto_optimize.py`.
+
+## Data Flows
+
+### SSE Streaming
+
+Four endpoints use Server-Sent Events via FastAPI's `StreamingResponse`:
+
+| Endpoint | Use |
+|----------|-----|
+| `/api/spaces/{id}/fix` | Fix agent progress + patches (10s keepalive) |
+| `/api/create/agent/chat` | Create agent events (15s keepalive) |
+
+The frontend consumes SSE via manual `fetch` + `ReadableStream` in `lib/api.ts` (not the `EventSource` API). Buffers are split on `\n\n` delimiters.
+
+For SSE endpoints, the OBO `ContextVar` is **not** cleared after `call_next` in the middleware, because the response body streams lazily after the middleware returns. Streaming handlers stash the user token on `request.state` and re-set it inside the generator.
+
+### Persistence
+
+| Store | Technology | Contents |
+|-------|-----------|----------|
+| Lakebase | PostgreSQL (asyncpg) | `scan_results`, `starred_spaces`, `seen_spaces`, `optimization_runs`, `agent_sessions` |
+| Delta Tables | Unity Catalog | GSO optimization state: 12 tables under `GSO_CATALOG.GSO_SCHEMA` |
+| MLflow | Experiment Tracking | LLM call traces, benchmark evaluations, prompt registry |
+
+Lakebase degrades gracefully to in-memory dictionaries when `LAKEBASE_HOST` is not configured, making the app functional (but non-persistent) without a database.
+
+## Key Design Decisions
+
+1. **No local dev server** — the app depends on Databricks OBO auth, Lakebase, and model serving endpoints that are only available inside a Databricks App environment. All testing is done by deploying to a real workspace.
+
+2. **Two deployment mechanisms** — `deploy.sh` manages the app (create, sync, `databricks apps deploy`); the GSO optimization job is managed by DABs (`databricks bundle deploy -t app`). They coexist but are independent.
+
+3. **Pydantic/TypeScript model sync** — `backend/models.py` and `frontend/src/types/index.ts` must be kept in sync manually. There is no code generation step.
+
+4. **Root `package.json` is a no-op** — exists solely to satisfy the Databricks Apps platform build hook. The real frontend build happens in `frontend/`.
+
+## Next Steps
+
+- [Authentication & Permissions](03-authentication-and-permissions.md) — the dual auth model in detail
+- [API Reference](appendices/A-api-reference.md) — complete endpoint listing

--- a/docs/03-authentication-and-permissions.md
+++ b/docs/03-authentication-and-permissions.md
@@ -1,0 +1,227 @@
+# Authentication & Permissions
+
+This is the authoritative reference for how identity and authorization work in Genie Workbench. The app uses a **dual-identity model**: the signed-in user's token for interactive operations and the app's Service Principal (SP) for background jobs and API fallback.
+
+## Overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        Databricks Apps                           │
+│                                                                  │
+│   Browser ──▶ Reverse Proxy ──▶ FastAPI Backend                  │
+│                  │                    │                           │
+│                  │ injects            │ reads header              │
+│                  │ x-forwarded-       │ stores in ContextVar      │
+│                  │ access-token       │                           │
+│                  ▼                    ▼                           │
+│            User's OAuth       OBO WorkspaceClient                │
+│            Token               (per-request)                     │
+│                                                                  │
+│                               SP WorkspaceClient                 │
+│                                (singleton, from                  │
+│                                 platform env vars)               │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## OBO (On-Behalf-Of) Authentication
+
+### How it works
+
+1. The Databricks Apps platform authenticates the user via SSO and forwards their OAuth access token in the `x-forwarded-access-token` HTTP header on every request.
+
+2. `OBOAuthMiddleware` in `backend/main.py` intercepts all `/api/*` requests and calls `set_obo_user_token(token)` from `backend/services/auth.py`.
+
+3. `set_obo_user_token()` creates a `WorkspaceClient` configured with `auth_type="pat"` using the user's token. This is stored in a Python `ContextVar` so it is scoped to the current request.
+
+   > The explicit `auth_type="pat"` is required because the Databricks Apps environment has `DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET` set for the SP. Without it, the SDK would default to OAuth M2M instead of the user's token.
+
+4. All downstream service calls use `get_workspace_client()`, which returns the OBO client if set, otherwise falls back to the SP singleton.
+
+### SSE streaming caveat
+
+For Server-Sent Events endpoints (fix agent, create agent), the `ContextVar` is **not** cleared after `call_next` in the middleware. This is because the response body streams lazily — the generator runs after the middleware returns. Streaming handlers stash the raw token on `request.state.user_token` and re-set it inside the generator function.
+
+### What OBO protects
+
+Users can only interact with resources they have permission to access:
+- **Unity Catalog**: catalogs, schemas, tables visible to the user
+- **Genie Spaces**: only spaces the user can manage
+- **SQL Warehouse**: queries execute under the user's identity
+- **Space creation/modification**: spaces are created and patched as the user
+
+## Service Principal (SP)
+
+### Singleton client
+
+`get_service_principal_client()` in `backend/services/auth.py` always returns the SP singleton — a `WorkspaceClient` initialized from the platform environment variables (`DATABRICKS_CLIENT_ID`, `DATABRICKS_CLIENT_SECRET`, `DATABRICKS_HOST`). On Databricks Apps, this is the app's own SP.
+
+### When SP is used
+
+The SP is used in three scenarios:
+
+#### 1. Genie API scope fallback
+
+Some user OAuth tokens lack the `dashboards.genie` scope, even though it is listed in `app.yaml` `user_api_scopes`. When `get_genie_space()` or `list_genie_spaces()` in `backend/services/genie_client.py` catches a scope error, it transparently retries with the SP:
+
+```python
+def _is_scope_error(e: Exception) -> bool:
+    msg = str(e).lower()
+    return "scope" in msg or "insufficient_scope" in msg
+```
+
+For this fallback to work, the SP must have **CAN_MANAGE** on each Genie Space.
+
+#### 2. Optimization job execution
+
+The Auto-Optimize pipeline runs as a Lakeflow Job — a long-running, multi-task DAG. Lakeflow Jobs execute in a separate environment with a fixed `run_as` identity. There is no mechanism to forward the user's short-lived OAuth token into a background job that may run for minutes.
+
+The job is configured to `run_as` the app's SP. At startup, `_ensure_gso_job_run_as()` in `backend/main.py` verifies and updates the job's `run_as` to match the current app SP.
+
+#### 3. GSO Delta table operations
+
+Reads and writes to the optimizer state tables (12 Delta tables under `GSO_CATALOG.GSO_SCHEMA`) use the SP because these tables are owned by the SP and are not user-scoped.
+
+## Optimization Trigger Flow
+
+When a user triggers Auto-Optimize, the app uses **both** identities in a carefully sequenced flow:
+
+```
+User clicks "Optimize"
+        │
+        ▼
+POST /api/auto-optimize/trigger
+        │
+        ▼
+┌───────────────────────────────┐
+│ 1. user_can_edit_space(OBO)   │◀── Verify user has CAN_EDIT/CAN_MANAGE
+│    Reject if unauthorized     │
+└───────────┬───────────────────┘
+            ▼
+┌───────────────────────────────┐
+│ 2. fetch_space_config         │◀── Try OBO first, then SP fallback
+│    Snapshot the space config  │
+└───────────┬───────────────────┘
+            ▼
+┌───────────────────────────────┐
+│ 3. fetch_uc_metadata(OBO)     │◀── Column/tag metadata respects user visibility
+└───────────┬───────────────────┘
+            ▼
+┌───────────────────────────────┐
+│ 4. sp_can_manage_space(SP)    │◀── Verify SP has CAN_MANAGE
+│    Reject if SP lacks access  │
+└───────────┬───────────────────┘
+            ▼
+┌───────────────────────────────┐
+│ 5. wh_create_run(OBO)         │◀── Insert run row in Delta (user identity)
+└───────────┬───────────────────┘
+            ▼
+┌───────────────────────────────┐
+│ 6. submit_optimization(SP)    │◀── jobs.run_now() as SP
+│    → Lakeflow Job submitted   │
+└───────────┬───────────────────┘
+            ▼
+┌───────────────────────────────┐
+│ 7. 6-task DAG executes as SP  │
+│    (preflight → baseline →    │
+│     enrichment → lever_loop → │
+│     finalize → deploy)        │
+└───────────────────────────────┘
+```
+
+**Source:** `packages/genie-space-optimizer/src/genie_space_optimizer/integration/trigger.py` — `trigger_optimization()`
+
+## Requested OAuth Scopes
+
+The `user_api_scopes` in `app.yaml` request these scopes for the user's OBO token:
+
+| Scope | Purpose |
+|-------|---------|
+| `sql` | Execute SQL queries via warehouses |
+| `dashboards.genie` | Access Genie Space API |
+| `serving.serving-endpoints` | Call model serving endpoints (LLM) |
+| `catalog.catalogs:read` | Browse Unity Catalog catalogs |
+| `catalog.schemas:read` | Browse Unity Catalog schemas |
+| `catalog.tables:read` | Browse Unity Catalog tables |
+| `files.files` | Access workspace files |
+| `iam.access-control:read` | Read ACLs for permission checks |
+
+If the workspace or user's OAuth consent doesn't grant all scopes, the app degrades gracefully — the SP fallback handles the most common gap (`dashboards.genie`).
+
+## SP Permissions Required
+
+### Per Genie Space
+
+| Permission | Purpose |
+|-----------|---------|
+| `CAN_MANAGE` | API fallback when user token lacks Genie scope; applying optimization patches during the GSO pipeline |
+
+Grant via the Genie Space sharing UI or the installer (`scripts/install.sh` automates this).
+
+### Per referenced data schema
+
+| Permission | Purpose |
+|-----------|---------|
+| `USE_CATALOG` | Access the catalog containing the schema |
+| `USE_SCHEMA` | Access the schema |
+| `SELECT` | Read table data during optimization benchmarks |
+
+```sql
+GRANT USE_CATALOG ON CATALOG <catalog> TO `<service-principal-name>`;
+GRANT USE_SCHEMA ON SCHEMA <catalog>.<schema> TO `<service-principal-name>`;
+GRANT SELECT ON SCHEMA <catalog>.<schema> TO `<service-principal-name>`;
+```
+
+### GSO optimizer schema
+
+The SP needs full access to the optimizer state schema (`<GSO_CATALOG>.genie_space_optimizer`):
+
+| Permission | Purpose |
+|-----------|---------|
+| `USE_CATALOG` | Access the catalog |
+| `USE_SCHEMA` | Access the schema |
+| `SELECT` | Read optimizer state tables |
+| `MODIFY` | Write optimizer state tables |
+| `CREATE_TABLE` | Create state tables on first run |
+| `CREATE_FUNCTION` | Create UDFs if needed |
+| `CREATE_MODEL` | MLflow model registration |
+| `CREATE_VOLUME` | Artifact storage |
+| `EXECUTE` | Execute functions |
+| `MANAGE` | Schema management |
+
+These are granted automatically by `scripts/grant_permissions.py` during deployment.
+
+## Complete Permission Boundary
+
+| Operation | Identity | Code Reference | Rationale |
+|-----------|----------|---------------|-----------|
+| Browse Genie Spaces, UC catalogs/schemas/tables | OBO (user) | `services/uc_client.py`, `routers/create.py` | User sees only what they have access to |
+| Genie API — fetch/list spaces | OBO → SP fallback | `services/genie_client.py` `_is_scope_error()` | User token may lack `dashboards.genie` scope |
+| Create Agent — tools, SQL, space creation | OBO (user) | `services/create_agent.py`, `services/create_agent_tools.py` | Space created under user identity |
+| Fix Agent — generate + apply patches | OBO (user) | `services/fix_agent.py` | Patches applied as the user |
+| Trigger optimization — permission check | OBO (user) | `integration/trigger.py` `user_can_edit_space()` | Verify user has CAN_EDIT/CAN_MANAGE |
+| Trigger optimization — SP entitlement check | SP | `integration/trigger.py` `sp_can_manage_space()` | Verify SP can manage the space |
+| Optimization job submission | SP | `backend/job_launcher.py` `submit_optimization()` | `jobs.run_now()` requires SP |
+| Optimization job execution (6-task DAG) | SP (run_as) | `backend/job_launcher.py` `ensure_job_run_as()` | Lakeflow Jobs have no OBO mechanism |
+| GSO Delta table reads/writes | SP | `routers/auto_optimize.py` `_delta_query()` | Optimizer state tables owned by SP |
+| Lakebase persistence | SP | `services/lakebase.py` | App-level storage, not user-scoped |
+| IQ Scan | OBO (user) → SP for GSO data | `services/scanner.py` | Space fetch via OBO; GSO run data via SP |
+| Apply optimization results | OBO (user) | `routers/auto_optimize.py` `/runs/{id}/apply` | Changes applied under user identity |
+
+## Security Considerations
+
+1. **Authorization before execution** — the user must have `CAN_EDIT` or `CAN_MANAGE` on the Genie Space before any optimization job is submitted. This check happens with the user's OBO token, not the SP.
+
+2. **SP entitlement validated** — even if the user is authorized, the SP must also have `CAN_MANAGE` on the space. If the SP lacks access, the trigger is rejected with a clear error.
+
+3. **Minimum-privilege SP** — the SP only needs read access to referenced data schemas (for benchmarking) and manage access to the GSO state schema. It does not need workspace-admin privileges.
+
+4. **No token forwarding to jobs** — the design intentionally does not pass user tokens into background jobs. Short-lived OAuth tokens would expire during long-running DAGs, and storing user credentials in job parameters would be a security risk.
+
+5. **Audit trail** — the triggering user's email is recorded in the optimization run metadata, providing traceability even though the job executes as the SP.
+
+## Related Documentation
+
+- [Architecture Overview](02-architecture-overview.md) — system components
+- [Auto-Optimize](07-auto-optimize.md) — the optimization pipeline that runs under SP
+- [Deployment Guide](08-deployment-guide.md) — how SP permissions are granted during deploy
+- [API Reference](appendices/A-api-reference.md) — per-endpoint auth identity

--- a/docs/04-create-agent.md
+++ b/docs/04-create-agent.md
@@ -1,0 +1,171 @@
+# Create Agent
+
+The Create Agent is a multi-turn, tool-calling LLM agent that walks users from business requirements to a fully configured and deployed Genie Space. It handles data discovery, profiling, plan generation, config assembly, validation, and space creation — all through a conversational interface.
+
+## How It Works
+
+The agent follows a structured progression through six steps. Each step focuses on gathering specific information before moving to the next:
+
+```
+┌──────────────┐    ┌──────────────┐    ┌──────────────┐
+│ Requirements │───▶│ Data Sources │───▶│  Inspection  │
+│ What does    │    │ Which tables │    │ Profile cols │
+│ the space    │    │ and schemas? │    │ assess data  │
+│ need to do?  │    │              │    │ quality      │
+└──────────────┘    └──────────────┘    └──────────────┘
+                                               │
+       ┌───────────────────────────────────────┘
+       ▼
+┌──────────────┐    ┌──────────────┐    ┌──────────────┐
+│     Plan     │───▶│ Config Create│───▶│Post-Creation │
+│ Generate and │    │ Build, valid-│    │ Summary and  │
+│ present the  │    │ ate, deploy  │    │ next steps   │
+│ space plan   │    │ the space    │    │              │
+└──────────────┘    └──────────────┘    └──────────────┘
+```
+
+### Step Descriptions
+
+| Step | Label | What Happens |
+|------|-------|-------------|
+| `requirements` | Understanding Requirements | Agent gathers business context, use case, terminology, and target audience |
+| `data_sources` | Discovering Data | Agent browses Unity Catalog (catalogs → schemas → tables) to find relevant tables |
+| `inspection` | Inspecting Tables | Agent profiles columns, assesses data quality, and checks table usage patterns |
+| `plan` | Building Plan | Agent generates a structured plan with tables, questions, example SQLs, benchmarks |
+| `config_create` | Creating Space | Agent builds the `serialized_space` config, validates it, and creates the Genie Space |
+| `post_creation` | Done | Agent provides a summary, the space URL, and suggests next steps (e.g., run IQ Scan) |
+
+Step detection is automatic — the agent infers the current step from conversation history using `detect_step()` in `backend/prompts_create/`.
+
+## Tool Inventory
+
+The agent has access to 17 tools organized into six categories:
+
+### UC Discovery
+
+| Tool | Purpose |
+|------|---------|
+| `discover_catalogs` | List Unity Catalog catalogs accessible to the user |
+| `discover_schemas` | List schemas within a catalog |
+| `discover_tables` | List tables within a catalog.schema |
+| `describe_table` | Get full table metadata (columns, types, comments) |
+
+### Profiling & Quality
+
+| Tool | Purpose |
+|------|---------|
+| `profile_columns` | Statistical profiling: distinct counts, nulls, min/max, sample values |
+| `assess_data_quality` | Data quality assessment: completeness, consistency, anomalies |
+| `profile_table_usage` | Usage patterns: query frequency, access patterns |
+
+### SQL
+
+| Tool | Purpose |
+|------|---------|
+| `test_sql` | Execute a SQL query on the warehouse (throttled to 8 concurrent) |
+| `discover_warehouses` | List available SQL warehouses |
+
+### Schema & Config
+
+| Tool | Purpose |
+|------|---------|
+| `get_config_schema` | Return the Genie Space JSON schema reference |
+| `generate_config` | Build a `serialized_space` config from the plan |
+| `validate_config` | Validate a config against the Genie API schema (errors + warnings) |
+| `update_config` | Modify an existing space's config |
+
+### Plan
+
+| Tool | Purpose |
+|------|---------|
+| `generate_plan` | Generate a structured plan (delegates to parallel plan builder) |
+| `present_plan` | Present the plan to the user for review/editing |
+
+### Deploy
+
+| Tool | Purpose |
+|------|---------|
+| `create_space` | Create a new Genie Space via the Databricks API |
+| `update_space` | Update an existing Genie Space |
+
+## Parallel Plan Generation
+
+When the agent calls `generate_plan`, the request is routed to `backend/services/plan_builder.py`, which splits the work into five parallel sections:
+
+| Section | Content Generated |
+|---------|-------------------|
+| `tables` | Table selection, descriptions, column configs |
+| `questions` | Sample questions for the space |
+| `example_sqls` | Example question-SQL pairs with usage guidance |
+| `benchmarks` | Benchmark question-answer pairs for accuracy measurement |
+| `analytics` | Join specs, measures, filters, expressions |
+
+These sections are generated concurrently using a `ThreadPoolExecutor` with 3 workers. After all sections complete, `_assemble()` merges the results and `_validate_plan_sqls()` runs SQL validation with 8 concurrent checks to catch syntax errors.
+
+## Fast Path
+
+When the user reviews the plan in the UI and clicks "Create" (sending `action: "create"` with `edited_plan`), the agent uses `_fast_create` to skip additional LLM rounds. It directly:
+
+1. Calls `generate_config` to build the `serialized_space` from the plan
+2. Calls `validate_config` to check for errors
+3. Calls `create_space` (or `update_space` if modifying an existing space)
+
+This avoids unnecessary LLM inference and completes in seconds.
+
+## Auto-Chain
+
+After certain tool calls, the agent automatically chains to the next logical step without requiring another LLM turn:
+
+- After `generate_config` → automatically calls `validate_config`
+- After `validate_config` (if clean) → automatically calls `create_space` or `update_space`
+
+This reduces latency and keeps the flow smooth.
+
+## Streaming Protocol
+
+The create agent uses SSE (Server-Sent Events) to stream progress to the frontend. Each event is a JSON object with a `type` field:
+
+| Event Type | Purpose |
+|------------|---------|
+| `session` | Session ID for reconnection |
+| `step` | Current step label and thinking status |
+| `thinking` | Agent is processing (shows thinking indicator) |
+| `tool_call` | Agent is calling a tool (name + arguments) |
+| `tool_result` | Tool execution result |
+| `message_delta` | Incremental text from the LLM (streamed token-by-token) |
+| `message` | Complete message from the agent |
+| `created` | Genie Space was created (includes space ID and URL) |
+| `updated` | Existing space was updated |
+| `heartbeat` | Keep-alive ping (every 15s to prevent proxy timeout) |
+| `error` | Something went wrong |
+| `done` | Stream complete (may include `needs_continuation: true`) |
+
+### Continuation Protocol
+
+Each HTTP request performs exactly **one** LLM inference plus **one** batch of tool calls, then closes. This keeps each response under the Databricks Apps reverse proxy timeout (~120s).
+
+When the LLM requests tools, the `done` event carries `needs_continuation: true`. The frontend immediately opens a new SSE stream with an empty message to start the next round. This creates a seamless multi-turn experience while respecting HTTP timeout limits.
+
+## Session Persistence
+
+Agent sessions are persisted across page refreshes:
+
+- **L1 (in-memory)**: Fast access for active sessions
+- **L2 (Lakebase)**: Durable storage; sessions survive app restarts
+
+`backend/services/create_agent_session.py` manages the two-tier cache. Sessions store the full message history and current step, enabling reconnection via `GET /api/create/agent/sessions/{session_id}`.
+
+## Source Files
+
+- `backend/services/create_agent.py` — agent orchestration and streaming
+- `backend/services/create_agent_tools.py` — all 17 tool definitions
+- `backend/services/plan_builder.py` — parallel plan generation
+- `backend/services/create_agent_session.py` — session persistence
+- `backend/routers/create.py` — HTTP endpoints
+- `backend/prompts_create/` — prompt templates for each step
+
+## Related Documentation
+
+- [IQ Scanner](05-iq-scanner.md) — run after creating a space to assess quality
+- [Fix Agent](06-fix-agent.md) — automatically fix issues found by the scanner
+- [Architecture Overview](02-architecture-overview.md) — how the create agent fits in the app

--- a/docs/05-iq-scanner.md
+++ b/docs/05-iq-scanner.md
@@ -1,0 +1,133 @@
+# IQ Scanner
+
+The IQ Scanner is a **deterministic, rule-based** quality assessment engine for Genie Space configurations. It evaluates 12 binary checks, assigns a maturity tier, and produces actionable findings that feed the Fix Agent.
+
+Unlike the LLM-based analysis tools, the scanner runs instantly with no LLM calls — it inspects the `serialized_space` JSON directly.
+
+## Scoring Model
+
+### Score: 0–12
+
+Each of the 12 checks is worth 1 point. A check either passes (1 point) or fails (0 points). The total score ranges from 0 to 12.
+
+### Maturity Tiers
+
+| Tier | Criteria | Meaning |
+|------|----------|---------|
+| **Trusted** | All 12 checks pass | Space is fully configured and has proven accuracy |
+| **Ready to Optimize** | Checks 1–10 pass (config complete) | Configuration is solid; ready for benchmark-driven optimization |
+| **Not Ready** | Any of checks 1–10 fail | Configuration gaps need to be addressed first |
+
+The first 10 checks evaluate configuration quality. The last 2 checks evaluate optimization results — you must run Auto-Optimize to pass them.
+
+## The 12 Checks
+
+### Configuration Checks (1–10)
+
+| # | Check | Pass Criteria | On Failure |
+|---|-------|--------------|------------|
+| 1 | **Tables exist** | At least 1 table configured | "No tables configured" |
+| 2 | **Table descriptions** | ≥80% of tables have descriptions | Finding + next step to add descriptions |
+| 3 | **Column descriptions** | ≥50% of columns have descriptions | Finding + next step to add descriptions |
+| 4 | **Text instructions** | Present and >50 characters total | Finding to add business context instructions |
+| 5 | **Join specifications** | At least 1 join spec (for multi-table spaces) | Finding to add join specs |
+| 6 | **Table count 1–12** | Between 1 and 12 tables | Finding to reduce tables or use multi-room architecture |
+| 7 | **8+ example SQLs** | At least 8 example question-SQL pairs | Finding to add more examples |
+| 8 | **SQL snippets** | At least 1 function, expression, measure, or filter | Finding to add SQL snippets |
+| 9 | **Entity/format matching** | At least 1 column with entity matching or format assistance | Finding to enable on categorical/date/number columns |
+| 10 | **10+ benchmark questions** | At least 10 benchmark questions | Finding to add benchmarks |
+
+### Optimization Checks (11–12)
+
+| # | Check | Pass Criteria | On Failure |
+|---|-------|--------------|------------|
+| 11 | **Optimization workflow completed** | A terminal optimization run exists (`CONVERGED`, `STALLED`, or `MAX_ITERATIONS`) | "Space has not been through the optimization workflow" |
+| 12 | **Optimization accuracy ≥ 85%** | Best accuracy from optimization is ≥ 0.85 | "Optimization accuracy is X% — target ≥ 85%" |
+
+## Severity Levels
+
+Each check has a severity beyond pass/fail:
+
+| Severity | Meaning |
+|----------|---------|
+| `pass` | Check passed cleanly |
+| `warning` | Check passed but with advisory guidance (e.g., table descriptions at 90% — aim for 100%) |
+| `fail` | Check failed — a finding is generated |
+
+Warnings do not reduce the score but provide improvement suggestions.
+
+## Output Structure
+
+The scanner returns:
+
+```json
+{
+  "score": 8,
+  "total": 12,
+  "maturity": "Not Ready",
+  "checks": [
+    {"label": "Tables exist", "passed": true, "detail": "5 table(s) configured", "severity": "pass"},
+    ...
+  ],
+  "findings": ["No join specifications for multi-table space", ...],
+  "next_steps": ["Add join specifications to help Genie correctly join your tables", ...],
+  "warnings": ["Instructions total 2,500 chars — keep under 2,000", ...],
+  "warning_next_steps": ["Restructure text instructions for optimal LLM context usage", ...],
+  "scanned_at": "2026-04-08T12:00:00+00:00"
+}
+```
+
+- **`findings`** and **`next_steps`** come from failed checks — these are the inputs for the [Fix Agent](06-fix-agent.md).
+- **`warnings`** and **`warning_next_steps`** come from warning-severity checks — advisory guidance that doesn't block maturity progression.
+- Both lists are capped at 8 items.
+
+## Advisory Warnings
+
+Beyond the 12 scored checks, the scanner emits additional warnings for edge cases:
+
+| Condition | Warning |
+|-----------|---------|
+| Column descriptions at 50–80% | "Higher coverage improves SQL generation accuracy" |
+| No column synonyms defined | "Add synonyms for columns with abbreviated or technical names" |
+| Text instructions > 2,000 chars | "Keep under 2,000 to avoid pushing out higher-value SQL context" |
+| SQL patterns in text instructions | "Move to Example SQLs or SQL Expressions" |
+| Table count 9–12 | "Consider splitting into focused rooms for >8 tables" |
+| Example SQLs 8–14 | "10-15 is the sweet spot for largest accuracy jump" |
+| Missing `usage_guidance` on >50% of example SQLs | "Add descriptions of when each example should be applied" |
+| Missing measures or filters in SQL snippets | "Add missing SQL snippet types for better coverage" |
+| Entity matching columns > 100 | "Approaching 120/space limit" |
+| Row-level security on tables with entity matching | "Entity matching is silently disabled for these" |
+
+## Integration with Auto-Optimize
+
+Checks 11 and 12 evaluate optimization results. The scanner reads from two sources concurrently:
+
+1. **Lakebase** `optimization_runs` table — legacy/simple optimization records
+2. **GSO Delta tables** (`genie_opt_runs`) — Auto-Optimize pipeline runs, with fallback from Lakebase synced tables to direct Delta queries via SP
+
+The scanner normalizes accuracy values (GSO stores 0–100, scanner expects 0.0–1.0) and uses the best accuracy across both sources.
+
+Only terminal GSO run statuses count: `CONVERGED`, `STALLED`, `MAX_ITERATIONS`. In-progress or failed runs are ignored.
+
+## Persistence
+
+Scan results are persisted to Lakebase (table: `scan_results`) with:
+- `space_id`, `score`, `maturity`
+- `breakdown` (JSONB with full checks, warnings)
+- `findings`, `next_steps`
+- `scanned_at` timestamp
+
+Historical scans are available via `GET /api/spaces/{id}/history`.
+
+## Source Files
+
+- `backend/services/scanner.py` — scoring engine
+- `backend/routers/spaces.py` — `POST /api/spaces/{id}/scan` endpoint
+- `backend/services/lakebase.py` — persistence
+- `backend/services/gso_lakebase.py` — GSO run data for checks 11–12
+
+## Related Documentation
+
+- [Fix Agent](06-fix-agent.md) — automatically fixes findings from the scanner
+- [Auto-Optimize](07-auto-optimize.md) — the optimization pipeline that satisfies checks 11–12
+- [Introduction](01-introduction.md) — how the scanner fits in the feature workflow

--- a/docs/06-fix-agent.md
+++ b/docs/06-fix-agent.md
@@ -1,0 +1,126 @@
+# Fix Agent
+
+The Fix Agent is an AI-powered service that takes IQ Scanner findings and automatically generates targeted JSON patches to fix configuration gaps in a Genie Space. It addresses each finding individually, then applies all patches together in a single Databricks API call.
+
+## How It Works
+
+```
+IQ Scanner findings
+        │
+        ▼
+┌───────────────────────┐
+│  Parallel LLM calls   │  One call per finding
+│  (run_in_executor)    │  All run concurrently
+└───────────┬───────────┘
+            │
+            ▼
+┌───────────────────────┐
+│  Patch validation     │  Check field_path against _VALID_FIELDS
+│  + merge into config  │  Apply to mutable config copy
+└───────────┬───────────┘
+            │
+            ▼
+┌───────────────────────┐
+│  Re-fetch + apply     │  Fresh GET → apply patches → PATCH API
+│  with retry           │  Up to 3 attempts with back-off
+└───────────────────────┘
+```
+
+## Parallel Patch Generation
+
+To stay under the Databricks Apps proxy timeout (~120s), the Fix Agent launches **all LLM calls in parallel** rather than sequentially. Total wall time equals the slowest individual call instead of the sum.
+
+Each finding gets its own LLM call with:
+- The finding text
+- The current space configuration (frozen snapshot)
+- The Genie Space JSON schema reference
+
+The LLM returns one or more patches in JSON format:
+
+```json
+{
+  "patches": [
+    {
+      "field_path": "instructions.join_specs",
+      "new_value": [...],
+      "rationale": "Added join specification for orders-customers relationship"
+    }
+  ]
+}
+```
+
+## Patch Format
+
+Each patch has three fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `field_path` | string | Dot-notation path into the `serialized_space` (e.g., `instructions.join_specs`, `data_sources.tables[0].description`) |
+| `new_value` | any | The value to set at that path |
+| `rationale` | string | Explanation of why this patch is needed |
+
+### Field Path Validation
+
+Every segment of `field_path` is validated against `_VALID_FIELDS` — a frozenset of all known Genie API field names. Patches with unknown field names are rejected and logged. This prevents the LLM from hallucinating invalid paths.
+
+Array indices are supported: `data_sources.tables[0].column_configs[2].description`.
+
+## ID Sanitization
+
+The Genie API requires all `id` fields to be 32-character lowercase hex strings (UUID without hyphens). LLMs sometimes generate IDs with wrong formats, non-hex characters, or omit them entirely.
+
+`_sanitize_ids()` recursively walks the config and:
+- **Replaces** any `id` field that doesn't match the `^[0-9a-f]{32}$` pattern
+- **Injects** missing `id` fields into entries within known ID-required arrays (`text_instructions`, `example_question_sqls`, `join_specs`, `filters`, `expressions`, `measures`, `questions`, `sql_functions`, `sample_questions`)
+
+## Apply Flow
+
+After all patches are generated and merged into a mutable config copy, the Fix Agent applies them to Databricks:
+
+1. **Re-fetch** the space configuration via `get_serialized_space()` — this avoids "Space configuration has been modified since this export was taken" errors from stale configs.
+
+2. **Apply** all patches to the fresh config.
+
+3. **Sanitize** IDs and normalize join relationships.
+
+4. **Deduplicate** column configs (reject duplicate `column_name`), instruction IDs (reject duplicates across all instruction arrays), sample questions, and benchmark questions.
+
+5. **Clean and sort** via `_clean_config()` for API compliance.
+
+6. **PATCH** to the Genie API: `PATCH /api/2.0/genie/spaces/{space_id}` with the updated `serialized_space`.
+
+7. **Retry** on failure — up to 3 attempts with 2s and 4s delays, re-fetching the space config on each retry to handle concurrent modifications.
+
+## SSE Events
+
+The Fix Agent streams progress via Server-Sent Events:
+
+| Event Status | Payload | When |
+|-------------|---------|------|
+| `thinking` | `message: "Analyzing N issue(s)..."` | Start of fix run |
+| `thinking` | `message: "Fixing issue 1/N: ..."` | Before each finding's result |
+| `patch` | `field_path`, `old_value`, `new_value`, `rationale` | After each finding produces patches |
+| `applying` | `message: "Applying N fix(es)..."` | Before API call |
+| `complete` | `patches_applied`, `summary`, `diff` | Success |
+| `error` | `message` | Failure |
+
+The `diff` in the `complete` event includes the full list of patches, the original config, and the updated config — enabling the frontend to show a before/after diff view.
+
+## MLflow Tracing
+
+All LLM calls and patch parsing are traced via MLflow:
+- `fix_generate_patch` — LLM span for each finding
+- `fix_parse_patch` — tool span for JSON parsing
+- `fix_apply_config` — tool span for the API call
+
+## Source Files
+
+- `backend/services/fix_agent.py` — all fix agent logic
+- `backend/prompts.py` — `get_fix_agent_single_prompt()` for per-finding prompts
+- `backend/routers/spaces.py` — `POST /api/spaces/{id}/fix` SSE endpoint
+
+## Related Documentation
+
+- [IQ Scanner](05-iq-scanner.md) — produces the findings that feed the Fix Agent
+- [Auto-Optimize](07-auto-optimize.md) — deeper optimization via benchmarks (independent path)
+- [Authentication & Permissions](03-authentication-and-permissions.md) — Fix Agent uses OBO auth

--- a/docs/07-auto-optimize.md
+++ b/docs/07-auto-optimize.md
@@ -1,0 +1,150 @@
+# Auto-Optimize (GSO)
+
+Auto-Optimize is a benchmark-driven optimization pipeline that measures Genie Space accuracy, diagnoses failures, and iteratively applies metadata patches until quality thresholds are met. It is powered by the Genie Space Optimizer (GSO) engine — a separate Python package at `packages/genie-space-optimizer/`.
+
+## Overview
+
+Unlike the [Fix Agent](06-fix-agent.md) (which applies targeted patches from scan findings), Auto-Optimize runs a **closed-loop pipeline**: it generates benchmarks, evaluates Genie's generated SQL against expected answers using specialized judges, identifies failure patterns, proposes and tests metadata changes, and only commits changes that pass multi-stage evaluation gates.
+
+## The 6-Task Pipeline
+
+The optimization runs as a Databricks Lakeflow Job with six sequential tasks:
+
+```
+┌───────────┐   ┌──────────┐   ┌────────────┐   ┌────────────┐   ┌──────────┐   ┌────────┐
+│ Preflight │──▶│ Baseline │──▶│ Enrichment │──▶│ Lever Loop │──▶│ Finalize │──▶│ Deploy │
+│           │   │   Eval   │   │            │   │            │   │          │   │        │
+└───────────┘   └──────────┘   └────────────┘   └────────────┘   └──────────┘   └────────┘
+     1               2               3                4               5             6
+```
+
+### Task Details
+
+| # | Task | Purpose | Key Actions |
+|---|------|---------|-------------|
+| 1 | **Preflight** | Validate prerequisites | Check SP permissions, verify benchmark questions, validate table access, ensure Prompt Registry is enabled |
+| 2 | **Baseline Evaluation** | Measure current accuracy | Run all benchmark questions through Genie, evaluate with 9 judges, establish baseline score |
+| 3 | **Enrichment** | Gather optimization context | Proactive metadata enrichment — profile tables, analyze query patterns, identify improvement opportunities |
+| 4 | **Lever Loop** | Iterative optimization | The core loop: cluster failures → pick levers → generate patches → 3-gate evaluation → accept or rollback |
+| 5 | **Finalize** | Consolidate results | Merge accepted patches, validate final configuration, compute final accuracy |
+| 6 | **Deploy** | Apply to space | Optionally apply the optimized configuration to the live Genie Space |
+
+## The 5 Lever Categories
+
+Levers are categories of metadata changes the optimizer can apply. Each lever targets a different aspect of the space configuration:
+
+| Lever | Target | Examples |
+|-------|--------|----------|
+| **Tables/Columns** | Table and column metadata | Add descriptions, synonyms, entity matching, format assistance |
+| **Metric Views** | Pre-computed metric definitions | Add metric views for common aggregations |
+| **TVFs (Table-Valued Functions)** | Custom SQL functions | Add TVFs for complex business logic |
+| **Join Specs** | Table relationship definitions | Add or refine join specifications between tables |
+| **Instructions/Example SQL** | Behavioral guidance | Add text instructions, example SQL pairs, SQL snippets (filters, measures, expressions) |
+
+The lever loop's **strategist** analyzes current failure patterns and selects the lever category most likely to address them.
+
+## 3-Gate Evaluation
+
+Before accepting any set of patches, the optimizer runs them through three progressively broader evaluation gates:
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│   Gate 1:    │────▶│   Gate 2:    │────▶│   Gate 3:    │
+│   Slice      │     │   P0         │     │   Full       │
+│              │     │              │     │              │
+│ Test on the  │     │ Test on high │     │ Test on all  │
+│ failing      │     │ priority     │     │ benchmark    │
+│ questions    │     │ questions    │     │ questions    │
+│ only         │     │              │     │              │
+└──────────────┘     └──────────────┘     └──────────────┘
+```
+
+| Gate | Scope | Purpose |
+|------|-------|---------|
+| **Slice** | Only the questions that currently fail | Quick check — did the patches fix the targeted failures? |
+| **P0** | High-priority / critical questions | Regression check — did we break anything important? |
+| **Full** | All benchmark questions | Complete evaluation — net accuracy improvement |
+
+If a patch set fails at any gate, it is **rolled back** and the optimizer tries a different approach. The strategist records the failure in a reflection buffer to avoid retrying the same strategy.
+
+## 9 Specialized Judges
+
+Accuracy evaluation uses 9 specialized judges that compare Genie's generated SQL against expected benchmark answers:
+
+Each judge evaluates a different dimension of SQL correctness (e.g., table selection, join logic, filter conditions, aggregation, column selection, output format). A question is considered "correct" when it passes the required subset of judges.
+
+Judge prompts are managed via **MLflow Prompt Registry**, providing version control and traceability for evaluation criteria.
+
+## Convergence
+
+The lever loop terminates when one of three conditions is met:
+
+| Status | Condition | Meaning |
+|--------|-----------|---------|
+| `CONVERGED` | Accuracy target reached (typically ≥ 85%) | Optimization succeeded |
+| `STALLED` | No improvement across consecutive iterations | Further optimization is unlikely |
+| `MAX_ITERATIONS` | Iteration limit reached | Time-boxed stop |
+
+The IQ Scanner checks for terminal GSO runs when evaluating checks 11 and 12. A `CONVERGED` run with `best_accuracy ≥ 85%` satisfies both checks.
+
+## Data Persistence
+
+Auto-Optimize stores all state in **12 Delta tables** under `GSO_CATALOG.GSO_SCHEMA`:
+
+| Table | Contents |
+|-------|----------|
+| `genie_opt_runs` | Run metadata: status, accuracy, timestamps, config |
+| `genie_opt_iterations` | Per-iteration evaluation results |
+| `genie_opt_patches` | All patches generated (accepted and rejected) |
+| `genie_opt_suggestions` | Strategist suggestions per iteration |
+| `genie_opt_eval_results` | Detailed per-question evaluation results |
+| `genie_opt_asi_results` | ASI (judge) results per question per iteration |
+| `genie_opt_benchmarks` | Benchmark question definitions |
+| `genie_opt_enrichments` | Proactive enrichment data |
+| `genie_opt_lever_configs` | Lever configuration per run |
+| `genie_opt_space_snapshots` | Space config snapshots (before/after) |
+| `genie_opt_failure_clusters` | Failure pattern clusters |
+| `genie_opt_reflection` | Reflection buffer (what worked, what didn't) |
+
+The Workbench frontend reads this data through `backend/routers/auto_optimize.py`, which queries Lakebase synced tables (preferred) or falls back to direct Delta queries via the SP.
+
+## Permission Model
+
+The optimization job runs entirely as the app's **Service Principal** (SP). See [Authentication & Permissions](03-authentication-and-permissions.md) for the full security model, including:
+
+- Why jobs can't use OBO
+- How user authorization is verified before job submission
+- What SP permissions are required
+
+## MLflow Integration
+
+- **Experiment tracking**: each optimization run is tracked as an MLflow experiment
+- **Prompt Registry**: judge prompts are versioned in MLflow Prompt Registry, enabling reproducible evaluations
+- **`MLFLOW_EXPERIMENT_ID`**: configured in `app.yaml`, validated at startup
+
+> MLflow Prompt Registry must be enabled on the workspace. If disabled, the preflight task will fail with `FEATURE_DISABLED`.
+
+## Triggering from the UI
+
+Users trigger optimization from the **Optimize** tab in the Space Detail view:
+
+1. The UI calls `GET /api/auto-optimize/permissions/{space_id}` to pre-check SP access
+2. User configures options (apply mode, levers) and clicks "Optimize"
+3. `POST /api/auto-optimize/trigger` starts the job (see [trigger flow](03-authentication-and-permissions.md#optimization-trigger-flow))
+4. The UI polls `GET /api/auto-optimize/runs/{run_id}/status` for progress
+5. On completion, the user can review patches and choose to apply or discard
+
+## Source Files
+
+- `packages/genie-space-optimizer/` — the GSO engine package
+- `backend/routers/auto_optimize.py` — 16 API endpoints for GSO management
+- `backend/services/gso_lakebase.py` — synced table reads
+- `backend/main.py` — `_ensure_gso_job_run_as()` startup hook
+- `databricks.yml` — job definition for the optimization DAG
+
+## Related Documentation
+
+- [Authentication & Permissions](03-authentication-and-permissions.md) — SP-based execution model
+- [IQ Scanner](05-iq-scanner.md) — checks 11–12 evaluate optimization results
+- [Fix Agent](06-fix-agent.md) — the simpler, scan-driven alternative
+- [Operations Guide](09-operations-guide.md) — managing the GSO job

--- a/docs/08-deployment-guide.md
+++ b/docs/08-deployment-guide.md
@@ -1,0 +1,212 @@
+# Deployment Guide
+
+Genie Workbench is deployed as a Databricks App using the provided deploy scripts. This guide covers first-time setup, subsequent deploys, teardown, and configuration.
+
+## Prerequisites
+
+- [Databricks CLI](https://docs.databricks.com/dev-tools/cli/install.html) **v0.239.0+** (validated by preflight)
+- [uv](https://docs.astral.sh/uv/) — Python package manager
+- Node.js 18+ and npm
+- Python 3.11+
+- A Databricks workspace with:
+  - Apps enabled
+  - A SQL Warehouse (Serverless recommended)
+  - A Unity Catalog with CREATE SCHEMA permission
+  - MLflow Prompt Registry enabled (required for Auto-Optimize judge prompts)
+
+## First-Time Setup
+
+### 1. Clone the repo
+
+```bash
+git clone <repo-url>
+cd databricks-genie-workbench
+```
+
+### 2. Authenticate with Databricks CLI
+
+```bash
+databricks auth login --profile <workspace-profile>
+```
+
+> **Do NOT run `databricks bundle init`** — it overwrites the project configuration.
+
+### 3. Run the guided installer
+
+```bash
+./scripts/install.sh
+```
+
+The installer will:
+
+1. Check prerequisites (CLI version, Node, Python, npm, uv)
+2. Ask for your Databricks CLI profile
+3. Ask for catalog (auto-discovered from your workspace)
+4. Ask for SQL warehouse (auto-discovered)
+5. Ask for LLM model endpoint
+6. Optionally configure MLflow tracing (creates or links an experiment)
+7. Ask for Lakebase instance name
+8. Ask for app name
+9. Write `.env.deploy` with your configuration
+10. Run `scripts/deploy.sh` to build and deploy the app
+11. Resolve the app's service principal
+12. Optionally grant the SP access to your existing Genie Spaces
+
+### 4. Attach Lakebase (optional but recommended)
+
+Without Lakebase, scan results and starred spaces are lost on app restart.
+
+> If you used `install.sh`, it already collected your Lakebase instance name (stored as `GENIE_LAKEBASE_INSTANCE` in `.env.deploy`). You still need to attach the resource manually.
+
+**Create a Lakebase instance** (if you don't have one):
+1. In the workspace UI, go to **Catalog → Lakebase**
+2. Click **Create** → name it (e.g. `genie-workbench`), capacity **CU_1**
+
+**Grant the app's SP access:**
+1. Go to **Databases → your instance → Roles**
+2. Find the app's SP and grant **CREATEDB** attribute
+3. Go to **Databases → your instance → Permissions** and grant **Can manage**
+
+**Attach to your app:**
+1. Open **Databricks Apps UI** → your app → **Resources**
+2. Click **+ Add resource** → **PostgreSQL (Lakebase)** → select your instance
+3. Set resource key to `postgres` with **CAN_CONNECT_AND_CREATE** permission
+4. Save and **redeploy** — the app auto-creates the `genie` schema and all tables
+
+## What `deploy.sh` Does
+
+### Full Deploy (8 steps)
+
+1. **Pre-flight checks** — validates tools, CLI profile, warehouse, catalog, app state
+2. **Build frontend** — `npm ci` + `npm run build` (strict lockfile)
+3. **Create app** — `databricks apps create` (skipped if app already exists)
+4. **Sync files** — `databricks sync --full` + explicit `frontend/dist/` upload
+5. **Grant UC permissions** — resolves app SP, creates GSO schema/tables, grants SP access, enables CDF
+6. **Set up optimization job** — builds GSO wheel, uploads notebooks, creates/finds the Databricks job, grants SP CAN_MANAGE
+7. **Redeploy app** — patches `app.yaml` with config values, configures scopes, deploys
+8. **Verify** — checks critical files, waits for deployment to succeed
+
+### Deploy Commands
+
+```bash
+./scripts/deploy.sh                           # Full deploy
+./scripts/deploy.sh --update                  # Code-only update (skips app creation)
+./scripts/deploy.sh --destroy                 # Tear down app and clean up jobs
+./scripts/deploy.sh --destroy --auto-approve  # Tear down without confirmation
+```
+
+### What `--update` skips
+
+`--update` skips step 3 (app creation). Use it for iterating on code changes after the initial deploy.
+
+### What `--destroy` cleans up (and what it doesn't)
+
+`--destroy` deletes:
+- The Databricks App
+- Runtime-created jobs
+- The bundle-managed optimization job
+
+It does **not** remove:
+- Lakebase data (the `genie` schema in `databricks_postgres`)
+- Unity Catalog schema/tables (`<catalog>.genie_space_optimizer` and its tables)
+- Genie Space SP permissions granted during install
+- MLflow experiments created during install
+- Synced tables (if manually created)
+
+Clean these up manually if you want a full teardown.
+
+## Configuration Reference
+
+Set these in `.env.deploy` or as environment variables:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `GENIE_WAREHOUSE_ID` | Yes | — | SQL Warehouse ID |
+| `GENIE_CATALOG` | Yes | — | Unity Catalog name (needs CREATE SCHEMA) |
+| `GENIE_APP_NAME` | No | `genie-workbench` | Databricks App name (unique in workspace) |
+| `GENIE_DEPLOY_PROFILE` | No | `DEFAULT` | Databricks CLI profile name |
+| `GENIE_LLM_MODEL` | No | `databricks-claude-sonnet-4-6` | LLM serving endpoint |
+| `GENIE_LAKEBASE_INSTANCE` | No | `<app-name>` | Lakebase instance name |
+
+## Manual Setup (without installer)
+
+If you prefer non-interactive setup:
+
+### 1. Create `.env.deploy`
+
+```bash
+cat > .env.deploy <<'EOF'
+GENIE_WAREHOUSE_ID=<your-sql-warehouse-id>
+GENIE_CATALOG=<your-catalog-name>
+GENIE_APP_NAME=genie-workbench
+GENIE_DEPLOY_PROFILE=genie-workbench
+GENIE_LLM_MODEL=databricks-claude-sonnet-4-6
+GENIE_LAKEBASE_INSTANCE=genie-workbench
+EOF
+```
+
+### 2. Deploy
+
+```bash
+./scripts/deploy.sh
+```
+
+## Platform Build Strategy
+
+The Databricks Apps platform detects `package.json` at the root and runs `npm install` then `npm run build`. To avoid cross-platform failures and redundant rebuilds:
+
+- **Root `postinstall`**: No-op. Frontend deps are installed by `deploy.sh` locally.
+- **Root `build`**: Checks for pre-built `frontend/dist/index.html`. If present (uploaded by `deploy.sh`), skips the rebuild. Falls back to a full build only if dist is missing.
+- **Python deps**: Use `uv sync` on the platform (because `requirements.txt` is excluded via `.databricksignore`). This gives a clean venv with SHA256-verified hashes.
+
+## Dependency Security
+
+All dependencies are pinned to exact versions with integrity hashes. Lock files are the source of truth.
+
+| File | Covers | Verification |
+|------|--------|-------------|
+| `uv.lock` | Root Python transitive deps | SHA256 hashes |
+| `packages/genie-space-optimizer/uv.lock` | GSO Python deps | SHA256 hashes |
+| `frontend/package-lock.json` | Frontend npm deps | SHA-512 integrity |
+| `packages/genie-space-optimizer/bun.lock` | GSO UI deps | Integrity hashes |
+
+### Updating Python dependencies
+
+```bash
+uv lock --upgrade-package <package-name>
+uv export --frozen --no-dev --no-hashes --format requirements-txt \
+  | grep -v "^-e " > requirements.txt
+echo "-e ./packages/genie-space-optimizer" >> requirements.txt
+git add uv.lock requirements.txt
+```
+
+> Do not edit `requirements.txt` manually. It is generated from `uv.lock`.
+
+### Updating npm dependencies
+
+```bash
+cd frontend
+npm install <package>@<new-version>
+# Update package.json to exact version (remove ^ prefix)
+git add package.json package-lock.json
+```
+
+## Typical Workflow
+
+```bash
+# First time
+./scripts/install.sh
+
+# After code changes
+./scripts/deploy.sh --update
+
+# Tear down
+./scripts/deploy.sh --destroy
+```
+
+## Related Documentation
+
+- [Operations Guide](09-operations-guide.md) — post-deploy monitoring and management
+- [Authentication & Permissions](03-authentication-and-permissions.md) — SP permissions granted during deploy
+- [Troubleshooting](appendices/B-troubleshooting.md) — common deployment issues
+- [Environment Variables](appendices/C-environment-variables.md) — full variable reference

--- a/docs/09-operations-guide.md
+++ b/docs/09-operations-guide.md
@@ -1,0 +1,146 @@
+# Operations Guide
+
+This guide covers day-to-day operations for a deployed Genie Workbench instance: Lakebase management, MLflow configuration, monitoring, and GSO job management.
+
+## Lakebase
+
+### Schema and Tables
+
+The app stores data in the `genie` schema within the `databricks_postgres` database. Tables are auto-created on first startup:
+
+| Table | Purpose |
+|-------|---------|
+| `scan_results` | IQ scan history: score, maturity, checks, findings, timestamps |
+| `starred_spaces` | User-starred spaces for quick access |
+| `seen_spaces` | Tracks which spaces the user has visited |
+| `optimization_runs` | Legacy optimization accuracy records (used by scanner checks 11–12) |
+| `agent_sessions` | Create agent session persistence (message history, step state) |
+
+### Credential Refresh
+
+Lakebase credentials are auto-generated via the Databricks SDK (`/api/2.0/database/credentials`). These OAuth tokens expire after ~1 hour, so the app recreates the asyncpg connection pool every **50 minutes** to stay ahead of expiration.
+
+### Graceful Degradation
+
+If `LAKEBASE_HOST` is not configured (no Lakebase attached), the app falls back to **in-memory dictionaries**. The app remains fully functional but:
+
+- Scan results are lost on restart
+- Starred spaces are lost on restart
+- Agent sessions are lost on restart
+- The Admin Dashboard shows no historical data
+
+### Troubleshooting Lakebase
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "Failed to list spaces" | Lakebase not attached | Attach a `postgres` resource in Apps UI |
+| Connection errors after ~1 hour | Token refresh failed | Check app logs for credential generation errors |
+| Tables not created | SP lacks CREATEDB | Grant CREATEDB role on the Lakebase instance |
+
+## MLflow
+
+### Experiment Tracking
+
+LLM calls in the fix agent, create agent, and optimization pipeline are traced via MLflow. Tracing is **optional** — controlled by the `MLFLOW_EXPERIMENT_ID` environment variable in `app.yaml`.
+
+At startup, the app validates that the experiment ID exists in the workspace. If it doesn't, tracing is silently disabled (the variable is cleared).
+
+### Prompt Registry
+
+Auto-Optimize requires MLflow Prompt Registry for versioned judge prompts. If Prompt Registry is not enabled on the workspace, the optimization preflight task will fail with `FEATURE_DISABLED`.
+
+### Configuration
+
+```yaml
+# In app.yaml
+- name: MLFLOW_TRACKING_URI
+  value: "databricks"
+- name: MLFLOW_REGISTRY_URI
+  value: "databricks-uc"
+- name: MLFLOW_EXPERIMENT_ID
+  value: "<your-experiment-id>"
+```
+
+The experiment ID is workspace-specific. The installer can create one during setup, or you can create one manually and update `app.yaml`.
+
+## Monitoring
+
+### App Logs
+
+```bash
+databricks apps logs <app-name> --profile <profile>
+```
+
+### App Status
+
+```bash
+databricks apps get <app-name> --profile <profile>
+```
+
+### Verify Workspace Files
+
+```bash
+databricks workspace list /Workspace/Users/<email>/<app-name>/backend --profile <profile>
+```
+
+### Key Log Patterns
+
+| Log Pattern | Meaning |
+|-------------|---------|
+| `OBO: using user token for /api/...` | Request authenticated via user's OBO token |
+| `OBO: no x-forwarded-access-token, using SP` | No user token — using SP (expected for health checks) |
+| `OBO token lacks genie scope, retrying with service principal` | Genie API scope fallback triggered |
+| `Lakebase pool created` | Database connection established |
+| `Lakebase pool re-created (credential refresh)` | Scheduled 50-minute token refresh |
+| `Failed to persist scan result` | Lakebase write failed (check connectivity) |
+
+## GSO Job Management
+
+### Job Creation
+
+The optimization job is created automatically during `deploy.sh` via `databricks bundle deploy -t app`. It uses Terraform state scoped to the deployer.
+
+### Job Reuse
+
+If the job already exists (from a previous deploy), it is reused. To force recreation:
+
+1. Delete the job in the Databricks UI
+2. Re-run `./scripts/deploy.sh --update`
+
+### `ensure_job_run_as` Self-Healing
+
+At app startup, `_ensure_gso_job_run_as()` checks that the optimization job's `run_as` matches the current app SP. If they don't match (e.g., the app was redeployed with a different SP), the job is automatically updated. This avoids manual reconfiguration when the app identity changes.
+
+### Bundle Management
+
+The GSO job is managed by Databricks Asset Bundles (DABs):
+
+```bash
+# Deploy/update the job (done automatically by deploy.sh)
+databricks bundle deploy -t app --profile <profile>
+```
+
+**Important:** Do NOT run `databricks bundle deploy -t dev` for production deployments — it creates `[dev username]` prefixed orphan jobs with separate Terraform state.
+
+The `app` target uses `mode: development` for per-deployer Terraform state with `presets.name_prefix: ""` for clean job names.
+
+### Post-Deploy: Genie Space Access
+
+After deploying, the app's SP needs access to Genie Spaces for API fallback and optimization:
+
+1. The installer grants SP access to your existing Genie Spaces
+2. For spaces created after install, share them with the SP (`CAN_MANAGE`)
+3. Grant SP `SELECT` on referenced schemas:
+
+```sql
+GRANT SELECT ON SCHEMA <catalog>.<schema> TO `<service-principal-name>`;
+```
+
+See [Authentication & Permissions](03-authentication-and-permissions.md) for the full permission model.
+
+## Related Documentation
+
+- [Deployment Guide](08-deployment-guide.md) — initial setup and deploy commands
+- [Authentication & Permissions](03-authentication-and-permissions.md) — SP permissions
+- [Auto-Optimize](07-auto-optimize.md) — the pipeline managed by the GSO job
+- [Troubleshooting](appendices/B-troubleshooting.md) — common issues

--- a/docs/appendices/A-api-reference.md
+++ b/docs/appendices/A-api-reference.md
@@ -1,0 +1,102 @@
+# Appendix A: API Reference
+
+All API endpoints are prefixed with `/api` and served by FastAPI routers. This reference lists every endpoint with its HTTP method, auth identity, and purpose.
+
+**Auth identity key:**
+- **OBO** — uses the signed-in user's On-Behalf-Of token
+- **SP** — uses the app's Service Principal
+- **OBO → SP** — tries OBO first, falls back to SP on scope error
+- **Mixed** — uses both identities for different parts of the operation
+
+## Analysis Router (`/api`)
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| POST | `/api/space/fetch` | OBO → SP | Fetch serialized Genie Space by ID |
+| POST | `/api/space/parse` | None | Parse pasted Genie API JSON (client-side data, no auth needed) |
+| GET | `/api/debug/auth` | OBO | Dev-only auth debug endpoint (404 on Databricks Apps) |
+| GET | `/api/settings` | None | Read-only app settings (LLM model, warehouse, host) |
+
+## Spaces Router (`/api`)
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/spaces` | OBO → SP | List Genie Spaces with IQ scores, starred sort, filters |
+| GET | `/api/spaces/{space_id}` | OBO | Space metadata + latest scan + star status |
+| POST | `/api/spaces/{space_id}/scan` | OBO | Run IQ scan and persist result to Lakebase |
+| GET | `/api/spaces/{space_id}/history` | OBO | Scan + auto-optimize run history for a space |
+| PUT | `/api/spaces/{space_id}/star` | OBO | Toggle starred status (Lakebase) |
+| POST | `/api/spaces/{space_id}/fix` | OBO | **SSE** — Fix agent: stream patches and progress |
+
+## Admin Router (`/api/admin`)
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/admin/dashboard` | OBO | Org-wide stats: space count, scan count, avg score, maturity distribution |
+| GET | `/api/admin/leaderboard` | OBO | Top/bottom spaces by IQ score (`top_n` param) |
+| GET | `/api/admin/alerts` | OBO | Spaces with "Not Ready" maturity (max 20) |
+
+## Auth Router (`/api/auth`)
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/auth/me` | OBO | Current user info from OBO headers, dev env, or SDK |
+| GET | `/api/auth/status` | OBO | Lightweight health check with workspace client / auth type |
+
+## Create Router (`/api/create`)
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/create/discover/catalogs` | OBO | List Unity Catalog catalogs |
+| GET | `/api/create/discover/schemas` | OBO | List schemas in a catalog |
+| GET | `/api/create/discover/tables` | OBO | List tables in a catalog.schema |
+| GET | `/api/create/discover/columns` | OBO | List columns for a table |
+| POST | `/api/create/validate` | OBO | Validate serialized space config (errors/warnings) |
+| POST | `/api/create` | OBO | Create Genie Space from wizard payload |
+| POST | `/api/create/agent/chat` | OBO | **SSE** — Create agent conversational flow |
+| GET | `/api/create/agent/sessions/{session_id}` | OBO | Load agent session for refresh/reconnect |
+| DELETE | `/api/create/agent/sessions/{session_id}` | OBO | Delete agent session |
+
+## Auto-Optimize Router (`/api/auto-optimize`)
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/auto-optimize/health` | SP | GSO health check: job/warehouse configuration status |
+| GET | `/api/auto-optimize/permissions/{space_id}` | Mixed | Pre-check SP manage + UC read + Prompt Registry |
+| POST | `/api/auto-optimize/trigger` | Mixed | Start GSO optimization job (OBO for auth, SP for job submission) |
+| GET | `/api/auto-optimize/runs/{run_id}` | SP | Full run detail: stages, steps, levers, links |
+| GET | `/api/auto-optimize/runs/{run_id}/status` | SP | Lightweight status poll: steps, scores |
+| GET | `/api/auto-optimize/levers` | None | List optimization lever definitions |
+| POST | `/api/auto-optimize/runs/{run_id}/apply` | OBO | Apply optimization results to the Genie Space |
+| POST | `/api/auto-optimize/runs/{run_id}/discard` | Mixed | Discard run / rollback changes |
+| GET | `/api/auto-optimize/spaces/{space_id}/active-run` | SP | Check for QUEUED/IN_PROGRESS run |
+| GET | `/api/auto-optimize/spaces/{space_id}/runs` | SP | List optimization runs for a space |
+| GET | `/api/auto-optimize/runs/{run_id}/iterations` | SP | Per-iteration evaluation rows |
+| GET | `/api/auto-optimize/runs/{run_id}/debug-data` | SP | Diagnostics for Lakebase vs Delta data |
+| GET | `/api/auto-optimize/runs/{run_id}/asi-results` | SP | ASI judge results (requires `iteration` param) |
+| GET | `/api/auto-optimize/runs/{run_id}/question-results` | SP | Per-question results (requires `iteration` param) |
+| GET | `/api/auto-optimize/runs/{run_id}/patches` | SP | All patches for the run |
+| GET | `/api/auto-optimize/runs/{run_id}/suggestions` | SP | Strategist suggestions for the run |
+
+## Static File Serving (`main.py`)
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/` | None | Serve `index.html` (React SPA) |
+| GET | `/{full_path:path}` | None | Serve static assets from `frontend/dist/`, fallback to SPA |
+
+## SSE Streaming Endpoints
+
+Two endpoints use Server-Sent Events:
+
+| Endpoint | Keepalive | Events |
+|----------|-----------|--------|
+| `POST /api/spaces/{id}/fix` | 10s | `thinking`, `patch`, `applying`, `complete`, `error` |
+| `POST /api/create/agent/chat` | 15s | `session`, `step`, `thinking`, `tool_call`, `tool_result`, `message_delta`, `message`, `created`, `updated`, `heartbeat`, `error`, `done` |
+
+The frontend consumes SSE via manual `fetch` + `ReadableStream` in `lib/api.ts` (not `EventSource`). Buffers are split on `\n\n`.
+
+## Related Documentation
+
+- [Authentication & Permissions](../03-authentication-and-permissions.md) — which identity is used where and why
+- [Architecture Overview](../02-architecture-overview.md) — router and service structure

--- a/docs/appendices/B-troubleshooting.md
+++ b/docs/appendices/B-troubleshooting.md
@@ -1,0 +1,82 @@
+# Appendix B: Troubleshooting
+
+## Common Issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| App shows blank page | `frontend/dist/` missing (gitignored, not synced) | Re-run `./scripts/deploy.sh --update` |
+| `Could not import module "backend.main"` | Source files missing on workspace | Re-run `./scripts/deploy.sh --update` (full sync) |
+| `No dependencies file found` | `requirements.txt` not on workspace | Re-run `./scripts/deploy.sh --update` |
+| "Failed to list spaces" | Lakebase not attached | Attach a `postgres` resource in Apps UI |
+| `Catalog 'X' is not accessible` | Wrong catalog or missing permissions | `databricks catalogs list --profile <profile>` |
+| `Invalid SQL warehouse resource` | Warehouse doesn't exist or no CAN_USE | `databricks warehouses list --profile <profile>` |
+| `Maximum number of apps` | Workspace hit the 300-app limit | Delete unused apps |
+| Auto-Optimize fails at "Baseline Evaluation" with `FEATURE_DISABLED` | Prompt Registry not enabled | Contact workspace admin to enable MLflow Prompt Registry |
+| Unresolved `__GSO_*__` placeholders | `deploy.sh` couldn't patch `app.yaml` | Ensure `GENIE_CATALOG` is set; check deploy output for warnings |
+| GSO job creation fails during deploy | Bundle deploy failed (CLI version, auth, or build issue) | Check `databricks bundle deploy -t app` output; ensure CLI >= 0.239.0 and `pip install build` |
+| Notebook upload fails (`RESOURCE_DOES_NOT_EXIST`) | `/Workspace/Shared/` not writable by deployer | Check workspace-level permissions on the upload path |
+
+## Permission Errors
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "You need CAN_EDIT or CAN_MANAGE permission" on optimize trigger | User lacks permission on the Genie Space | Share the space with the user (CAN_EDIT or CAN_MANAGE) |
+| "The service principal does not have CAN_MANAGE" | SP not shared on the Genie Space | Share the space with the app's SP (CAN_MANAGE) |
+| "OBO token lacks genie scope, retrying with service principal" (in logs) | User token missing `dashboards.genie` scope | This is handled automatically via SP fallback — no action needed unless SP also fails |
+| Optimization job fails with catalog/schema access errors | SP lacks UC permissions on referenced data | Grant `SELECT` on referenced schemas to the SP |
+| "Permission denied" on scan | User lacks access to the Genie Space | Share the space with the user |
+
+## Lakebase Issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "Failed to list spaces" on first load | Lakebase not attached | Attach a `postgres` resource with key `postgres` in Apps UI |
+| Connection timeouts after ~1 hour | Credential refresh failed | Check logs for `database.generate_database_credential` errors |
+| Tables not created on startup | SP lacks CREATEDB on Lakebase | Grant CREATEDB role on the Lakebase instance |
+| Scan results not persisting | Lakebase write failed | Check logs for `Failed to persist scan result` |
+| Agent sessions lost on restart | Lakebase not configured | Without Lakebase, sessions use in-memory storage (ephemeral) |
+
+## GSO / Auto-Optimize Issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "GSO not configured" in health check | `GSO_JOB_ID` or `GSO_CATALOG` not set | Re-run `./scripts/deploy.sh` (patches `app.yaml` with values from bundle state) |
+| Optimization job never starts | Job doesn't exist or SP can't run it | Check job exists in workspace; verify SP has CAN_MANAGE on job |
+| Job stuck in QUEUED | No available cluster or warehouse | Check cluster policies and warehouse availability |
+| "Baseline Evaluation" fails | Benchmark questions reference inaccessible tables | Grant SP `SELECT` on all referenced schemas |
+| "FEATURE_DISABLED" during preflight | MLflow Prompt Registry not enabled | Contact workspace admin to enable it |
+| Patches generated but accuracy doesn't improve | Optimization strategy exhausted | Run may reach `STALLED` status — review suggestions for manual improvements |
+| `__GSO_*__` values in running app | `deploy.sh` didn't patch `app.yaml` before deploy | Check `GENIE_CATALOG` in `.env.deploy`; re-run deploy |
+
+## Debug Commands
+
+```bash
+# View app logs
+databricks apps logs <app-name> --profile <profile>
+
+# Check app status
+databricks apps get <app-name> --profile <profile>
+
+# List workspace files to verify sync
+databricks workspace list /Workspace/Users/<email>/<app-name>/backend --profile <profile>
+
+# Check GSO job status
+databricks jobs get <job-id> --profile <profile>
+
+# List GSO job runs
+databricks jobs list-runs --job-id <job-id> --profile <profile>
+
+# Check SP identity
+databricks apps get <app-name> --profile <profile> | grep service_principal
+```
+
+## MLflow Tracing
+
+> `MLFLOW_EXPERIMENT_ID` is workspace-specific. The app validates it at startup and silently disables tracing if the experiment doesn't exist. To enable tracing, create an MLflow experiment and update the value in `app.yaml` before deploying.
+
+## Related Documentation
+
+- [Deployment Guide](../08-deployment-guide.md) — deploy commands and configuration
+- [Operations Guide](../09-operations-guide.md) — monitoring and management
+- [Authentication & Permissions](../03-authentication-and-permissions.md) — permission model
+- [Environment Variables](C-environment-variables.md) — full variable reference

--- a/docs/appendices/C-environment-variables.md
+++ b/docs/appendices/C-environment-variables.md
@@ -1,0 +1,96 @@
+# Appendix C: Environment Variables
+
+## App Environment Variables (`app.yaml`)
+
+These variables are defined in `app.yaml` and injected into the app runtime. Placeholder values (e.g., `__GSO_CATALOG__`) are patched by `deploy.sh` before deployment.
+
+### MLflow Tracing
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `MLFLOW_TRACKING_URI` | `databricks` | MLflow tracking server (Databricks workspace) |
+| `MLFLOW_REGISTRY_URI` | `databricks-uc` | MLflow model registry (Unity Catalog) |
+| `MLFLOW_EXPERIMENT_ID` | `__MLFLOW_EXPERIMENT_ID__` | Experiment for tracing LLM calls. Workspace-specific; validated at startup, cleared if invalid |
+
+### LLM Model
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `LLM_MODEL` | `__LLM_MODEL__` | Databricks model serving endpoint for analysis, fix agent, create agent. Default: `databricks-claude-sonnet-4-6` |
+
+### SQL Warehouse
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `SQL_WAREHOUSE_ID` | `valueFrom: sql-warehouse` | SQL Warehouse ID, pulled from the app resource named `sql-warehouse` |
+
+### Genie Space Configuration
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `GENIE_TARGET_DIRECTORY` | `/Shared/` | Where new Genie Spaces are created. Override to a specific folder if needed |
+
+### Local Development
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `DEV_USER_EMAIL` | (empty) | User email for local dev auth. Only used when running outside Databricks Apps |
+
+### Lakebase PostgreSQL
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `LAKEBASE_HOST` | `valueFrom: postgres` | Hostname, injected from the `postgres` app resource |
+| `LAKEBASE_PORT` | `5432` | PostgreSQL port |
+| `LAKEBASE_DATABASE` | `databricks_postgres` | Database name (standard Lakebase default) |
+| `LAKEBASE_INSTANCE_NAME` | `__LAKEBASE_INSTANCE__` | Lakebase instance name (patched by deploy script) |
+
+### Auto-Optimize (GSO Engine)
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `GSO_CATALOG` | `__GSO_CATALOG__` | Unity Catalog for optimizer state tables. Patched from `.env.deploy` |
+| `GSO_SCHEMA` | `genie_space_optimizer` | Schema within the catalog for GSO tables (fixed name) |
+| `GSO_JOB_ID` | `__GSO_JOB_ID__` | Databricks Job ID for the optimization DAG. Patched from bundle deploy state |
+| `GSO_WAREHOUSE_ID` | `valueFrom: sql-warehouse` | SQL Warehouse for GSO queries |
+
+## Deploy Configuration Variables (`.env.deploy`)
+
+These variables are used by `deploy.sh` and `install.sh` at deploy time. They are **not** injected into the app runtime directly — instead, deploy scripts use them to patch `app.yaml` placeholders and configure resources.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `GENIE_WAREHOUSE_ID` | Yes | — | SQL Warehouse ID (hex string from warehouse URL or detail page) |
+| `GENIE_CATALOG` | Yes | — | Unity Catalog name (you need CREATE SCHEMA permission) |
+| `GENIE_APP_NAME` | No | `genie-workbench` | Databricks App name (must be unique in your workspace) |
+| `GENIE_DEPLOY_PROFILE` | No | `DEFAULT` | Databricks CLI profile name |
+| `GENIE_LLM_MODEL` | No | `databricks-claude-sonnet-4-6` | LLM serving endpoint for analysis |
+| `GENIE_LAKEBASE_INSTANCE` | No | `<app-name>` | Lakebase instance name (patched into `app.yaml` at deploy) |
+
+## How Variables Flow
+
+```
+.env.deploy                    app.yaml (template)              app.yaml (deployed)
+┌──────────────────┐          ┌───────────────────┐           ┌───────────────────┐
+│ GENIE_CATALOG=foo│─────────▶│ GSO_CATALOG:      │──────────▶│ GSO_CATALOG: foo  │
+│ GENIE_WAREHOUSE  │          │   __GSO_CATALOG__  │           │                   │
+│ GENIE_LLM_MODEL │          │ LLM_MODEL:        │           │ LLM_MODEL:        │
+│ ...              │          │   __LLM_MODEL__    │           │   claude-sonnet   │
+└──────────────────┘          └───────────────────┘           └───────────────────┘
+                                                                       │
+                                 deploy.sh patches                     │
+                                 placeholders with                     ▼
+                                 real values                    App Runtime
+                                                               (env vars available)
+```
+
+1. `install.sh` collects values and writes `.env.deploy`
+2. `deploy.sh` reads `.env.deploy` and patches `__PLACEHOLDER__` strings in `app.yaml`
+3. `databricks apps deploy` uploads the patched `app.yaml`
+4. The Databricks Apps platform injects env vars into the running container
+5. `valueFrom` variables (e.g., `LAKEBASE_HOST`, `SQL_WAREHOUSE_ID`) are resolved from app resources at runtime
+
+## Related Documentation
+
+- [Deployment Guide](../08-deployment-guide.md) — deploy workflow and configuration
+- [Operations Guide](../09-operations-guide.md) — MLflow and Lakebase management

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,16 @@
 /**
  * App - Genie Workbench root component.
- * Supports four top-level views: SpaceList, SpaceDetail, AdminDashboard, CreateSpace.
+ * Supports five top-level views: SpaceList, SpaceDetail, AdminDashboard, CreateSpace, HowItWorks.
  */
 import { useState, Component } from "react"
 import type { ReactNode, ErrorInfo } from "react"
-import { LayoutGrid, BarChart2 } from "lucide-react"
+import { LayoutGrid, BarChart2, BookOpen } from "lucide-react"
 import { ThemeToggle } from "@/components/ThemeToggle"
 import { useTheme } from "@/hooks/useTheme"
 import { SpaceList } from "@/pages/SpaceList"
 import { SpaceDetail } from "@/pages/SpaceDetail"
 import { AdminDashboard } from "@/pages/AdminDashboard"
+import { HowItWorks } from "@/pages/HowItWorks"
 import { CreateAgentChat } from "@/components/CreateAgentChat"
 
 class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
@@ -31,7 +32,7 @@ class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | 
   }
 }
 
-type View = "list" | "detail" | "admin" | "create"
+type View = "list" | "detail" | "admin" | "create" | "how-it-works"
 
 interface DetailState {
   spaceId: string
@@ -68,6 +69,11 @@ export default function App() {
 
   const handleNavCreate = () => {
     setCurrentView("create")
+    setDetailState(null)
+  }
+
+  const handleNavHowItWorks = () => {
+    setCurrentView("how-it-works")
     setDetailState(null)
   }
 
@@ -118,6 +124,17 @@ export default function App() {
               <BarChart2 className="w-4 h-4" />
               Admin
             </button>
+            <button
+              onClick={handleNavHowItWorks}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                currentView === "how-it-works"
+                  ? "bg-accent/10 text-accent"
+                  : "text-muted hover:text-secondary hover:bg-surface-secondary"
+              }`}
+            >
+              <BookOpen className="w-4 h-4" />
+              How It Works
+            </button>
           </nav>
 
           <ThemeToggle />
@@ -144,6 +161,10 @@ export default function App() {
 
         {currentView === "admin" && (
           <AdminDashboard onSelectSpace={handleSelectSpace} />
+        )}
+
+        {currentView === "how-it-works" && (
+          <HowItWorks />
         )}
 
         {/* CreateAgentChat stays mounted (hidden when inactive) so SSE streams

--- a/frontend/src/components/how-it-works/FeatureCard.tsx
+++ b/frontend/src/components/how-it-works/FeatureCard.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+interface FeatureCardProps {
+  icon: ReactNode
+  title: string
+  description: string
+  accentColor: string
+  glowColor: string
+  className?: string
+}
+
+export function FeatureCard({ icon, title, description, accentColor, glowColor, className }: FeatureCardProps) {
+  return (
+    <div
+      className={cn(
+        "group relative rounded-xl border border-default bg-surface p-6",
+        "transition-all duration-300 hover:scale-[1.02] hover:shadow-lg",
+        "dark:card-glow",
+        className,
+      )}
+    >
+      <div
+        className="absolute inset-0 rounded-xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+        style={{ background: `radial-gradient(ellipse at 50% 0%, ${glowColor}, transparent 70%)` }}
+      />
+
+      <div className="relative">
+        <div
+          className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg"
+          style={{ background: `linear-gradient(135deg, ${accentColor}20, ${accentColor}40)` }}
+        >
+          <div style={{ color: accentColor }}>{icon}</div>
+        </div>
+
+        <h3 className="mb-2 text-lg font-display font-bold text-primary">{title}</h3>
+        <p className="text-sm leading-relaxed text-secondary">{description}</p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/how-it-works/PermissionDiagram.tsx
+++ b/frontend/src/components/how-it-works/PermissionDiagram.tsx
@@ -1,0 +1,125 @@
+import { User, Bot, ArrowRight } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface PermRow {
+  operation: string
+  identity: "user" | "service-principal" | "both"
+  note?: string
+}
+
+const rows: PermRow[] = [
+  { operation: "Browse Unity Catalog", identity: "user" },
+  { operation: "Query Genie Spaces", identity: "user", note: "Falls back to SP if scope missing" },
+  { operation: "Create Genie Space", identity: "user" },
+  { operation: "IQ Scan (Score)", identity: "user" },
+  { operation: "Fix Agent (Apply Patches)", identity: "user" },
+  { operation: "Trigger Auto-Optimize", identity: "both", note: "User triggers, SP executes job" },
+  { operation: "Run Optimization Job", identity: "service-principal" },
+  { operation: "Read/Write Lakebase", identity: "service-principal" },
+]
+
+export function PermissionDiagram({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-6", className)}>
+      {/* Visual: two identity lanes */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* OBO Lane */}
+        <div className="rounded-xl border-2 border-accent/30 bg-accent/5 p-5">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-accent/20">
+              <User className="h-5 w-5 text-accent" />
+            </div>
+            <div>
+              <h4 className="font-display font-bold text-primary text-sm">On-Behalf-Of (OBO)</h4>
+              <p className="text-xs text-muted">User's own identity via token</p>
+            </div>
+          </div>
+          <div className="space-y-2">
+            {["Browse catalogs & schemas", "List & query Genie Spaces", "Create new Genie Spaces", "Score spaces (IQ Scan)", "Apply fixes (Fix Agent)", "Trigger optimization"].map(
+              (item) => (
+                <div key={item} className="flex items-center gap-2 text-sm text-secondary">
+                  <div className="h-1.5 w-1.5 rounded-full bg-accent shrink-0" />
+                  {item}
+                </div>
+              ),
+            )}
+          </div>
+        </div>
+
+        {/* SP Lane */}
+        <div className="rounded-xl border-2 border-cyan/30 bg-cyan/5 p-5">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-cyan/20">
+              <Bot className="h-5 w-5 text-cyan" />
+            </div>
+            <div>
+              <h4 className="font-display font-bold text-primary text-sm">Service Principal (SP)</h4>
+              <p className="text-xs text-muted">App's own machine identity</p>
+            </div>
+          </div>
+          <div className="space-y-2">
+            {["Run optimization Lakeflow Job", "Read/write Lakebase storage", "Fallback for Genie API scope gap", "Access benchmark results", "Write optimization state", "Deploy approved changes"].map(
+              (item) => (
+                <div key={item} className="flex items-center gap-2 text-sm text-secondary">
+                  <div className="h-1.5 w-1.5 rounded-full bg-cyan shrink-0" />
+                  {item}
+                </div>
+              ),
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Handoff visual */}
+      <div className="flex items-center justify-center gap-3 py-3 px-4 rounded-lg bg-elevated border border-default">
+        <div className="flex items-center gap-1.5 text-xs font-medium text-accent">
+          <User className="h-4 w-4" /> User triggers
+        </div>
+        <ArrowRight className="h-4 w-4 text-muted" />
+        <div className="text-xs text-muted">permission verified</div>
+        <ArrowRight className="h-4 w-4 text-muted" />
+        <div className="flex items-center gap-1.5 text-xs font-medium text-cyan">
+          <Bot className="h-4 w-4" /> SP executes
+        </div>
+      </div>
+
+      {/* Detailed table */}
+      <div className="overflow-x-auto rounded-lg border border-default">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-elevated">
+              <th className="text-left font-semibold text-primary px-4 py-2.5">Operation</th>
+              <th className="text-center font-semibold text-primary px-4 py-2.5">Identity</th>
+              <th className="text-left font-semibold text-primary px-4 py-2.5">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.operation} className="border-t border-default">
+                <td className="px-4 py-2.5 text-secondary">{row.operation}</td>
+                <td className="px-4 py-2.5 text-center">
+                  {row.identity === "user" && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-accent/10 px-2.5 py-0.5 text-xs font-medium text-accent">
+                      <User className="h-3 w-3" /> OBO
+                    </span>
+                  )}
+                  {row.identity === "service-principal" && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-cyan/10 px-2.5 py-0.5 text-xs font-medium text-cyan">
+                      <Bot className="h-3 w-3" /> SP
+                    </span>
+                  )}
+                  {row.identity === "both" && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-warning/10 px-2.5 py-0.5 text-xs font-medium text-warning">
+                      OBO → SP
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-2.5 text-muted text-xs">{row.note ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/how-it-works/PipelineDiagram.tsx
+++ b/frontend/src/components/how-it-works/PipelineDiagram.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react"
+import { ChevronRight } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+export interface PipelineStep {
+  icon: ReactNode
+  label: string
+  description?: string
+  color: string
+}
+
+interface PipelineDiagramProps {
+  steps: PipelineStep[]
+  className?: string
+}
+
+export function PipelineDiagram({ steps, className }: PipelineDiagramProps) {
+  return (
+    <div className={cn("flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-0", className)}>
+      {steps.map((step, i) => (
+        <div key={i} className="flex items-start sm:flex-1 sm:flex-col sm:items-center gap-3 sm:gap-0">
+          <div className="flex items-center gap-2 sm:gap-0 sm:flex-col sm:w-full">
+            {/* Step node */}
+            <div className="flex flex-col items-center">
+              <div
+                className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border-2 transition-colors"
+                style={{
+                  borderColor: step.color,
+                  background: `${step.color}15`,
+                }}
+              >
+                <div style={{ color: step.color }}>{step.icon}</div>
+              </div>
+            </div>
+
+            {/* Connector arrow (between nodes, not after last) */}
+            {i < steps.length - 1 && (
+              <ChevronRight
+                className="hidden sm:block h-5 w-5 text-muted self-center shrink-0 mx-auto"
+                style={{ marginTop: 0 }}
+              />
+            )}
+          </div>
+
+          {/* Label + description */}
+          <div className="sm:mt-2.5 sm:text-center sm:px-1">
+            <span className="text-xs font-semibold text-primary leading-tight block">{step.label}</span>
+            {step.description && (
+              <span className="text-[11px] text-muted leading-snug mt-0.5 block">{step.description}</span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/how-it-works/PipelineDiagram.tsx
+++ b/frontend/src/components/how-it-works/PipelineDiagram.tsx
@@ -16,41 +16,62 @@ interface PipelineDiagramProps {
 
 export function PipelineDiagram({ steps, className }: PipelineDiagramProps) {
   return (
-    <div className={cn("flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-0", className)}>
-      {steps.map((step, i) => (
-        <div key={i} className="flex items-start sm:flex-1 sm:flex-col sm:items-center gap-3 sm:gap-0">
-          <div className="flex items-center gap-2 sm:gap-0 sm:flex-col sm:w-full">
-            {/* Step node */}
-            <div className="flex flex-col items-center">
+    <div className={cn("", className)}>
+      {/* Mobile: vertical stack */}
+      <div className="flex flex-col gap-3 sm:hidden">
+        {steps.map((step, i) => (
+          <div key={i} className="flex items-start gap-3">
+            <div
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border-2"
+              style={{ borderColor: step.color, background: `${step.color}15` }}
+            >
+              <div style={{ color: step.color }}>{step.icon}</div>
+            </div>
+            <div className="pt-0.5">
+              <span className="text-xs font-semibold text-primary leading-tight block">{step.label}</span>
+              {step.description && (
+                <span className="text-[11px] text-muted leading-snug mt-0.5 block">{step.description}</span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Desktop: two-row layout — icons+arrows row, labels row */}
+      <div className="hidden sm:block">
+        {/* Row 1: icons interleaved with chevron arrows */}
+        <div className="flex items-center justify-center">
+          {steps.map((step, i) => (
+            <div key={i} className="flex items-center">
               <div
-                className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border-2 transition-colors"
-                style={{
-                  borderColor: step.color,
-                  background: `${step.color}15`,
-                }}
+                className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border-2"
+                style={{ borderColor: step.color, background: `${step.color}15` }}
               >
                 <div style={{ color: step.color }}>{step.icon}</div>
               </div>
+              {i < steps.length - 1 && (
+                <ChevronRight className="h-5 w-5 text-muted mx-2 shrink-0" />
+              )}
             </div>
-
-            {/* Connector arrow (between nodes, not after last) */}
-            {i < steps.length - 1 && (
-              <ChevronRight
-                className="hidden sm:block h-5 w-5 text-muted self-center shrink-0 mx-auto"
-                style={{ marginTop: 0 }}
-              />
-            )}
-          </div>
-
-          {/* Label + description */}
-          <div className="sm:mt-2.5 sm:text-center sm:px-1">
-            <span className="text-xs font-semibold text-primary leading-tight block">{step.label}</span>
-            {step.description && (
-              <span className="text-[11px] text-muted leading-snug mt-0.5 block">{step.description}</span>
-            )}
-          </div>
+          ))}
         </div>
-      ))}
+
+        {/* Row 2: labels aligned under each icon */}
+        <div className="flex justify-center mt-2.5">
+          {steps.map((step, i) => (
+            <div key={i} className="flex items-start">
+              <div className="w-11 text-center shrink-0">
+                <span className="text-xs font-semibold text-primary leading-tight block">{step.label}</span>
+                {step.description && (
+                  <span className="text-[11px] text-muted leading-snug mt-0.5 block">{step.description}</span>
+                )}
+              </div>
+              {/* Spacer matching the chevron+margin width */}
+              {i < steps.length - 1 && <div className="w-9 shrink-0" />}
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/how-it-works/StageCard.tsx
+++ b/frontend/src/components/how-it-works/StageCard.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+interface StageCardProps {
+  title: string
+  subtitle?: string
+  icon?: ReactNode
+  children: ReactNode
+  className?: string
+}
+
+export function StageCard({ title, subtitle, icon, children, className }: StageCardProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-default bg-surface overflow-hidden",
+        "dark:card-glow",
+        className,
+      )}
+    >
+      <div className="border-b border-default bg-elevated/50 px-6 py-4">
+        <div className="flex items-center gap-3">
+          {icon && (
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent/10 text-accent">
+              {icon}
+            </div>
+          )}
+          <div>
+            <h3 className="font-display font-bold text-primary">{title}</h3>
+            {subtitle && <p className="text-sm text-muted mt-0.5">{subtitle}</p>}
+          </div>
+        </div>
+      </div>
+      <div className="p-6">{children}</div>
+    </div>
+  )
+}

--- a/frontend/src/pages/HowItWorks.tsx
+++ b/frontend/src/pages/HowItWorks.tsx
@@ -147,16 +147,10 @@ export function HowItWorks() {
         </span>
 
         <button
-          onClick={goNext}
-          disabled={activeStage === stages.length - 1}
-          className={cn(
-            "flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
-            activeStage === stages.length - 1
-              ? "text-muted/40 cursor-not-allowed"
-              : "text-secondary hover:text-primary hover:bg-elevated",
-          )}
+          onClick={activeStage === stages.length - 1 ? () => setActiveStage(0) : goNext}
+          className="flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors text-secondary hover:text-primary hover:bg-elevated"
         >
-          {activeStage < stages.length - 1 ? stages[activeStage + 1].label : "Next"} <ChevronRight className="h-4 w-4" />
+          {activeStage < stages.length - 1 ? stages[activeStage + 1].label : "Back to Overview"} <ChevronRight className="h-4 w-4" />
         </button>
       </div>
     </div>
@@ -302,25 +296,28 @@ function CreateAgentContent() {
    STAGE 2 — IQ Scanner
    ================================================================ */
 function IQScannerContent() {
-  const checks = [
-    { name: "Has Instructions", severity: "critical", desc: "Space has user-facing instructions" },
-    { name: "Has Sample Questions", severity: "critical", desc: "At least one sample question provided" },
-    { name: "Has Tables", severity: "critical", desc: "One or more tables attached" },
-    { name: "Table Descriptions", severity: "high", desc: "All tables have meaningful descriptions" },
-    { name: "Column Descriptions", severity: "high", desc: "Columns are well-documented" },
-    { name: "Instruction Length", severity: "medium", desc: "Instructions are detailed enough (>100 chars)" },
-    { name: "Question Count", severity: "medium", desc: "Multiple sample questions (3+)" },
-    { name: "Question Quality", severity: "medium", desc: "Questions are specific, not generic" },
-    { name: "Table Count", severity: "low", desc: "Appropriate number of tables" },
-    { name: "No Empty Descriptions", severity: "low", desc: "No placeholder or empty descriptions" },
-    { name: "Naming Conventions", severity: "low", desc: "Consistent, readable naming" },
-    { name: "Column Coverage", severity: "low", desc: "Sufficient % of columns documented" },
+  const configChecks = [
+    { name: "Tables exist", desc: "At least one table attached to the space" },
+    { name: "Table descriptions (≥80%)", desc: "80%+ of tables have meaningful descriptions" },
+    { name: "Column descriptions (≥50%)", desc: "50%+ of columns are documented" },
+    { name: "Text instructions (>50 chars)", desc: "Business context and terminology explained" },
+    { name: "Join specifications", desc: "Join paths defined for multi-table spaces" },
+    { name: "Table count 1–12", desc: "Optimal number of tables for accuracy" },
+    { name: "8+ example SQLs", desc: "Diverse query patterns for the model to learn" },
+    { name: "SQL snippets", desc: "Functions, expressions, measures, or filters defined" },
+    { name: "Entity/format matching", desc: "Categorical and date/number columns annotated" },
+    { name: "10+ benchmark questions", desc: "Ground-truth questions to measure accuracy" },
+  ]
+
+  const optimizationChecks = [
+    { name: "Optimization workflow completed", desc: "Space has been through the optimization pipeline" },
+    { name: "Optimization accuracy ≥ 85%", desc: "Benchmark accuracy meets the trusted threshold" },
   ]
 
   const tiers = [
-    { name: "Not Ready", range: "0–5", color: DANGER, icon: <XCircle className="h-5 w-5" />, desc: "Critical gaps — needs immediate attention" },
-    { name: "Ready to Optimize", range: "6–9", color: INFO, icon: <AlertTriangle className="h-5 w-5" />, desc: "Functional but has improvement areas" },
-    { name: "Trusted", range: "10–12", color: SUCCESS, icon: <CheckCircle2 className="h-5 w-5" />, desc: "Production-quality configuration" },
+    { name: "Not Ready", criteria: "Config gaps remain", color: DANGER, icon: <XCircle className="h-5 w-5" />, desc: "One or more of the 10 config checks fail" },
+    { name: "Ready to Optimize", criteria: "All config checks pass", color: INFO, icon: <AlertTriangle className="h-5 w-5" />, desc: "All 10 config checks pass — optimization pending" },
+    { name: "Trusted", criteria: "All 12 checks pass", color: SUCCESS, icon: <CheckCircle2 className="h-5 w-5" />, desc: "Config + optimization checks all pass" },
   ]
 
   return (
@@ -347,37 +344,41 @@ function IQScannerContent() {
               </div>
             </div>
             <h3 className="font-display font-bold text-primary text-base">{tier.name}</h3>
-            <div className="text-2xl font-bold mt-1" style={{ color: tier.color }}>{tier.range}</div>
-            <p className="text-xs text-muted mt-1">{tier.desc}</p>
+            <div className="text-sm font-semibold mt-1" style={{ color: tier.color }}>{tier.criteria}</div>
+            <p className="text-xs text-muted mt-1.5">{tier.desc}</p>
           </div>
         ))}
       </div>
 
       {/* Score gauge illustration */}
       <StageCard title="12 Quality Checks" subtitle="Each check contributes 1 point" icon={<Gauge className="h-4 w-4" />}>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-          {checks.map((check) => (
-            <div key={check.name} className="flex items-center gap-2.5 py-1.5">
-              <div
-                className="h-2 w-2 rounded-full shrink-0"
-                style={{
-                  background:
-                    check.severity === "critical" ? DANGER
-                    : check.severity === "high" ? WARNING
-                    : check.severity === "medium" ? INFO
-                    : SUCCESS,
-                }}
-              />
-              <span className="text-sm text-primary font-medium">{check.name}</span>
-              <span className="text-xs text-muted ml-auto hidden sm:block">{check.severity}</span>
-            </div>
-          ))}
+        <div className="mb-3">
+          <h4 className="text-xs font-semibold text-muted uppercase tracking-wide mb-2">Config Checks (1–10)</h4>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {configChecks.map((check) => (
+              <div key={check.name} className="flex items-start gap-2.5 py-1.5">
+                <div className="h-2 w-2 rounded-full shrink-0 mt-1.5" style={{ background: ACCENT }} />
+                <div>
+                  <span className="text-sm text-primary font-medium block">{check.name}</span>
+                  <span className="text-xs text-muted">{check.desc}</span>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
-        <div className="flex items-center gap-4 mt-4 pt-3 border-t border-default text-xs text-muted">
-          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full inline-block" style={{ background: DANGER }} /> Critical</span>
-          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full inline-block" style={{ background: WARNING }} /> High</span>
-          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full inline-block" style={{ background: INFO }} /> Medium</span>
-          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full inline-block" style={{ background: SUCCESS }} /> Low</span>
+        <div className="pt-3 border-t border-default">
+          <h4 className="text-xs font-semibold text-muted uppercase tracking-wide mb-2">Optimization Checks (11–12)</h4>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {optimizationChecks.map((check) => (
+              <div key={check.name} className="flex items-start gap-2.5 py-1.5">
+                <div className="h-2 w-2 rounded-full shrink-0 mt-1.5" style={{ background: SUCCESS }} />
+                <div>
+                  <span className="text-sm text-primary font-medium block">{check.name}</span>
+                  <span className="text-xs text-muted">{check.desc}</span>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       </StageCard>
     </div>

--- a/frontend/src/pages/HowItWorks.tsx
+++ b/frontend/src/pages/HowItWorks.tsx
@@ -1,0 +1,641 @@
+import { useState, useEffect, useCallback } from "react"
+import {
+  Sparkles,
+  MessageSquarePlus,
+  ShieldCheck,
+  Wrench,
+  Zap,
+  Lock,
+  Layers,
+  ChevronLeft,
+  ChevronRight,
+  Search,
+  Database,
+  FileText,
+  Settings,
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
+  Target,
+  BarChart3,
+  GitBranch,
+  RefreshCw,
+  ArrowRightLeft,
+  Gauge,
+  Box,
+  Globe,
+  HardDrive,
+  Network,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import { FeatureCard } from "@/components/how-it-works/FeatureCard"
+import { StageCard } from "@/components/how-it-works/StageCard"
+import { PipelineDiagram } from "@/components/how-it-works/PipelineDiagram"
+import type { PipelineStep } from "@/components/how-it-works/PipelineDiagram"
+import { PermissionDiagram } from "@/components/how-it-works/PermissionDiagram"
+
+const ACCENT = "#4F46E5"
+const CYAN = "#06B6D4"
+const SUCCESS = "#10B981"
+const WARNING = "#F59E0B"
+const DANGER = "#EF4444"
+const INFO = "#3B82F6"
+
+interface Stage {
+  id: string
+  label: string
+  icon: React.ReactNode
+  color: string
+}
+
+const stages: Stage[] = [
+  { id: "overview", label: "Overview", icon: <Sparkles className="h-4 w-4" />, color: ACCENT },
+  { id: "create", label: "Create Agent", icon: <MessageSquarePlus className="h-4 w-4" />, color: CYAN },
+  { id: "score", label: "IQ Scanner", icon: <ShieldCheck className="h-4 w-4" />, color: SUCCESS },
+  { id: "fix", label: "Fix Agent", icon: <Wrench className="h-4 w-4" />, color: WARNING },
+  { id: "optimize", label: "Auto-Optimize", icon: <Zap className="h-4 w-4" />, color: DANGER },
+  { id: "permissions", label: "Permissions", icon: <Lock className="h-4 w-4" />, color: INFO },
+  { id: "architecture", label: "Architecture", icon: <Layers className="h-4 w-4" />, color: ACCENT },
+]
+
+export function HowItWorks() {
+  const [activeStage, setActiveStage] = useState(0)
+
+  const goNext = useCallback(() => setActiveStage((s) => Math.min(s + 1, stages.length - 1)), [])
+  const goPrev = useCallback(() => setActiveStage((s) => Math.max(s - 1, 0)), [])
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight") goNext()
+      else if (e.key === "ArrowLeft") goPrev()
+    }
+    window.addEventListener("keydown", handleKey)
+    return () => window.removeEventListener("keydown", handleKey)
+  }, [goNext, goPrev])
+
+  return (
+    <div className="animate-fade-in">
+      {/* Hero */}
+      <div className="relative mb-8 rounded-2xl hero-mesh overflow-hidden border border-default">
+        <div className="absolute inset-0 hero-grid pointer-events-none" />
+        <div className="relative px-8 py-10 text-center">
+          <div className="inline-flex items-center gap-2 rounded-full bg-accent/10 border border-accent/20 px-4 py-1.5 text-xs font-semibold text-accent mb-4">
+            <Sparkles className="h-3.5 w-3.5" /> Interactive Guide
+          </div>
+          <h1 className="text-3xl md:text-4xl font-display font-bold text-primary mb-3">
+            How <span className="text-gradient">Genie Workbench</span> Works
+          </h1>
+          <p className="text-secondary text-base max-w-2xl mx-auto leading-relaxed">
+            Create, score, fix, and optimize your Genie Spaces — all from one intelligent interface.
+            Explore each capability below.
+          </p>
+        </div>
+      </div>
+
+      {/* Stage navigation pills */}
+      <div className="mb-8 flex flex-wrap justify-center gap-1.5">
+        {stages.map((stage, i) => (
+          <button
+            key={stage.id}
+            onClick={() => setActiveStage(i)}
+            className={cn(
+              "flex items-center gap-1.5 rounded-full px-3.5 py-2 text-xs font-medium transition-all duration-200",
+              i === activeStage
+                ? "shadow-md scale-105"
+                : "bg-elevated text-muted hover:text-secondary hover:bg-surface border border-default",
+            )}
+            style={
+              i === activeStage
+                ? { background: `${stage.color}18`, color: stage.color, boxShadow: `0 4px 12px ${stage.color}25` }
+                : undefined
+            }
+          >
+            {stage.icon}
+            <span className="hidden sm:inline">{stage.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Stage content */}
+      <div key={stages[activeStage].id} className="animate-slide-up">
+        {activeStage === 0 && <OverviewContent />}
+        {activeStage === 1 && <CreateAgentContent />}
+        {activeStage === 2 && <IQScannerContent />}
+        {activeStage === 3 && <FixAgentContent />}
+        {activeStage === 4 && <AutoOptimizeContent />}
+        {activeStage === 5 && <PermissionsContent />}
+        {activeStage === 6 && <ArchitectureContent />}
+      </div>
+
+      {/* Prev / Next navigation */}
+      <div className="mt-8 flex items-center justify-between">
+        <button
+          onClick={goPrev}
+          disabled={activeStage === 0}
+          className={cn(
+            "flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
+            activeStage === 0
+              ? "text-muted/40 cursor-not-allowed"
+              : "text-secondary hover:text-primary hover:bg-elevated",
+          )}
+        >
+          <ChevronLeft className="h-4 w-4" /> {activeStage > 0 ? stages[activeStage - 1].label : "Back"}
+        </button>
+
+        <span className="text-xs text-muted">
+          {activeStage + 1} / {stages.length} &middot; arrow keys to navigate
+        </span>
+
+        <button
+          onClick={goNext}
+          disabled={activeStage === stages.length - 1}
+          className={cn(
+            "flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
+            activeStage === stages.length - 1
+              ? "text-muted/40 cursor-not-allowed"
+              : "text-secondary hover:text-primary hover:bg-elevated",
+          )}
+        >
+          {activeStage < stages.length - 1 ? stages[activeStage + 1].label : "Next"} <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/* ================================================================
+   STAGE 0 — Overview
+   ================================================================ */
+function OverviewContent() {
+  return (
+    <div className="space-y-6">
+      <div className="text-center mb-2">
+        <h2 className="text-xl font-display font-bold text-primary">Everything You Need for Genie Spaces</h2>
+        <p className="text-sm text-muted mt-1">Four powerful capabilities, one streamlined workflow</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 animate-stagger">
+        <FeatureCard
+          icon={<MessageSquarePlus className="h-6 w-6" />}
+          title="Create"
+          description="Describe what you need in plain English. Our AI agent discovers your data, builds a plan, and creates a fully configured Genie Space."
+          accentColor={CYAN}
+          glowColor={`${CYAN}15`}
+        />
+        <FeatureCard
+          icon={<ShieldCheck className="h-6 w-6" />}
+          title="Score"
+          description="Instantly scan any Genie Space against 12 quality checks. Get a maturity tier (Not Ready → Ready → Trusted) and actionable findings."
+          accentColor={SUCCESS}
+          glowColor={`${SUCCESS}15`}
+        />
+        <FeatureCard
+          icon={<Wrench className="h-6 w-6" />}
+          title="Fix"
+          description="Turn scan findings into concrete fixes. The Fix Agent generates JSON patches and applies them directly — no manual editing required."
+          accentColor={WARNING}
+          glowColor={`${WARNING}15`}
+        />
+        <FeatureCard
+          icon={<Zap className="h-6 w-6" />}
+          title="Optimize"
+          description="Run a full benchmark-driven optimization pipeline. Tests real questions, evaluates with 9 judges, and applies improvements automatically."
+          accentColor={DANGER}
+          glowColor={`${DANGER}15`}
+        />
+      </div>
+
+      {/* End-to-end flow */}
+      <StageCard title="End-to-End Workflow" icon={<ArrowRightLeft className="h-4 w-4" />}>
+        <PipelineDiagram
+          steps={[
+            { icon: <MessageSquarePlus className="h-5 w-5" />, label: "Create", description: "AI builds your space", color: CYAN },
+            { icon: <ShieldCheck className="h-5 w-5" />, label: "Score", description: "12-check quality scan", color: SUCCESS },
+            { icon: <Wrench className="h-5 w-5" />, label: "Fix", description: "Auto-apply patches", color: WARNING },
+            { icon: <Zap className="h-5 w-5" />, label: "Optimize", description: "Benchmark & refine", color: DANGER },
+            { icon: <CheckCircle2 className="h-5 w-5" />, label: "Trusted", description: "Production-ready", color: SUCCESS },
+          ]}
+        />
+      </StageCard>
+    </div>
+  )
+}
+
+/* ================================================================
+   STAGE 1 — Create Agent
+   ================================================================ */
+function CreateAgentContent() {
+  const agentSteps: PipelineStep[] = [
+    { icon: <FileText className="h-5 w-5" />, label: "Requirements", description: "Describe your goal", color: CYAN },
+    { icon: <Database className="h-5 w-5" />, label: "Data Sources", description: "Pick catalogs & tables", color: INFO },
+    { icon: <Search className="h-5 w-5" />, label: "Inspection", description: "AI reads your schema", color: ACCENT },
+    { icon: <GitBranch className="h-5 w-5" />, label: "Plan", description: "Parallel plan generation", color: SUCCESS },
+    { icon: <Settings className="h-5 w-5" />, label: "Configure", description: "Build the Genie Space", color: WARNING },
+    { icon: <CheckCircle2 className="h-5 w-5" />, label: "Created", description: "Ready to score", color: SUCCESS },
+  ]
+
+  const tools = [
+    { name: "list_catalogs", desc: "Browse available Unity Catalog catalogs" },
+    { name: "list_schemas", desc: "List schemas within a selected catalog" },
+    { name: "list_tables", desc: "Discover tables and their descriptions" },
+    { name: "get_table_schema", desc: "Read column names, types, and comments" },
+    { name: "run_sql", desc: "Sample data to verify table contents" },
+    { name: "create_genie_space", desc: "Build and configure the final space" },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center mb-2">
+        <h2 className="text-xl font-display font-bold text-primary">Create Agent</h2>
+        <p className="text-sm text-muted mt-1">A multi-turn AI conversation that builds your Genie Space step by step</p>
+      </div>
+
+      <StageCard title="6-Step Progression" subtitle="The agent walks you through each phase" icon={<MessageSquarePlus className="h-4 w-4" />}>
+        <PipelineDiagram steps={agentSteps} />
+      </StageCard>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <StageCard title="Agent Tools" subtitle="What the AI can do" icon={<Settings className="h-4 w-4" />}>
+          <div className="space-y-2.5">
+            {tools.map((t) => (
+              <div key={t.name} className="flex items-start gap-3">
+                <code className="text-xs font-mono bg-accent/10 text-accent px-2 py-0.5 rounded shrink-0 mt-0.5">{t.name}</code>
+                <span className="text-sm text-secondary">{t.desc}</span>
+              </div>
+            ))}
+          </div>
+        </StageCard>
+
+        <StageCard title="How It Feels" subtitle="What you experience" icon={<Sparkles className="h-4 w-4" />}>
+          <div className="space-y-4">
+            <div className="rounded-lg bg-elevated border border-default p-4">
+              <p className="text-sm text-secondary italic">"I need a Genie Space for our retail analytics — we have sales transactions and inventory tables in the commerce catalog."</p>
+              <div className="mt-3 flex items-center gap-2 text-xs text-muted">
+                <div className="h-5 w-5 rounded-full bg-accent/20 flex items-center justify-center">
+                  <MessageSquarePlus className="h-3 w-3 text-accent" />
+                </div>
+                Agent discovers tables, reads schemas, suggests a plan...
+              </div>
+            </div>
+            <div className="space-y-2 text-sm">
+              <div className="flex items-center gap-2 text-secondary">
+                <CheckCircle2 className="h-4 w-4 text-success shrink-0" />
+                Real-time streaming — see the agent think and act
+              </div>
+              <div className="flex items-center gap-2 text-secondary">
+                <CheckCircle2 className="h-4 w-4 text-success shrink-0" />
+                Parallel plan generation for speed
+              </div>
+              <div className="flex items-center gap-2 text-secondary">
+                <CheckCircle2 className="h-4 w-4 text-success shrink-0" />
+                Session persistence — pick up where you left off
+              </div>
+            </div>
+          </div>
+        </StageCard>
+      </div>
+    </div>
+  )
+}
+
+/* ================================================================
+   STAGE 2 — IQ Scanner
+   ================================================================ */
+function IQScannerContent() {
+  const checks = [
+    { name: "Has Instructions", severity: "critical", desc: "Space has user-facing instructions" },
+    { name: "Has Sample Questions", severity: "critical", desc: "At least one sample question provided" },
+    { name: "Has Tables", severity: "critical", desc: "One or more tables attached" },
+    { name: "Table Descriptions", severity: "high", desc: "All tables have meaningful descriptions" },
+    { name: "Column Descriptions", severity: "high", desc: "Columns are well-documented" },
+    { name: "Instruction Length", severity: "medium", desc: "Instructions are detailed enough (>100 chars)" },
+    { name: "Question Count", severity: "medium", desc: "Multiple sample questions (3+)" },
+    { name: "Question Quality", severity: "medium", desc: "Questions are specific, not generic" },
+    { name: "Table Count", severity: "low", desc: "Appropriate number of tables" },
+    { name: "No Empty Descriptions", severity: "low", desc: "No placeholder or empty descriptions" },
+    { name: "Naming Conventions", severity: "low", desc: "Consistent, readable naming" },
+    { name: "Column Coverage", severity: "low", desc: "Sufficient % of columns documented" },
+  ]
+
+  const tiers = [
+    { name: "Not Ready", range: "0–5", color: DANGER, icon: <XCircle className="h-5 w-5" />, desc: "Critical gaps — needs immediate attention" },
+    { name: "Ready to Optimize", range: "6–9", color: INFO, icon: <AlertTriangle className="h-5 w-5" />, desc: "Functional but has improvement areas" },
+    { name: "Trusted", range: "10–12", color: SUCCESS, icon: <CheckCircle2 className="h-5 w-5" />, desc: "Production-quality configuration" },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center mb-2">
+        <h2 className="text-xl font-display font-bold text-primary">IQ Scanner</h2>
+        <p className="text-sm text-muted mt-1">Instant, rule-based quality scoring — no LLM needed</p>
+      </div>
+
+      {/* Maturity tiers */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 animate-stagger">
+        {tiers.map((tier) => (
+          <div
+            key={tier.name}
+            className="rounded-xl border-2 p-5 text-center transition-shadow hover:shadow-lg"
+            style={{ borderColor: `${tier.color}40`, background: `${tier.color}08` }}
+          >
+            <div className="flex justify-center mb-3">
+              <div
+                className="h-12 w-12 rounded-full flex items-center justify-center"
+                style={{ background: `${tier.color}20`, color: tier.color }}
+              >
+                {tier.icon}
+              </div>
+            </div>
+            <h3 className="font-display font-bold text-primary text-base">{tier.name}</h3>
+            <div className="text-2xl font-bold mt-1" style={{ color: tier.color }}>{tier.range}</div>
+            <p className="text-xs text-muted mt-1">{tier.desc}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Score gauge illustration */}
+      <StageCard title="12 Quality Checks" subtitle="Each check contributes 1 point" icon={<Gauge className="h-4 w-4" />}>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {checks.map((check) => (
+            <div key={check.name} className="flex items-center gap-2.5 py-1.5">
+              <div
+                className="h-2 w-2 rounded-full shrink-0"
+                style={{
+                  background:
+                    check.severity === "critical" ? DANGER
+                    : check.severity === "high" ? WARNING
+                    : check.severity === "medium" ? INFO
+                    : SUCCESS,
+                }}
+              />
+              <span className="text-sm text-primary font-medium">{check.name}</span>
+              <span className="text-xs text-muted ml-auto hidden sm:block">{check.severity}</span>
+            </div>
+          ))}
+        </div>
+        <div className="flex items-center gap-4 mt-4 pt-3 border-t border-default text-xs text-muted">
+          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full inline-block" style={{ background: DANGER }} /> Critical</span>
+          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full inline-block" style={{ background: WARNING }} /> High</span>
+          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full inline-block" style={{ background: INFO }} /> Medium</span>
+          <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full inline-block" style={{ background: SUCCESS }} /> Low</span>
+        </div>
+      </StageCard>
+    </div>
+  )
+}
+
+/* ================================================================
+   STAGE 3 — Fix Agent
+   ================================================================ */
+function FixAgentContent() {
+  const fixSteps: PipelineStep[] = [
+    { icon: <ShieldCheck className="h-5 w-5" />, label: "Scan Results", description: "Findings from IQ Scanner", color: SUCCESS },
+    { icon: <Search className="h-5 w-5" />, label: "Analyze", description: "LLM reviews each finding", color: INFO },
+    { icon: <FileText className="h-5 w-5" />, label: "Generate Patches", description: "JSON patches per finding", color: WARNING },
+    { icon: <Target className="h-5 w-5" />, label: "Validate", description: "Check patch safety", color: ACCENT },
+    { icon: <CheckCircle2 className="h-5 w-5" />, label: "Apply", description: "Write to Genie API", color: SUCCESS },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center mb-2">
+        <h2 className="text-xl font-display font-bold text-primary">Fix Agent</h2>
+        <p className="text-sm text-muted mt-1">Automatically generates and applies fixes from IQ Scanner findings</p>
+      </div>
+
+      <StageCard title="Scan → Fix Pipeline" icon={<Wrench className="h-4 w-4" />}>
+        <PipelineDiagram steps={fixSteps} />
+      </StageCard>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <StageCard title="What Gets Fixed" icon={<Target className="h-4 w-4" />}>
+          <div className="space-y-3">
+            {[
+              { label: "Missing instructions", fix: "Generates contextual instructions from table metadata" },
+              { label: "Missing sample questions", fix: "Creates realistic questions users would actually ask" },
+              { label: "Empty table descriptions", fix: "Writes descriptions from column analysis" },
+              { label: "Missing column docs", fix: "Documents columns based on names, types, and samples" },
+              { label: "Weak naming", fix: "Suggests clearer display names" },
+            ].map((item) => (
+              <div key={item.label} className="flex items-start gap-3">
+                <div className="mt-1 h-5 w-5 rounded bg-warning/10 flex items-center justify-center shrink-0">
+                  <Wrench className="h-3 w-3 text-warning" />
+                </div>
+                <div>
+                  <span className="text-sm font-medium text-primary">{item.label}</span>
+                  <p className="text-xs text-muted">{item.fix}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </StageCard>
+
+        <StageCard title="Patch Format" subtitle="JSON Patch (RFC 6902)" icon={<FileText className="h-4 w-4" />}>
+          <div className="rounded-lg bg-sunken border border-default p-4 font-mono text-xs leading-relaxed">
+            <div className="text-muted">{"// Example: adding a table description"}</div>
+            <div className="mt-2">
+              <span className="text-accent">{"{"}</span><br />
+              <span className="ml-3 text-cyan">"op"</span>: <span className="text-success">"replace"</span>,<br />
+              <span className="ml-3 text-cyan">"path"</span>: <span className="text-success">"/tables/0/description"</span>,<br />
+              <span className="ml-3 text-cyan">"value"</span>: <span className="text-success">"Daily sales transactions..."</span><br />
+              <span className="text-accent">{"}"}</span>
+            </div>
+          </div>
+          <div className="mt-4 space-y-2 text-sm">
+            <div className="flex items-center gap-2 text-secondary">
+              <CheckCircle2 className="h-4 w-4 text-success shrink-0" />
+              Patches run in parallel for speed
+            </div>
+            <div className="flex items-center gap-2 text-secondary">
+              <CheckCircle2 className="h-4 w-4 text-success shrink-0" />
+              ID sanitization prevents targeting errors
+            </div>
+            <div className="flex items-center gap-2 text-secondary">
+              <CheckCircle2 className="h-4 w-4 text-success shrink-0" />
+              Applied via Genie Space API — no file editing
+            </div>
+          </div>
+        </StageCard>
+      </div>
+    </div>
+  )
+}
+
+/* ================================================================
+   STAGE 4 — Auto-Optimize (GSO)
+   ================================================================ */
+function AutoOptimizeContent() {
+  const pipelineSteps: PipelineStep[] = [
+    { icon: <ShieldCheck className="h-5 w-5" />, label: "Preflight", description: "Validate space readiness", color: INFO },
+    { icon: <BarChart3 className="h-5 w-5" />, label: "Baseline", description: "Run benchmark questions", color: ACCENT },
+    { icon: <Database className="h-5 w-5" />, label: "Enrich", description: "Gather metadata context", color: CYAN },
+    { icon: <RefreshCw className="h-5 w-5" />, label: "Lever Loop", description: "Apply & evaluate levers", color: WARNING },
+    { icon: <Target className="h-5 w-5" />, label: "Finalize", description: "Select best combination", color: SUCCESS },
+    { icon: <CheckCircle2 className="h-5 w-5" />, label: "Deploy", description: "Apply winning config", color: SUCCESS },
+  ]
+
+  const levers = [
+    { name: "Instructions", desc: "Rewrite or enhance space-level instructions", color: ACCENT },
+    { name: "Table Descriptions", desc: "Improve how tables are described to the model", color: CYAN },
+    { name: "Column Descriptions", desc: "Add or refine column-level documentation", color: SUCCESS },
+    { name: "Sample Questions", desc: "Generate better example queries", color: WARNING },
+    { name: "Certified Queries", desc: "Add verified SQL for common questions", color: DANGER },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center mb-2">
+        <h2 className="text-xl font-display font-bold text-primary">Auto-Optimize (GSO)</h2>
+        <p className="text-sm text-muted mt-1">Benchmark-driven optimization — tests real questions, picks what actually works</p>
+      </div>
+
+      <StageCard title="6-Task Pipeline" icon={<Zap className="h-4 w-4" />}>
+        <PipelineDiagram steps={pipelineSteps} />
+      </StageCard>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <StageCard title="5 Lever Categories" subtitle="What gets tuned" icon={<Settings className="h-4 w-4" />}>
+          <div className="space-y-3">
+            {levers.map((l) => (
+              <div key={l.name} className="flex items-center gap-3">
+                <div
+                  className="h-8 w-8 rounded-lg flex items-center justify-center shrink-0"
+                  style={{ background: `${l.color}15` }}
+                >
+                  <div className="h-3 w-3 rounded-sm" style={{ background: l.color }} />
+                </div>
+                <div>
+                  <span className="text-sm font-medium text-primary">{l.name}</span>
+                  <p className="text-xs text-muted">{l.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </StageCard>
+
+        <StageCard title="3-Gate Evaluation" subtitle="How quality is measured" icon={<BarChart3 className="h-4 w-4" />}>
+          <div className="space-y-4">
+            {[
+              { gate: "Gate 1 — SQL Validity", desc: "Does the generated SQL parse and execute?", color: INFO },
+              { gate: "Gate 2 — Schema Match", desc: "Do columns and tables match the expected output?", color: WARNING },
+              { gate: "Gate 3 — Semantic Accuracy", desc: "Do results match ground-truth answers? (9 judges)", color: SUCCESS },
+            ].map((g) => (
+              <div key={g.gate} className="rounded-lg border p-3" style={{ borderColor: `${g.color}30`, background: `${g.color}05` }}>
+                <h4 className="text-sm font-semibold" style={{ color: g.color }}>{g.gate}</h4>
+                <p className="text-xs text-muted mt-0.5">{g.desc}</p>
+              </div>
+            ))}
+            <div className="flex items-center gap-2 pt-2 text-xs text-muted border-t border-default">
+              <RefreshCw className="h-3.5 w-3.5" />
+              Iterates until accuracy converges or max rounds reached
+            </div>
+          </div>
+        </StageCard>
+      </div>
+    </div>
+  )
+}
+
+/* ================================================================
+   STAGE 5 — Permissions
+   ================================================================ */
+function PermissionsContent() {
+  return (
+    <div className="space-y-6">
+      <div className="text-center mb-2">
+        <h2 className="text-xl font-display font-bold text-primary">Permissions Model</h2>
+        <p className="text-sm text-muted mt-1">Dual-identity architecture — your token for interactive work, app identity for background jobs</p>
+      </div>
+      <PermissionDiagram />
+    </div>
+  )
+}
+
+/* ================================================================
+   STAGE 6 — Architecture
+   ================================================================ */
+function ArchitectureContent() {
+  const layers = [
+    {
+      name: "Frontend",
+      desc: "React 19 + TypeScript + Tailwind CSS v4",
+      color: CYAN,
+      icon: <Globe className="h-5 w-5" />,
+      items: ["Single-page app served by FastAPI", "SSE streaming for real-time updates", "Dark/light theme with CSS variables"],
+    },
+    {
+      name: "Backend",
+      desc: "FastAPI + Pydantic + asyncio",
+      color: ACCENT,
+      icon: <Box className="h-5 w-5" />,
+      items: ["4 routers: analysis, spaces, admin, create", "OBO middleware (ContextVar-based)", "LLM calls via Databricks serving endpoints"],
+    },
+    {
+      name: "Persistence",
+      desc: "Lakebase (PostgreSQL) + Delta Tables",
+      color: SUCCESS,
+      icon: <HardDrive className="h-5 w-5" />,
+      items: ["Scans, stars, sessions in Lakebase", "Optimization state in 12 Delta tables", "Graceful fallback to in-memory storage"],
+    },
+    {
+      name: "Integrations",
+      desc: "Databricks platform services",
+      color: WARNING,
+      icon: <Network className="h-5 w-5" />,
+      items: ["Unity Catalog for data discovery", "Genie API for space management", "Lakeflow Jobs for optimization pipeline"],
+    },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center mb-2">
+        <h2 className="text-xl font-display font-bold text-primary">Architecture</h2>
+        <p className="text-sm text-muted mt-1">Full-stack Databricks App — React frontend, FastAPI backend, platform integrations</p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 animate-stagger">
+        {layers.map((layer) => (
+          <div
+            key={layer.name}
+            className="rounded-xl border-2 p-5 transition-shadow hover:shadow-lg"
+            style={{ borderColor: `${layer.color}30`, background: `${layer.color}05` }}
+          >
+            <div className="flex items-center gap-3 mb-3">
+              <div
+                className="h-10 w-10 rounded-lg flex items-center justify-center"
+                style={{ background: `${layer.color}20`, color: layer.color }}
+              >
+                {layer.icon}
+              </div>
+              <div>
+                <h3 className="font-display font-bold text-primary text-sm">{layer.name}</h3>
+                <p className="text-xs text-muted">{layer.desc}</p>
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              {layer.items.map((item) => (
+                <div key={item} className="flex items-center gap-2 text-sm text-secondary">
+                  <div className="h-1.5 w-1.5 rounded-full shrink-0" style={{ background: layer.color }} />
+                  {item}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Data flow diagram */}
+      <StageCard title="Data Flow" subtitle="How requests move through the system" icon={<ArrowRightLeft className="h-4 w-4" />}>
+        <PipelineDiagram
+          steps={[
+            { icon: <Globe className="h-5 w-5" />, label: "Browser", description: "React SPA", color: CYAN },
+            { icon: <Box className="h-5 w-5" />, label: "FastAPI", description: "OBO middleware", color: ACCENT },
+            { icon: <Database className="h-5 w-5" />, label: "Genie API", description: "Space CRUD", color: INFO },
+            { icon: <HardDrive className="h-5 w-5" />, label: "Lakebase", description: "State storage", color: SUCCESS },
+            { icon: <Network className="h-5 w-5" />, label: "Unity Catalog", description: "Data governance", color: WARNING },
+          ]}
+        />
+      </StageCard>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **README.md**: Added a "Permissions & Authentication Model" section explaining the OBO/SP dual-identity architecture, permission boundary table, and required GRANT statements. Updated the "Post-Deploy" section to cross-reference the new permissions docs.
- **AGENTS.md**: Added a "Documentation" section pointing AI agents to the new `docs/` folder.
- **`docs/` folder** (15 files): Comprehensive documentation covering architecture, authentication & permissions, create agent, IQ scanner, fix agent, auto-optimize (GSO), deployment, operations, API reference, troubleshooting, and environment variables.
- **In-app "How It Works" page**: Interactive, visually rich guide with 7 navigable stages (Overview, Create Agent, IQ Scanner, Fix Agent, Auto-Optimize, Permissions, Architecture). Includes feature cards, pipeline diagrams, permission diagrams, and keyboard navigation. Uses existing theme tokens and CSS animations — no new dependencies added.

### New files
| Area | Files |
|------|-------|
| Documentation | `docs/00-index.md` through `docs/09-operations-guide.md`, `docs/appendices/A-api-reference.md`, `B-troubleshooting.md`, `C-environment-variables.md` |
| Frontend page | `frontend/src/pages/HowItWorks.tsx` |
| Frontend components | `frontend/src/components/how-it-works/FeatureCard.tsx`, `StageCard.tsx`, `PipelineDiagram.tsx`, `PermissionDiagram.tsx` |

### Modified files
- `README.md` — permissions section + cross-reference
- `AGENTS.md` — documentation reference
- `frontend/src/App.tsx` — new view type, nav button, render block

## Test plan
- [ ] Verify `npm run build` succeeds in `frontend/`
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Navigate to "How It Works" via the header nav button
- [ ] Click through all 7 stages and verify content renders
- [ ] Test arrow-key navigation between stages
- [ ] Verify dark/light mode toggle works on all stages
- [ ] Verify responsive layout on mobile viewport
- [ ] Review `docs/` markdown files render correctly on GitHub