### PR TITLE
Fix GSO stale config after instruction restructuring

### DIFF
--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
@@ -4552,7 +4552,7 @@ def _run_lever_loop(
                     _set_general_instructions(metadata_snapshot, _restructured_text)
                     try:
                         from genie_space_optimizer.common.genie_client import (
-                            fetch_space_config as _fetch_post_restructure,
+                            fetch_space_config,
                             patch_space_config,
                         )
                         patch_space_config(w, space_id, metadata_snapshot)
@@ -4560,10 +4560,10 @@ def _run_lever_loop(
                         # Without this, metadata_snapshot diverges from the API's
                         # version and all subsequent lever PATCHes fail with
                         # "Space configuration has been modified since this export".
-                        _refreshed = _fetch_post_restructure(w, space_id)
-                        metadata_snapshot = _refreshed.get("_parsed_space", _refreshed)
-                        if data_profile:
-                            metadata_snapshot["_data_profile"] = data_profile
+                        config = fetch_space_config(w, space_id)
+                        config["_uc_columns"] = uc_columns
+                        metadata_snapshot = config.get("_parsed_space", config)
+                        metadata_snapshot["_data_profile"] = data_profile
                         if uc_columns:
                             enrich_metadata_with_uc_types(metadata_snapshot, uc_columns)
                         logger.info(

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
@@ -4552,9 +4552,20 @@ def _run_lever_loop(
                     _set_general_instructions(metadata_snapshot, _restructured_text)
                     try:
                         from genie_space_optimizer.common.genie_client import (
+                            fetch_space_config as _fetch_post_restructure,
                             patch_space_config,
                         )
                         patch_space_config(w, space_id, metadata_snapshot)
+                        # Re-fetch to get server-canonical state after PATCH.
+                        # Without this, metadata_snapshot diverges from the API's
+                        # version and all subsequent lever PATCHes fail with
+                        # "Space configuration has been modified since this export".
+                        _refreshed = _fetch_post_restructure(w, space_id)
+                        metadata_snapshot = _refreshed.get("_parsed_space", _refreshed)
+                        if data_profile:
+                            metadata_snapshot["_data_profile"] = data_profile
+                        if uc_columns:
+                            enrich_metadata_with_uc_types(metadata_snapshot, uc_columns)
                         logger.info(
                             "Persisted restructured instructions (%d chars, %d sections)",
                             len(_restructured_text), len(_restructured_secs),


### PR DESCRIPTION
## Summary
- After Phase 1.5 instruction restructuring PATCHes the Genie Space, `metadata_snapshot` was not re-fetched from the API
- The Genie API normalizes content on write (re-sorting arrays, canonicalizing IDs), so the local copy diverges from the server state
- All subsequent lever loop PATCHes fail with: "Space configuration has been modified since this export was taken"
- This caused the optimizer to report STALLED with 0 levers accepted, even though the job completed successfully
- Fix: re-fetch `metadata_snapshot` after the Phase 1.5 PATCH, following the same pattern used after other enrichment sub-steps (e.g., line 4677)

## Root cause trace
1. `_run_lever_loop` fetches config at line 4490 (correct)
2. Phase 1.5 modifies `metadata_snapshot` in-memory and PATCHes API at line 4558 (correct)
3. **No re-fetch** — `metadata_snapshot` is now stale vs server state (bug)
4. `apply_patch_set` at line 5315 sends patches built on stale snapshot → API rejects

## Test plan
- [ ] Deploy the fix and re-run optimization on the same Genie Space (FinOps Cost Analytics)
- [ ] Verify lever loop iterations produce `eval_scope="full"` rows in `genie_opt_iterations`
- [ ] Verify no "Space configuration has been modified" errors in stage events

This pull request was AI-assisted by Isaac.