### PR TITLE
Harden fix agent, enrich IQ scanner with UC metadata, guard duplicate space creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,8 @@ backend/
   services/
     auth.py                # OBO auth (ContextVar), SP fallback, WorkspaceClient mgmt
     genie_client.py        # Databricks Genie API (fetch space, list spaces, query for SQL)
-    scanner.py             # Rule-based IQ scoring engine (0-12, 12 checks, 3-tier maturity)
-    fix_agent.py           # LLM agent that generates JSON patches and applies via Genie API
+    scanner.py             # Rule-based IQ scoring engine (0-12, 12 checks, 3-tier maturity, UC-enriched)
+    fix_agent.py           # LLM agent (Quick Fix in UI) that generates JSON patches and applies via Genie API
     create_agent.py        # Multi-turn LLM agent for creating new Genie Spaces
     create_agent_session.py # Session persistence for create agent (Lakebase)
     create_agent_tools.py  # Tool definitions for create agent (UC discovery, SQL, etc.)
@@ -117,10 +117,10 @@ Frontend consumes these via manual `fetch` + `ReadableStream` in `lib/api.ts` (n
 All LLM calls go through Databricks model serving endpoints using OpenAI-compatible API. Model configured via `LLM_MODEL` env var (default: `databricks-claude-sonnet-4-6`). MLflow tracing is optional — controlled by `MLFLOW_EXPERIMENT_ID`.
 
 ### Analysis
-IQ Scan (`scanner.py`) is the only analysis path — rule-based, instant, 0-12 score with 12 checks and 3-tier maturity (Not Ready / Ready to Optimize / Trusted). `routers/analysis.py` only handles space fetching/parsing and settings — it does not perform analysis.
+IQ Scan (`scanner.py`) is the only analysis path — rule-based, instant, 0-12 score with 12 checks and 3-tier maturity (Not Ready / Ready to Optimize / Trusted). Before scoring, `scan_space()` enriches the config with upstream Unity Catalog table/column descriptions so checks 2–3 reflect metadata that exists in UC even if not inlined in the Genie Space config. `routers/analysis.py` only handles space fetching/parsing and settings — it does not perform analysis.
 
 ### Two Separate Optimization Paths
-- **Fix Agent** (`fix_agent.py`): triggered from scan findings, auto-applies JSON patches
+- **Quick Fix** (`fix_agent.py`): triggered from scan findings, auto-applies JSON patches
 - **Auto-Optimize** (`auto_optimize.py` + GSO engine in `packages/genie-space-optimizer/`): full benchmark-driven optimization pipeline. They're independent.
 
 ## Environment Variables
@@ -170,7 +170,7 @@ attacks like the litellm PyPI credential stealer (March 2026) and axios npm RAT
 - **`.databricksignore` excludes `*.md`** but explicitly re-includes `backend/references/schema.md` (needed at runtime by create agent and analysis prompts).
 - **OBO ContextVar and streaming** — for SSE endpoints, the ContextVar is NOT cleared after `call_next` because the response streams lazily. Streaming handlers stash the token on `request.state` and re-set it inside the generator.
 - **IQ Scan is the only analysis path** — `scanner.py` runs 12 rule-based checks via `/api/spaces/{id}/scan`. `routers/analysis.py` only handles space fetching/parsing (`/api/space/fetch`, `/api/space/parse`) and settings — it does not perform analysis.
-- **Two separate optimization paths** — Fix Agent (`fix_agent.py`, from scan findings, auto-applies JSON patches) and Auto-Optimize (`auto_optimize.py` + GSO engine in `packages/genie-space-optimizer/`, full benchmark-driven optimization pipeline). They're independent.
+- **Two separate optimization paths** — Quick Fix (`fix_agent.py`, from scan findings, auto-applies JSON patches) and Auto-Optimize (`auto_optimize.py` + GSO engine in `packages/genie-space-optimizer/`, full benchmark-driven optimization pipeline). They're independent.
 - **Vite proxy** — dev frontend at :5173 proxies `/api` to :8000. In production, FastAPI serves static files from `frontend/dist/` directly.
 - **Python 3.11+** required (`pyproject.toml`). Uses `uv` for dependency management (`uv.lock` present).
 - **Root `package.json`** exists solely as a build hook for Databricks Apps. `postinstall` is a no-op (frontend deps are installed by `deploy.sh` locally). `build` checks for pre-built `frontend/dist/index.html` — if present (uploaded by `deploy.sh`), skips the rebuild; falls back to a full build only if dist is missing. This prevents cross-platform Rollup failures on the Linux deploy container.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Security is preserved because:
 | Browse Genie Spaces, UC catalogs/schemas/tables | OBO (user) | User sees only what they have access to |
 | Genie API (fetch/list spaces) | OBO, SP fallback on scope error | User token may lack `dashboards.genie` scope |
 | Create Agent (tools, SQL, space creation) | OBO (user) | Space created under user's identity |
-| Fix Agent (generate + apply patches) | OBO (user) | Patches applied as the user |
+| Quick Fix (generate + apply patches) | OBO (user) | Patches applied as the user |
 | Trigger optimization (permission check) | OBO (user) | Verifies user has CAN_EDIT/CAN_MANAGE |
 | Optimization job execution (6-task DAG) | SP | Lakeflow Jobs have no OBO; SP runs the pipeline |
 | GSO Delta table reads/writes | SP | Optimizer state tables owned by SP |

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -36,6 +36,8 @@ async def get_dashboard() -> AdminDashboardStats:
 
         # Get all scan summaries from Lakebase
         scan_summaries = await get_all_scan_summaries()
+        valid_ids = {s.get("space_id", "") for s in all_spaces}
+        scan_summaries = [s for s in scan_summaries if s["space_id"] in valid_ids]
         scanned_spaces = len(scan_summaries)
 
         if not scan_summaries:
@@ -76,6 +78,7 @@ async def get_leaderboard(top_n: int = 5) -> dict:
         spaces_map = {s.get("space_id", ""): s for s in all_spaces}
 
         scan_summaries = await get_all_scan_summaries()
+        scan_summaries = [s for s in scan_summaries if s["space_id"] in spaces_map]
         if not scan_summaries:
             return {"top": [], "bottom": []}
 
@@ -107,6 +110,7 @@ async def get_alerts() -> list[AlertItem]:
         spaces_map = {s.get("space_id", ""): s for s in all_spaces}
 
         scan_summaries = await get_all_scan_summaries()
+        scan_summaries = [s for s in scan_summaries if s["space_id"] in spaces_map]
         critical = [s for s in scan_summaries if s.get("maturity") == "Not Ready"]
         critical.sort(key=lambda x: x["score"])  # lowest first
 

--- a/backend/services/create_agent.py
+++ b/backend/services/create_agent.py
@@ -277,7 +277,10 @@ class CreateGenieAgent:
                             session.space_config = recovered
                             logger.info("Recovered space_config from session history for %s", tool_name)
 
-                    # Guard: skip duplicate create_space if space already exists (#67)
+                    # Guard: skip duplicate create_space if space already exists (#67).
+                    # Only emits tool_result (not "created") because the first creation
+                    # already sent "created" to the frontend — re-sending would trigger
+                    # duplicate navigation.
                     if tool_name == "create_space" and session.space_id:
                         logger.info("Skipping duplicate create_space — space %s already exists", session.space_id)
                         result = {
@@ -785,7 +788,9 @@ class CreateGenieAgent:
         Idempotent: if session.space_id is already set (space already created),
         returns immediately without calling the API again (#67).
         """
-        # Guard: space already created in this session — skip duplicate API call (#67)
+        # Guard: space already created in this session — skip duplicate API call (#67).
+        # Emits both tool_result AND "created" because direct callers (e.g. _fast_create)
+        # bypass the tool-call loop, so no prior "created" event was sent to the frontend.
         if session.space_id:
             logger.info("Space %s already created — skipping duplicate create_space", session.space_id)
             result = {

--- a/backend/services/create_agent.py
+++ b/backend/services/create_agent.py
@@ -277,6 +277,21 @@ class CreateGenieAgent:
                             session.space_config = recovered
                             logger.info("Recovered space_config from session history for %s", tool_name)
 
+                    # Guard: skip duplicate create_space if space already exists (#67)
+                    if tool_name == "create_space" and session.space_id:
+                        logger.info("Skipping duplicate create_space — space %s already exists", session.space_id)
+                        result = {
+                            "success": True,
+                            "space_id": session.space_id,
+                            "space_url": session.space_url or "",
+                            "display_name": tool_args.get("display_name", ""),
+                            "already_existed": True,
+                        }
+                        tools_used.append(tool_name)
+                        yield {"event": "tool_result", "data": {"tool": tool_name, "result": result}}
+                        session.add_tool_result(tc["id"], json.dumps(result, default=str))
+                        continue
+
                     if tool_name in ("generate_plan", "present_plan"):
                         plan_item_count = sum(
                             len(v) for v in tool_args.values() if isinstance(v, list)
@@ -766,7 +781,28 @@ class CreateGenieAgent:
 
         Yields SSE events (tool_call, tool_result, thinking, created).
         Updates session.space_config/space_id/space_url on success.
+
+        Idempotent: if session.space_id is already set (space already created),
+        returns immediately without calling the API again (#67).
         """
+        # Guard: space already created in this session — skip duplicate API call (#67)
+        if session.space_id:
+            logger.info("Space %s already created — skipping duplicate create_space", session.space_id)
+            result = {
+                "success": True,
+                "space_id": session.space_id,
+                "display_name": display_name,
+                "space_url": session.space_url or "",
+                "already_existed": True,
+            }
+            yield {"event": "tool_result", "data": {"tool": "create_space", "result": result}}
+            yield {"event": "created", "data": {
+                "space_id": session.space_id,
+                "url": session.space_url or "",
+                "display_name": display_name,
+            }}
+            return
+
         from backend.services.create_agent_tools import handle_tool_call
         loop = asyncio.get_event_loop()
 

--- a/backend/services/create_agent_tools.py
+++ b/backend/services/create_agent_tools.py
@@ -2462,12 +2462,15 @@ def _update_config(actions: list[dict], config: dict | None = None) -> dict:
 
         # ── SQL snippet actions (measures, filters, expressions) ──────
         elif action == "add_measure":
+            alias = act.get("alias", "")
             dn = act.get("display_name", "")
             sql = act.get("sql", "")
-            if not dn or not sql:
-                applied.append("Skipped add_measure — display_name and sql required")
+            if not alias or not sql:
+                applied.append("Skipped add_measure — alias and sql required")
                 continue
-            entry_m: dict[str, Any] = {"id": secrets.token_hex(16), "display_name": dn, "sql": [sql]}
+            entry_m: dict[str, Any] = {"id": secrets.token_hex(16), "alias": alias, "sql": [sql]}
+            if dn:
+                entry_m["display_name"] = dn
             if act.get("synonyms"):
                 entry_m["synonyms"] = act["synonyms"]
             if act.get("instruction"):

--- a/backend/services/scanner.py
+++ b/backend/services/scanner.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from typing import Optional
 
@@ -24,6 +25,9 @@ CONFIG_CHECK_COUNT = 10
 # Subset of auto_optimize._TERMINAL_RUN_STATUSES — only includes statuses
 # where best_accuracy is meaningful for IQ scoring.
 _GSO_TERMINAL = {"CONVERGED", "STALLED", "MAX_ITERATIONS"}
+
+# Shared thread pool for UC metadata fetches — avoids per-scan pool churn.
+_uc_pool = ThreadPoolExecutor(max_workers=8, thread_name_prefix="uc-enrich")
 
 
 def get_maturity_label(checks: list[dict]) -> str:
@@ -360,6 +364,95 @@ def calculate_score(space_data: dict, optimization_run: dict | None = None) -> d
     }
 
 
+def _parse_identifier(identifier: str) -> tuple[str, str, str]:
+    """Parse a 3-part table identifier into (catalog, schema, table)."""
+    parts = identifier.replace("`", "").split(".")
+    if len(parts) == 3:
+        return parts[0], parts[1], parts[2]
+    if len(parts) == 2:
+        return "", parts[0], parts[1]
+    return "", "", parts[0] if parts else ""
+
+
+def _enrich_with_uc_descriptions(space_data: dict, ws) -> int:
+    """Fetch UC table/column descriptions and merge into *space_data* in-place.
+
+    Only fills blanks — never overwrites existing ``description`` or ``comment``
+    values in the Genie Space config.  Returns the number of enriched items.
+    """
+    ds = space_data.get("data_sources", {})
+    all_sources = list(ds.get("tables", [])) + list(ds.get("metric_views", []))
+    if not all_sources:
+        return 0
+
+    # Build (cat, sch, tbl) refs + index back to space_data items
+    refs: list[tuple[str, str, str]] = []
+    source_by_fqn: dict[str, dict] = {}
+    for src in all_sources:
+        ident = src.get("identifier", "")
+        if not ident:
+            continue
+        cat, sch, tbl = _parse_identifier(ident)
+        if cat and sch and tbl:
+            fqn = f"{cat}.{sch}.{tbl}"
+            refs.append((cat, sch, tbl))
+            source_by_fqn[fqn] = src
+
+    if not refs:
+        return 0
+
+    # Fetch UC metadata in parallel (sync SDK calls)
+    table_infos: dict[str, object] = {}
+
+    def _fetch_one(ref: tuple[str, str, str]):
+        cat, sch, tbl = ref
+        fqn = f"{cat}.{sch}.{tbl}"
+        try:
+            return fqn, ws.tables.get(full_name=fqn)
+        except Exception as exc:
+            logger.debug("UC metadata fetch failed for %s: %s", fqn, exc)
+            return fqn, None
+
+    for fqn, info in _uc_pool.map(_fetch_one, refs):
+        if info is not None:
+            table_infos[fqn] = info
+
+    if not table_infos:
+        return 0
+
+    enriched = 0
+
+    for fqn, info in table_infos.items():
+        src = source_by_fqn.get(fqn)
+        if not src:
+            continue
+
+        # Enrich table-level description
+        if not (src.get("description") or src.get("comment")):
+            tbl_comment = getattr(info, "comment", None) or ""
+            if tbl_comment:
+                src["comment"] = tbl_comment
+                enriched += 1
+
+        # Enrich column-level descriptions
+        uc_cols = {
+            getattr(c, "name", "").lower(): getattr(c, "comment", None) or ""
+            for c in (getattr(info, "columns", None) or [])
+        }
+        if not uc_cols:
+            continue
+        for col in src.get("column_configs", []) + src.get("columns", []):
+            if col.get("description") or col.get("comment"):
+                continue
+            col_name = (col.get("column_name") or col.get("name", "")).lower()
+            uc_comment = uc_cols.get(col_name, "")
+            if uc_comment:
+                col["comment"] = uc_comment
+                enriched += 1
+
+    return enriched
+
+
 async def scan_space(space_id: str, user_token: Optional[str] = None) -> dict:
     """Fetch space config, calculate IQ score, and persist to Lakebase.
 
@@ -377,6 +470,17 @@ async def scan_space(space_id: str, user_token: Optional[str] = None) -> dict:
     except Exception as e:
         logger.error(f"Failed to fetch space {space_id}: {e}")
         raise ValueError(f"Cannot scan space {space_id}: {e}")
+
+    # Enrich with UC descriptions so checks 2-3 reflect upstream metadata (#62)
+    try:
+        from backend.services.auth import get_workspace_client, run_in_context
+        ws = get_workspace_client()
+        loop = asyncio.get_event_loop()
+        n = await loop.run_in_executor(None, run_in_context(_enrich_with_uc_descriptions, space_data, ws))
+        if n:
+            logger.info("Enriched %d descriptions from Unity Catalog for %s", n, space_id)
+    except Exception as e:
+        logger.warning("UC description enrichment skipped for %s: %s", space_id, e)
 
     # Fetch optimization runs from both sources concurrently
     async def _fetch_opt_run():

--- a/backend/services/scanner.py
+++ b/backend/services/scanner.py
@@ -79,18 +79,26 @@ def calculate_score(space_data: dict, optimization_run: dict | None = None) -> d
     warning_next_steps = []
 
     tables = space_data.get("data_sources", {}).get("tables", [])
+    metric_views = space_data.get("data_sources", {}).get("metric_views", [])
+    total_sources = len(tables) + len(metric_views)
 
     # --- Config checks (1-10) ---
 
-    # 1. Tables exist
-    passed = bool(tables)
-    _check(checks, "Tables exist", passed,
-           detail=f"{len(tables)} table(s) configured" if passed else "No tables configured")
-    if not passed:
-        findings.append("No tables configured")
-        next_steps.append("Add at least one table to your Genie Space")
+    # 1. Data sources exist (tables or metric views)
+    has_data_sources = bool(tables) or bool(metric_views)
+    ds_parts = []
+    if tables:
+        ds_parts.append(f"{len(tables)} table(s)")
+    if metric_views:
+        ds_parts.append(f"{len(metric_views)} metric view(s)")
+    _check(checks, "Data sources exist", has_data_sources,
+           detail=", ".join(ds_parts) + " configured" if has_data_sources else "No tables or metric views configured")
+    if not has_data_sources:
+        findings.append("No tables or metric views configured")
+        next_steps.append("Add at least one table or metric view to your Genie Space")
 
     # 2. Table descriptions — require ≥80% coverage (Gap 2)
+    #    Auto-pass when no tables (metric-view-only spaces manage descriptions in UC).
     if tables:
         described_tables = sum(
             1 for t in tables if t.get("description") or t.get("comment")
@@ -111,10 +119,13 @@ def calculate_score(space_data: dict, optimization_run: dict | None = None) -> d
         elif severity == "warning":
             warnings.append(detail)
             warning_next_steps.append("Add descriptions to remaining tables for better Intent Agent routing")
+    elif metric_views:
+        _check(checks, "Table descriptions", True, detail="Metric-view-only space — descriptions managed in Unity Catalog", severity="pass")
     else:
-        _check(checks, "Table descriptions", False, detail="No tables configured", severity="fail")
+        _check(checks, "Table descriptions", False, detail="No data sources configured", severity="fail")
 
     # 3. Column descriptions — require ≥50% coverage (Gap 1)
+    #    Auto-pass when no tables (metric-view-only spaces manage columns in UC).
     if tables:
         total_cols = 0
         described_cols = 0
@@ -145,8 +156,10 @@ def calculate_score(space_data: dict, optimization_run: dict | None = None) -> d
         if passed and not has_synonyms:
             warnings.append("No column synonyms defined")
             warning_next_steps.append("Add synonyms for columns with abbreviated or technical names")
+    elif metric_views:
+        _check(checks, "Column descriptions", True, detail="Metric-view-only space — columns managed in Unity Catalog", severity="pass")
     else:
-        _check(checks, "Column descriptions", False, detail="No tables configured", severity="fail")
+        _check(checks, "Column descriptions", False, detail="No data sources configured", severity="fail")
 
     # 4. Text instructions > 50 chars (Gap 6: length + SQL-in-text warnings)
     text_instructions = space_data.get("instructions", {}).get("text_instructions", [])
@@ -181,28 +194,27 @@ def calculate_score(space_data: dict, optimization_run: dict | None = None) -> d
     # 5. Join specifications
     join_specs = space_data.get("instructions", {}).get("join_specs", [])
     passed = bool(join_specs)
-    detail = f"{len(join_specs)} join spec(s) for {len(tables)} tables" if passed else None
+    detail = f"{len(join_specs)} join spec(s) for {total_sources} data source(s)" if passed else None
     _check(checks, "Join specifications", passed, detail=detail)
-    if not passed and len(tables) > 1:
-        findings.append("No join specifications for multi-table space")
-        next_steps.append("Add join specifications to help Genie correctly join your tables")
+    if not passed and total_sources > 1:
+        findings.append("No join specifications for multi-source space")
+        next_steps.append("Add join specifications to help Genie correctly join your data sources")
 
-    # 6. Table count 1-12 (Gap 10: adjusted from 1-10)
-    table_count = len(tables)
-    passed = 1 <= table_count <= 12
-    detail = f"{table_count} tables"
+    # 6. Data source count 1-12 (Gap 10: adjusted from 1-10)
+    passed = 1 <= total_sources <= 12
+    detail = f"{total_sources} data source(s)"
     severity = "pass"
-    if not passed and table_count > 12:
+    if not passed and total_sources > 12:
         detail += " — consider multi-room architecture"
         severity = "fail"
-    elif passed and table_count > 8:
-        detail += " — consider splitting into focused rooms for >8 tables"
+    elif passed and total_sources > 8:
+        detail += " — consider splitting into focused rooms for >8 data sources"
         severity = "warning"
-    _check(checks, "Table count 1-12", passed, detail=detail, severity=severity)
-    if not passed and tables:
-        if table_count > 12:
-            findings.append(f"{table_count} tables — more than 12 reduces Genie accuracy")
-            next_steps.append("Consider multi-room architecture or reducing to the most relevant 5-12 tables")
+    _check(checks, "Data source count 1-12", passed, detail=detail, severity=severity)
+    if not passed and (tables or metric_views):
+        if total_sources > 12:
+            findings.append(f"{total_sources} data sources — more than 12 reduces Genie accuracy")
+            next_steps.append("Consider multi-room architecture or reducing to the most relevant 5-12 data sources")
     elif severity == "warning":
         warnings.append(detail)
         warning_next_steps.append("Consider splitting into focused rooms for better accuracy")
@@ -265,7 +277,7 @@ def calculate_score(space_data: dict, optimization_run: dict | None = None) -> d
     entity_count = 0
     format_count = 0
     rls_tables = []
-    for t in tables:
+    for t in tables + metric_views:
         table_has_rls = bool(t.get("row_filter") or t.get("column_mask"))
         for col in t.get("column_configs", []) + t.get("columns", []):
             if col.get("enable_entity_matching"):
@@ -288,7 +300,7 @@ def calculate_score(space_data: dict, optimization_run: dict | None = None) -> d
             detail += f" — approaching 120/space limit"
             severity = "warning"
     _check(checks, "Entity/format matching", entity_or_format, detail=detail, severity=severity)
-    if not entity_or_format and tables:
+    if not entity_or_format and (tables or metric_views):
         findings.append("No columns have entity matching or format assistance enabled")
         next_steps.append("Enable entity matching on categorical columns and format assistance on date/number columns")
     elif severity == "warning":

--- a/backend/services/scanner.py
+++ b/backend/services/scanner.py
@@ -12,6 +12,8 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from typing import Optional
 
+from databricks.sdk.errors import NotFound
+
 from backend.services.genie_client import get_genie_space, get_serialized_space
 from backend.services.lakebase import save_scan_result, get_latest_score, get_latest_optimization_run
 
@@ -409,8 +411,11 @@ def _enrich_with_uc_descriptions(space_data: dict, ws) -> int:
         fqn = f"{cat}.{sch}.{tbl}"
         try:
             return fqn, ws.tables.get(full_name=fqn)
+        except NotFound:
+            logger.debug("UC table not found: %s", fqn)
+            return fqn, None
         except Exception as exc:
-            logger.debug("UC metadata fetch failed for %s: %s", fqn, exc)
+            logger.warning("UC metadata fetch failed for %s: %s", fqn, exc)
             return fqn, None
 
     for fqn, info in _uc_pool.map(_fetch_one, refs):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -108,3 +108,13 @@ def empty_space_data():
         "instructions": {},
         "benchmarks": {},
     }
+
+
+@pytest.fixture
+def metric_view_only_space():
+    """Space with only metric views, no tables."""
+    return {
+        "data_sources": {"metric_views": [{"identifier": "cat.sch.mv1"}]},
+        "instructions": {},
+        "benchmarks": {},
+    }

--- a/backend/tests/test_create_agent.py
+++ b/backend/tests/test_create_agent.py
@@ -1,0 +1,61 @@
+"""Tests for CreateAgent idempotency guards (backend/services/create_agent.py)."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from backend.services.create_agent import CreateGenieAgent
+
+
+def _make_session(space_id=None, space_url=None):
+    """Build a minimal mock session with the fields CreateAgent checks."""
+    return SimpleNamespace(
+        space_id=space_id,
+        space_url=space_url,
+        space_config={"data_sources": {"tables": []}},
+    )
+
+
+class TestCreateSpaceIdempotency:
+    """_create_space_with_repair must not call the API if space already exists (#67)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_early_when_space_exists(self):
+        agent = CreateGenieAgent.__new__(CreateGenieAgent)  # skip __init__
+        session = _make_session(space_id="abc123", space_url="https://example.com/space/abc123")
+
+        events = []
+        async for event in agent._create_space_with_repair(session, {}, "Test Space"):
+            events.append(event)
+
+        # Should yield tool_result + created, NOT actually call the API
+        assert any(e["event"] == "tool_result" for e in events)
+        result_data = next(e for e in events if e["event"] == "tool_result")["data"]["result"]
+        assert result_data["success"] is True
+        assert result_data["space_id"] == "abc123"
+        assert result_data["already_existed"] is True
+
+        assert any(e["event"] == "created" for e in events)
+        created_data = next(e for e in events if e["event"] == "created")["data"]
+        assert created_data["space_id"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_no_early_return_when_no_space(self):
+        """When space_id is not set, the guard should NOT fire (normal flow proceeds)."""
+        agent = CreateGenieAgent.__new__(CreateGenieAgent)
+        session = _make_session(space_id=None)
+
+        # We can't run the full flow without mocking the API, but we can verify
+        # the guard doesn't yield early-return events by checking the first event
+        events = []
+        try:
+            async for event in agent._create_space_with_repair(session, {}, "Test Space"):
+                events.append(event)
+                break  # stop after first event to avoid API call
+        except Exception:
+            pass  # expected — we didn't mock handle_tool_call
+
+        # First event should be tool_call (not tool_result with already_existed)
+        assert events, "Expected at least one event before API call"
+        assert events[0]["event"] == "tool_call"

--- a/backend/tests/test_create_agent_tools.py
+++ b/backend/tests/test_create_agent_tools.py
@@ -15,6 +15,7 @@ from backend.services.create_agent_tools import (
     _DATE_TYPES,
     _NUMERIC_TYPES,
     _BOOLEAN_TYPES,
+    _update_config,
 )
 
 
@@ -139,3 +140,98 @@ class TestTypeSets:
 
     def test_boolean_types(self):
         assert "boolean" in _BOOLEAN_TYPES
+
+
+# ---------------------------------------------------------------------------
+# _update_config — SQL snippet actions
+# ---------------------------------------------------------------------------
+
+def _empty_config():
+    return {"data_sources": {"tables": []}, "instructions": {}, "benchmarks": {}}
+
+
+class TestUpdateConfigAddMeasure:
+    def test_adds_measure_with_alias(self):
+        cfg = _empty_config()
+        result = _update_config(
+            [{"action": "add_measure", "alias": "total_rev", "display_name": "Total Revenue", "sql": "SUM(revenue)"}],
+            config=cfg,
+        )
+        measures = result["config"]["instructions"]["sql_snippets"]["measures"]
+        assert len(measures) == 1
+        assert measures[0]["alias"] == "total_rev"
+        assert measures[0]["display_name"] == "Total Revenue"
+        assert measures[0]["sql"] == ["SUM(revenue)"]
+        assert len(measures[0]["id"]) == 32  # hex ID
+
+    def test_skips_measure_without_alias(self):
+        cfg = _empty_config()
+        result = _update_config(
+            [{"action": "add_measure", "display_name": "Total Revenue", "sql": "SUM(revenue)"}],
+            config=cfg,
+        )
+        measures = result["config"].get("instructions", {}).get("sql_snippets", {}).get("measures", [])
+        assert len(measures) == 0
+        assert any("Skipped" in a for a in result["applied"])
+
+    def test_skips_measure_without_sql(self):
+        cfg = _empty_config()
+        result = _update_config(
+            [{"action": "add_measure", "alias": "total_rev"}],
+            config=cfg,
+        )
+        measures = result["config"].get("instructions", {}).get("sql_snippets", {}).get("measures", [])
+        assert len(measures) == 0
+
+    def test_display_name_optional(self):
+        cfg = _empty_config()
+        result = _update_config(
+            [{"action": "add_measure", "alias": "total_rev", "sql": "SUM(revenue)"}],
+            config=cfg,
+        )
+        measures = result["config"]["instructions"]["sql_snippets"]["measures"]
+        assert len(measures) == 1
+        assert "display_name" not in measures[0]
+
+
+class TestUpdateConfigAddExpression:
+    def test_adds_expression_with_alias(self):
+        cfg = _empty_config()
+        result = _update_config(
+            [{"action": "add_expression", "alias": "profit_margin", "sql": "(revenue - cost) / revenue"}],
+            config=cfg,
+        )
+        exprs = result["config"]["instructions"]["sql_snippets"]["expressions"]
+        assert len(exprs) == 1
+        assert exprs[0]["alias"] == "profit_margin"
+
+    def test_skips_expression_without_alias(self):
+        cfg = _empty_config()
+        result = _update_config(
+            [{"action": "add_expression", "sql": "SUM(x)"}],
+            config=cfg,
+        )
+        exprs = result["config"].get("instructions", {}).get("sql_snippets", {}).get("expressions", [])
+        assert len(exprs) == 0
+
+
+class TestUpdateConfigAddFilter:
+    def test_adds_filter(self):
+        cfg = _empty_config()
+        result = _update_config(
+            [{"action": "add_filter", "display_name": "Current Year", "sql": "YEAR(date) = YEAR(CURRENT_DATE())"}],
+            config=cfg,
+        )
+        filters = result["config"]["instructions"]["sql_snippets"]["filters"]
+        assert len(filters) == 1
+        assert filters[0]["display_name"] == "Current Year"
+        assert "alias" not in filters[0]  # filters don't have alias
+
+    def test_strips_where_prefix(self):
+        cfg = _empty_config()
+        result = _update_config(
+            [{"action": "add_filter", "display_name": "Active", "sql": "WHERE status = 'active'"}],
+            config=cfg,
+        )
+        filters = result["config"]["instructions"]["sql_snippets"]["filters"]
+        assert filters[0]["sql"] == ["status = 'active'"]

--- a/backend/tests/test_scanner.py
+++ b/backend/tests/test_scanner.py
@@ -2,12 +2,23 @@
 
 Tests calculate_score() and get_maturity_label() — pure functions that take
 dicts and return dicts, no mocking required.
+
+_enrich_with_uc_descriptions() tests use mocked WorkspaceClient.
 """
 
 import copy
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 
-from backend.services.scanner import calculate_score, get_maturity_label, CONFIG_CHECK_COUNT
+from backend.services.scanner import (
+    calculate_score,
+    get_maturity_label,
+    CONFIG_CHECK_COUNT,
+    _enrich_with_uc_descriptions,
+    _parse_identifier,
+)
 
 
 def _check_by_label(result, label):
@@ -504,3 +515,260 @@ class TestOptimization:
     def test_accuracy_100_passes(self, full_space_data):
         result = calculate_score(full_space_data, optimization_run={"accuracy": 1.0})
         assert _check_by_label(result, "Optimization accuracy ≥ 85%")["passed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Check 9 addendum: Metric view entity matching
+# ---------------------------------------------------------------------------
+
+class TestMetricViewEntityMatching:
+    def test_metric_view_entity_matching_counted(self):
+        """Metric view columns with entity matching should pass Check 9."""
+        data = {
+            "data_sources": {
+                "tables": [],
+                "metric_views": [{
+                    "identifier": "cat.sch.mv1",
+                    "column_configs": [
+                        {"name": "region", "enable_entity_matching": True},
+                    ],
+                }],
+            },
+            "instructions": {},
+            "benchmarks": {},
+        }
+        check = _check_by_label(calculate_score(data), "Entity/format matching")
+        assert check["passed"] is True
+
+    def test_metric_view_format_assistance_counted(self):
+        """Metric view columns with format assistance should pass Check 9."""
+        data = {
+            "data_sources": {
+                "tables": [],
+                "metric_views": [{
+                    "identifier": "cat.sch.mv1",
+                    "column_configs": [
+                        {"name": "order_date", "enable_format_assistance": True},
+                    ],
+                }],
+            },
+            "instructions": {},
+            "benchmarks": {},
+        }
+        check = _check_by_label(calculate_score(data), "Entity/format matching")
+        assert check["passed"] is True
+
+
+# ---------------------------------------------------------------------------
+# _enrich_with_uc_descriptions
+# ---------------------------------------------------------------------------
+
+def _mock_table_info(comment="", columns=None):
+    """Build a mock TableInfo object matching the Databricks SDK shape."""
+    cols = []
+    for c in (columns or []):
+        cols.append(SimpleNamespace(name=c["name"], comment=c.get("comment", ""), type_text=c.get("type_text", "")))
+    return SimpleNamespace(comment=comment, columns=cols)
+
+
+class TestUCEnrichment:
+    def test_enriches_table_comment(self):
+        space_data = {
+            "data_sources": {
+                "tables": [{"identifier": "cat.sch.orders", "columns": []}],
+            },
+        }
+        ws = MagicMock()
+        ws.tables.get.return_value = _mock_table_info(comment="All customer orders")
+        count = _enrich_with_uc_descriptions(space_data, ws)
+        assert count == 1
+        assert space_data["data_sources"]["tables"][0]["comment"] == "All customer orders"
+
+    def test_enriches_column_comment(self):
+        space_data = {
+            "data_sources": {
+                "tables": [{
+                    "identifier": "cat.sch.orders",
+                    "description": "has table desc",
+                    "column_configs": [
+                        {"column_name": "order_id"},
+                        {"column_name": "amount"},
+                    ],
+                }],
+            },
+        }
+        ws = MagicMock()
+        ws.tables.get.return_value = _mock_table_info(
+            comment="All orders",
+            columns=[
+                {"name": "order_id", "comment": "Primary key"},
+                {"name": "amount", "comment": "Order total in USD"},
+            ],
+        )
+        count = _enrich_with_uc_descriptions(space_data, ws)
+        assert count == 2  # 2 columns enriched (table already has description)
+        cols = space_data["data_sources"]["tables"][0]["column_configs"]
+        assert cols[0]["comment"] == "Primary key"
+        assert cols[1]["comment"] == "Order total in USD"
+
+    def test_no_overwrite_existing_description(self):
+        space_data = {
+            "data_sources": {
+                "tables": [{
+                    "identifier": "cat.sch.orders",
+                    "description": "Existing table desc",
+                    "column_configs": [
+                        {"column_name": "order_id", "description": "Existing col desc"},
+                    ],
+                }],
+            },
+        }
+        ws = MagicMock()
+        ws.tables.get.return_value = _mock_table_info(
+            comment="UC table comment",
+            columns=[{"name": "order_id", "comment": "UC col comment"}],
+        )
+        count = _enrich_with_uc_descriptions(space_data, ws)
+        assert count == 0
+        tbl = space_data["data_sources"]["tables"][0]
+        assert tbl["description"] == "Existing table desc"
+        assert "comment" not in tbl  # not set since description exists
+        assert tbl["column_configs"][0]["description"] == "Existing col desc"
+
+    def test_no_overwrite_existing_comment(self):
+        space_data = {
+            "data_sources": {
+                "tables": [{
+                    "identifier": "cat.sch.orders",
+                    "comment": "Existing comment",
+                    "column_configs": [
+                        {"column_name": "order_id", "comment": "Existing col comment"},
+                    ],
+                }],
+            },
+        }
+        ws = MagicMock()
+        ws.tables.get.return_value = _mock_table_info(
+            comment="UC table comment",
+            columns=[{"name": "order_id", "comment": "UC col comment"}],
+        )
+        count = _enrich_with_uc_descriptions(space_data, ws)
+        assert count == 0
+
+    def test_partial_failure_continues(self):
+        space_data = {
+            "data_sources": {
+                "tables": [
+                    {"identifier": "cat.sch.t1", "columns": []},
+                    {"identifier": "cat.sch.t2", "columns": []},
+                ],
+            },
+        }
+        ws = MagicMock()
+        ws.tables.get.side_effect = [
+            Exception("Permission denied"),
+            _mock_table_info(comment="Table 2 desc"),
+        ]
+        count = _enrich_with_uc_descriptions(space_data, ws)
+        assert count == 1
+        assert space_data["data_sources"]["tables"][0].get("comment") is None
+        assert space_data["data_sources"]["tables"][1]["comment"] == "Table 2 desc"
+
+    def test_empty_space_noop(self):
+        space_data = {"data_sources": {"tables": [], "metric_views": []}}
+        ws = MagicMock()
+        count = _enrich_with_uc_descriptions(space_data, ws)
+        assert count == 0
+        ws.tables.get.assert_not_called()
+
+    def test_enrichment_makes_check2_pass(self):
+        """End-to-end: table with no inline description but UC comment → Check 2 passes."""
+        space_data = {
+            "data_sources": {
+                "tables": [{"identifier": "cat.sch.orders", "columns": []}],
+            },
+            "instructions": {},
+            "benchmarks": {},
+        }
+        ws = MagicMock()
+        ws.tables.get.return_value = _mock_table_info(comment="All customer orders")
+        _enrich_with_uc_descriptions(space_data, ws)
+        result = calculate_score(space_data)
+        check = _check_by_label(result, "Table descriptions")
+        assert check["passed"] is True
+
+    def test_enrichment_makes_check3_pass(self):
+        """End-to-end: columns with no inline description but UC comment → Check 3 passes."""
+        space_data = {
+            "data_sources": {
+                "tables": [{
+                    "identifier": "cat.sch.orders",
+                    "description": "Orders",
+                    "column_configs": [
+                        {"column_name": "order_id"},
+                        {"column_name": "amount"},
+                    ],
+                }],
+            },
+            "instructions": {},
+            "benchmarks": {},
+        }
+        ws = MagicMock()
+        ws.tables.get.return_value = _mock_table_info(
+            comment="Orders",
+            columns=[
+                {"name": "order_id", "comment": "PK"},
+                {"name": "amount", "comment": "Total"},
+            ],
+        )
+        _enrich_with_uc_descriptions(space_data, ws)
+        result = calculate_score(space_data)
+        check = _check_by_label(result, "Column descriptions")
+        assert check["passed"] is True
+
+    def test_metric_view_enrichment(self):
+        """Metric views should also be enriched from UC."""
+        space_data = {
+            "data_sources": {
+                "tables": [],
+                "metric_views": [{"identifier": "cat.sch.mv1"}],
+            },
+        }
+        ws = MagicMock()
+        ws.tables.get.return_value = _mock_table_info(comment="Revenue metrics")
+        count = _enrich_with_uc_descriptions(space_data, ws)
+        assert count == 1
+        assert space_data["data_sources"]["metric_views"][0]["comment"] == "Revenue metrics"
+
+    def test_skips_two_part_identifier(self):
+        """Two-part identifiers (no catalog) are skipped — can't call UC API without catalog."""
+        space_data = {
+            "data_sources": {
+                "tables": [{"identifier": "sch.orders", "columns": []}],
+            },
+        }
+        ws = MagicMock()
+        count = _enrich_with_uc_descriptions(space_data, ws)
+        assert count == 0
+        ws.tables.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _parse_identifier
+# ---------------------------------------------------------------------------
+
+class TestParseIdentifier:
+    def test_three_parts(self):
+        assert _parse_identifier("cat.sch.tbl") == ("cat", "sch", "tbl")
+
+    def test_backticks_stripped(self):
+        assert _parse_identifier("`cat`.`sch`.`tbl`") == ("cat", "sch", "tbl")
+
+    def test_two_parts(self):
+        assert _parse_identifier("sch.tbl") == ("", "sch", "tbl")
+
+    def test_one_part(self):
+        assert _parse_identifier("tbl") == ("", "", "tbl")
+
+    def test_empty_string(self):
+        assert _parse_identifier("") == ("", "", "")

--- a/backend/tests/test_scanner.py
+++ b/backend/tests/test_scanner.py
@@ -71,18 +71,37 @@ class TestScoreEndToEnd:
 
 
 # ---------------------------------------------------------------------------
-# Check 1: Tables exist
+# Check 1: Data sources exist
 # ---------------------------------------------------------------------------
 
-class TestTablesExist:
+class TestDataSourcesExist:
     def test_no_tables(self, empty_space_data):
         result = calculate_score(empty_space_data)
-        check = _check_by_label(result, "Tables exist")
+        check = _check_by_label(result, "Data sources exist")
         assert check["passed"] is False
 
     def test_has_tables(self, full_space_data):
-        check = _check_by_label(calculate_score(full_space_data), "Tables exist")
+        check = _check_by_label(calculate_score(full_space_data), "Data sources exist")
         assert check["passed"] is True
+
+    def test_metric_views_only_passes(self, metric_view_only_space):
+        check = _check_by_label(calculate_score(metric_view_only_space), "Data sources exist")
+        assert check["passed"] is True
+        assert "1 metric view(s)" in check["detail"]
+
+    def test_both_tables_and_metric_views(self):
+        data = {
+            "data_sources": {
+                "tables": [{"name": "t1", "columns": []}],
+                "metric_views": [{"identifier": "cat.sch.mv1"}],
+            },
+            "instructions": {},
+            "benchmarks": {},
+        }
+        check = _check_by_label(calculate_score(data), "Data sources exist")
+        assert check["passed"] is True
+        assert "1 table(s)" in check["detail"]
+        assert "1 metric view(s)" in check["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -120,6 +139,12 @@ class TestTableDescriptions:
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
         check = _check_by_label(calculate_score(data), "Table descriptions")
         assert check["passed"] is True
+
+    def test_metric_views_only_auto_passes(self, metric_view_only_space):
+        """No tables but metric views → auto-pass (managed in UC)."""
+        check = _check_by_label(calculate_score(metric_view_only_space), "Table descriptions")
+        assert check["passed"] is True
+        assert "Unity Catalog" in check["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +196,12 @@ class TestColumnDescriptions:
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
         check = _check_by_label(calculate_score(data), "Column descriptions")
         assert check["passed"] is True  # 1/2 = 50%
+
+    def test_metric_views_only_auto_passes(self, metric_view_only_space):
+        """No tables but metric views → auto-pass (managed in UC)."""
+        check = _check_by_label(calculate_score(metric_view_only_space), "Column descriptions")
+        assert check["passed"] is True
+        assert "Unity Catalog" in check["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -236,51 +267,72 @@ class TestJoinSpecs:
         check = _check_by_label(calculate_score(full_space_data), "Join specifications")
         assert check["passed"] is True
 
-    def test_absent_multi_table_generates_finding(self):
+    def test_absent_multi_source_generates_finding(self):
         tables = [{"name": "t1", "columns": []}, {"name": "t2", "columns": []}]
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
         result = calculate_score(data)
-        assert "No join specifications for multi-table space" in result["findings"]
+        assert "No join specifications for multi-source space" in result["findings"]
 
     def test_absent_single_table_no_finding(self):
         tables = [{"name": "t1", "columns": []}]
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
         result = calculate_score(data)
-        assert "No join specifications for multi-table space" not in result["findings"]
+        assert "No join specifications for multi-source space" not in result["findings"]
+
+    def test_absent_with_table_and_metric_view(self):
+        """1 table + 1 metric view = 2 sources → finding generated."""
+        data = {
+            "data_sources": {
+                "tables": [{"name": "t1", "columns": []}],
+                "metric_views": [{"identifier": "cat.sch.mv1"}],
+            },
+            "instructions": {},
+            "benchmarks": {},
+        }
+        result = calculate_score(data)
+        assert "No join specifications for multi-source space" in result["findings"]
 
 
 # ---------------------------------------------------------------------------
-# Check 6: Table count 1-12
+# Check 6: Data source count 1-12
 # ---------------------------------------------------------------------------
 
 class TestTableCount:
     def test_0_tables_fails(self, empty_space_data):
-        check = _check_by_label(calculate_score(empty_space_data), "Table count 1-12")
+        check = _check_by_label(calculate_score(empty_space_data), "Data source count 1-12")
         assert check["passed"] is False
 
     def test_1_table_passes(self):
         tables = [{"name": "t", "columns": []}]
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
-        check = _check_by_label(calculate_score(data), "Table count 1-12")
+        check = _check_by_label(calculate_score(data), "Data source count 1-12")
         assert check["passed"] is True
 
     def test_12_tables_passes(self):
         tables = [{"name": f"t{i}", "columns": []} for i in range(12)]
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
-        check = _check_by_label(calculate_score(data), "Table count 1-12")
+        check = _check_by_label(calculate_score(data), "Data source count 1-12")
         assert check["passed"] is True
 
     def test_9_tables_warning(self):
         tables = [{"name": f"t{i}", "columns": []} for i in range(9)]
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
-        check = _check_by_label(calculate_score(data), "Table count 1-12")
+        check = _check_by_label(calculate_score(data), "Data source count 1-12")
         assert check["passed"] is True
         assert check["severity"] == "warning"
 
     def test_13_tables_fails(self):
         tables = [{"name": f"t{i}", "columns": []} for i in range(13)]
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
-        check = _check_by_label(calculate_score(data), "Table count 1-12")
+        check = _check_by_label(calculate_score(data), "Data source count 1-12")
+        assert check["passed"] is False
+
+    def test_metric_views_counted_toward_limit(self):
+        """10 tables + 5 metric views = 15 data sources → fails."""
+        tables = [{"name": f"t{i}", "columns": []} for i in range(10)]
+        mvs = [{"identifier": f"cat.sch.mv{i}"} for i in range(5)]
+        data = {"data_sources": {"tables": tables, "metric_views": mvs}, "instructions": {}, "benchmarks": {}}
+        check = _check_by_label(calculate_score(data), "Data source count 1-12")
         assert check["passed"] is False
 
 

--- a/docs/05-iq-scanner.md
+++ b/docs/05-iq-scanner.md
@@ -1,8 +1,12 @@
 # IQ Scanner
 
-The IQ Scanner is a **deterministic, rule-based** quality assessment engine for Genie Space configurations. It evaluates 12 binary checks, assigns a maturity tier, and produces actionable findings that feed the Fix Agent.
+The IQ Scanner is a **deterministic, rule-based** quality assessment engine for Genie Space configurations. It evaluates 12 binary checks, assigns a maturity tier, and produces actionable findings that feed Quick Fix.
 
 Unlike the LLM-based analysis tools, the scanner runs instantly with no LLM calls — it inspects the `serialized_space` JSON directly.
+
+### Unity Catalog Enrichment
+
+Before scoring, `scan_space()` fetches table and column descriptions from Unity Catalog via `WorkspaceClient.tables.get()` and merges them into the space config. This means checks 2 (table descriptions) and 3 (column descriptions) reflect metadata that exists in UC even if not inlined in the Genie Space config. Existing inline descriptions are never overwritten. If UC metadata is unavailable (permissions, network), the scan continues with config-only data.
 
 ## Scoring Model
 
@@ -77,7 +81,7 @@ The scanner returns:
 }
 ```
 
-- **`findings`** and **`next_steps`** come from failed checks — these are the inputs for the [Fix Agent](06-fix-agent.md).
+- **`findings`** and **`next_steps`** come from failed checks — these are the inputs for the [Quick Fix](06-fix-agent.md).
 - **`warnings`** and **`warning_next_steps`** come from warning-severity checks — advisory guidance that doesn't block maturity progression.
 - Both lists are capped at 8 items.
 
@@ -128,6 +132,6 @@ Historical scans are available via `GET /api/spaces/{id}/history`.
 
 ## Related Documentation
 
-- [Fix Agent](06-fix-agent.md) — automatically fixes findings from the scanner
+- [Quick Fix](06-fix-agent.md) — automatically fixes findings from the scanner
 - [Auto-Optimize](07-auto-optimize.md) — the optimization pipeline that satisfies checks 11–12
 - [Introduction](01-introduction.md) — how the scanner fits in the feature workflow

--- a/docs/05-iq-scanner.md
+++ b/docs/05-iq-scanner.md
@@ -26,12 +26,12 @@ The first 10 checks evaluate configuration quality. The last 2 checks evaluate o
 
 | # | Check | Pass Criteria | On Failure |
 |---|-------|--------------|------------|
-| 1 | **Tables exist** | At least 1 table configured | "No tables configured" |
+| 1 | **Data sources exist** | At least 1 table or metric view configured | "No tables or metric views configured" |
 | 2 | **Table descriptions** | ≥80% of tables have descriptions | Finding + next step to add descriptions |
 | 3 | **Column descriptions** | ≥50% of columns have descriptions | Finding + next step to add descriptions |
 | 4 | **Text instructions** | Present and >50 characters total | Finding to add business context instructions |
-| 5 | **Join specifications** | At least 1 join spec (for multi-table spaces) | Finding to add join specs |
-| 6 | **Table count 1–12** | Between 1 and 12 tables | Finding to reduce tables or use multi-room architecture |
+| 5 | **Join specifications** | At least 1 join spec (for multi-source spaces) | Finding to add join specs |
+| 6 | **Data source count 1–12** | Between 1 and 12 tables + metric views | Finding to reduce data sources or use multi-room architecture |
 | 7 | **8+ example SQLs** | At least 8 example question-SQL pairs | Finding to add more examples |
 | 8 | **SQL snippets** | At least 1 function, expression, measure, or filter | Finding to add SQL snippets |
 | 9 | **Entity/format matching** | At least 1 column with entity matching or format assistance | Finding to enable on categorical/date/number columns |
@@ -66,10 +66,10 @@ The scanner returns:
   "total": 12,
   "maturity": "Not Ready",
   "checks": [
-    {"label": "Tables exist", "passed": true, "detail": "5 table(s) configured", "severity": "pass"},
+    {"label": "Data sources exist", "passed": true, "detail": "5 table(s) configured", "severity": "pass"},
     ...
   ],
-  "findings": ["No join specifications for multi-table space", ...],
+  "findings": ["No join specifications for multi-source space", ...],
   "next_steps": ["Add join specifications to help Genie correctly join your tables", ...],
   "warnings": ["Instructions total 2,500 chars — keep under 2,000", ...],
   "warning_next_steps": ["Restructure text instructions for optimal LLM context usage", ...],
@@ -91,7 +91,7 @@ Beyond the 12 scored checks, the scanner emits additional warnings for edge case
 | No column synonyms defined | "Add synonyms for columns with abbreviated or technical names" |
 | Text instructions > 2,000 chars | "Keep under 2,000 to avoid pushing out higher-value SQL context" |
 | SQL patterns in text instructions | "Move to Example SQLs or SQL Expressions" |
-| Table count 9–12 | "Consider splitting into focused rooms for >8 tables" |
+| Data source count 9–12 | "Consider splitting into focused rooms for >8 data sources" |
 | Example SQLs 8–14 | "10-15 is the sweet spot for largest accuracy jump" |
 | Missing `usage_guidance` on >50% of example SQLs | "Add descriptions of when each example should be applied" |
 | Missing measures or filters in SQL snippets | "Add missing SQL snippet types for better coverage" |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,8 +77,8 @@ export default function App() {
     setDetailState(null)
   }
 
-  const handleCreated = (spaceId: string, displayName: string, initialTab?: string) => {
-    handleSelectSpace(spaceId, displayName, undefined, initialTab, initialTab === "score")
+  const handleCreated = (spaceId: string, displayName: string, spaceUrl?: string, initialTab?: string) => {
+    handleSelectSpace(spaceId, displayName, spaceUrl, initialTab, initialTab === "score")
   }
 
   return (

--- a/frontend/src/components/CreateAgentChat.tsx
+++ b/frontend/src/components/CreateAgentChat.tsx
@@ -41,7 +41,7 @@ import { streamAgentChat } from "@/lib/api"
 import type { AgentChatMessage, AgentUIElement } from "@/types"
 import { TableBrowserDrawer } from "@/components/TableBrowserDrawer"
 interface CreateAgentChatProps {
-  onCreated: (spaceId: string, displayName: string, initialTab?: string) => void
+  onCreated: (spaceId: string, displayName: string, spaceUrl?: string, initialTab?: string) => void
 }
 
 let msgCounter = 0
@@ -2451,7 +2451,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
             Open Genie Space
           </a>
           <button
-            onClick={() => onCreated(space.space_id, space.display_name)}
+            onClick={() => onCreated(space.space_id, space.display_name, space.url)}
             className="flex items-center gap-1.5 px-3 py-1.5 border border-default text-secondary rounded-lg text-xs font-medium hover:bg-elevated transition-colors"
           >
             Diagnose Space
@@ -2484,7 +2484,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
             Open Genie Space
           </a>
           <button
-            onClick={() => onCreated(space.space_id, "", "score")}
+            onClick={() => onCreated(space.space_id, "", space.url, "score")}
             className="flex items-center gap-1.5 px-3 py-1.5 border border-default text-secondary rounded-lg text-xs font-medium hover:bg-elevated transition-colors"
           >
             <BarChart3 className="w-3 h-3" />
@@ -2821,7 +2821,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
             Open Space
           </a>
           <button
-            onClick={() => onCreated(fixResult.spaceId, "", "score")}
+            onClick={() => onCreated(fixResult.spaceId, "", fixResult.url, "score")}
             className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium text-secondary border border-default rounded-lg hover:bg-elevated transition-colors"
           >
             <BarChart3 className="w-3 h-3" />
@@ -2840,7 +2840,7 @@ export function CreateAgentChat({ onCreated }: CreateAgentChatProps) {
             Open Space
           </a>
           <button
-            onClick={() => onCreated(progress.spaceId, progress.spaceDisplayName)}
+            onClick={() => onCreated(progress.spaceId, progress.spaceDisplayName, progress.spaceUrl)}
             className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium text-secondary border border-default rounded-lg hover:bg-elevated transition-colors"
           >
             Diagnose Space

--- a/frontend/src/components/SpaceOverview.tsx
+++ b/frontend/src/components/SpaceOverview.tsx
@@ -43,6 +43,7 @@ function safeObj(val: unknown): Record<string, unknown> {
 function extractOverviewData(spaceData: Record<string, unknown>) {
   const dataSources = safeObj(spaceData.data_sources)
   const tables = safeArray(dataSources.tables)
+  const metricViews = safeArray(dataSources.metric_views)
   const instructions = safeObj(spaceData.instructions)
   const textInstructions = safeArray(instructions.text_instructions)
   const exampleSqls = safeArray(instructions.example_question_sqls)
@@ -63,6 +64,7 @@ function extractOverviewData(spaceData: Record<string, unknown>) {
 
   return {
     tables,
+    metricViews,
     instructionText,
     joinSpecs,
     filters,
@@ -110,32 +112,42 @@ export function SpaceOverview({ spaceData, isLoading }: SpaceOverviewProps) {
   const data = extractOverviewData(spaceData)
   const sqlExpressionCount = data.measures.length + data.filters.length + data.expressions.length
 
+  const renderDataSourceList = (items: unknown[], showColumns = false) =>
+    items.length === 0 ? (
+      <p className="text-muted italic">None configured</p>
+    ) : (
+      <div className="space-y-2">
+        {items.map((item, i) => {
+          const obj = safeObj(item)
+          const identifier = String(obj.identifier || "")
+          const description = joinStringArray(obj.description)
+          return (
+            <div key={i} className="border border-default rounded-lg p-3 bg-elevated">
+              <code className="text-xs font-mono text-accent">{identifier}</code>
+              {description && <p className="text-xs text-secondary mt-1">{description}</p>}
+              {showColumns && (
+                <span className="text-[10px] text-muted mt-1 block">{safeArray(obj.column_configs).length} columns</span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    )
+
   const sections: OverviewSection[] = [
     {
       key: "tables",
       label: "Tables",
       Icon: Table2,
       count: data.tables.length,
-      render: () =>
-        data.tables.length === 0 ? (
-          <p className="text-muted italic">None configured</p>
-        ) : (
-          <div className="space-y-2">
-            {data.tables.map((t, i) => {
-              const table = safeObj(t)
-              const identifier = String(table.identifier || "")
-              const description = joinStringArray(table.description)
-              const columns = safeArray(table.column_configs)
-              return (
-                <div key={i} className="border border-default rounded-lg p-3 bg-elevated">
-                  <code className="text-xs font-mono text-accent">{identifier}</code>
-                  {description && <p className="text-xs text-secondary mt-1">{description}</p>}
-                  <span className="text-[10px] text-muted mt-1 block">{columns.length} columns</span>
-                </div>
-              )
-            })}
-          </div>
-        ),
+      render: () => renderDataSourceList(data.tables, true),
+    },
+    {
+      key: "metric_views",
+      label: "Metric Views",
+      Icon: BarChart3,
+      count: data.metricViews.length,
+      render: () => renderDataSourceList(data.metricViews),
     },
     {
       key: "text_instructions",

--- a/frontend/src/pages/HowItWorks.tsx
+++ b/frontend/src/pages/HowItWorks.tsx
@@ -52,7 +52,7 @@ const stages: Stage[] = [
   { id: "overview", label: "Overview", icon: <Sparkles className="h-4 w-4" />, color: ACCENT },
   { id: "create", label: "Create Agent", icon: <MessageSquarePlus className="h-4 w-4" />, color: CYAN },
   { id: "score", label: "IQ Scanner", icon: <ShieldCheck className="h-4 w-4" />, color: SUCCESS },
-  { id: "fix", label: "Fix Agent", icon: <Wrench className="h-4 w-4" />, color: WARNING },
+  { id: "fix", label: "Quick Fix", icon: <Wrench className="h-4 w-4" />, color: WARNING },
   { id: "optimize", label: "Auto-Optimize", icon: <Zap className="h-4 w-4" />, color: DANGER },
   { id: "permissions", label: "Permissions", icon: <Lock className="h-4 w-4" />, color: INFO },
   { id: "architecture", label: "Architecture", icon: <Layers className="h-4 w-4" />, color: ACCENT },
@@ -185,8 +185,8 @@ function OverviewContent() {
         />
         <FeatureCard
           icon={<Wrench className="h-6 w-6" />}
-          title="Fix"
-          description="Turn scan findings into concrete fixes. The Fix Agent generates JSON patches and applies them directly — no manual editing required."
+          title="Quick Fix"
+          description="Turn scan findings into config-level fixes. Generates JSON patches and applies them directly — for bulk descriptions, use AI Generate in Unity Catalog."
           accentColor={WARNING}
           glowColor={`${WARNING}15`}
         />
@@ -205,7 +205,7 @@ function OverviewContent() {
           steps={[
             { icon: <MessageSquarePlus className="h-5 w-5" />, label: "Create", description: "AI builds your space", color: CYAN },
             { icon: <ShieldCheck className="h-5 w-5" />, label: "Score", description: "12-check quality scan", color: SUCCESS },
-            { icon: <Wrench className="h-5 w-5" />, label: "Fix", description: "Auto-apply patches", color: WARNING },
+            { icon: <Wrench className="h-5 w-5" />, label: "Quick Fix", description: "Auto-apply patches", color: WARNING },
             { icon: <Zap className="h-5 w-5" />, label: "Optimize", description: "Benchmark & refine", color: DANGER },
             { icon: <CheckCircle2 className="h-5 w-5" />, label: "Trusted", description: "Production-ready", color: SUCCESS },
           ]}
@@ -297,12 +297,12 @@ function CreateAgentContent() {
    ================================================================ */
 function IQScannerContent() {
   const configChecks = [
-    { name: "Tables exist", desc: "At least one table attached to the space" },
+    { name: "Data sources exist", desc: "At least one table or metric view attached to the space" },
     { name: "Table descriptions (≥80%)", desc: "80%+ of tables have meaningful descriptions" },
     { name: "Column descriptions (≥50%)", desc: "50%+ of columns are documented" },
     { name: "Text instructions (>50 chars)", desc: "Business context and terminology explained" },
-    { name: "Join specifications", desc: "Join paths defined for multi-table spaces" },
-    { name: "Table count 1–12", desc: "Optimal number of tables for accuracy" },
+    { name: "Join specifications", desc: "Join paths defined for multi-source spaces" },
+    { name: "Data source count 1–12", desc: "Optimal number of tables and metric views for accuracy" },
     { name: "8+ example SQLs", desc: "Diverse query patterns for the model to learn" },
     { name: "SQL snippets", desc: "Functions, expressions, measures, or filters defined" },
     { name: "Entity/format matching", desc: "Categorical and date/number columns annotated" },
@@ -400,8 +400,8 @@ function FixAgentContent() {
   return (
     <div className="space-y-6">
       <div className="text-center mb-2">
-        <h2 className="text-xl font-display font-bold text-primary">Fix Agent</h2>
-        <p className="text-sm text-muted mt-1">Automatically generates and applies fixes from IQ Scanner findings</p>
+        <h2 className="text-xl font-display font-bold text-primary">Quick Fix</h2>
+        <p className="text-sm text-muted mt-1">Automatically generates and applies config-level fixes from IQ Scanner findings</p>
       </div>
 
       <StageCard title="Scan → Fix Pipeline" icon={<Wrench className="h-4 w-4" />}>
@@ -458,6 +458,23 @@ function FixAgentContent() {
           </div>
         </StageCard>
       </div>
+
+      <StageCard title="Limitations" subtitle="What Quick Fix cannot do" icon={<AlertTriangle className="h-4 w-4" />}>
+        <div className="space-y-2.5 text-sm">
+          {[
+            "Column descriptions are capped at 50 per run — use AI Generate in Unity Catalog for bulk coverage",
+            "No data access — descriptions are inferred from column names only, not actual values",
+            "Generated example SQLs are untested — verify them in the Genie Space after applying",
+            "Cannot add or remove tables — manage data sources upstream in Unity Catalog",
+            "Optimization checks (11–12) require running the Optimize pipeline",
+          ].map((item) => (
+            <div key={item} className="flex items-start gap-2.5">
+              <XCircle className="h-4 w-4 text-red-400 shrink-0 mt-0.5" />
+              <span className="text-secondary">{item}</span>
+            </div>
+          ))}
+        </div>
+      </StageCard>
     </div>
   )
 }

--- a/frontend/src/pages/IQScoreTab.tsx
+++ b/frontend/src/pages/IQScoreTab.tsx
@@ -289,14 +289,22 @@ export function IQScoreTab({ scanResult, isLoading, onScan, isScanning, onAction
 
           {/* Single contextual action */}
           {onAction && actionLabel && (
-            <div className="mt-4 pt-4 border-t border-default">
+            <div className="mt-4 pt-4 border-t border-default flex items-start gap-4">
               <button
                 onClick={onAction}
-                className="flex items-center gap-2 text-sm font-medium px-4 py-2.5 rounded-lg bg-accent text-white hover:bg-accent/90 transition-colors"
+                className="flex items-center gap-2 text-sm font-medium px-4 py-2.5 rounded-lg bg-accent text-white hover:bg-accent/90 transition-colors shrink-0"
               >
                 {actionIcon}
                 {actionLabel}
               </button>
+              {actionLabel === "Quick Fix" && (
+                <p className="text-xs text-muted leading-relaxed pt-0.5">
+                  Fixes most config issues automatically. Column descriptions are limited to 50 per
+                  run and inferred from names — use <strong className="text-secondary">AI Generate</strong> in
+                  Unity Catalog for bulk or higher-accuracy results. Adding tables and optimization
+                  require separate workflows.
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/pages/SpaceDetail.tsx
+++ b/frontend/src/pages/SpaceDetail.tsx
@@ -171,10 +171,10 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
   const maturity = scanResult?.maturity
   let actionProps: { onAction?: () => void; actionLabel?: string; actionIcon?: React.ReactNode } = {}
   if (hasFixableItems && scanResult) {
-    // Show "Fix Issues" whenever there are findings or warnings to address
+    // Show "Quick Fix" whenever there are findings or warnings to address
     actionProps = {
       onAction: () => openFixPanel(scanResult),
-      actionLabel: "Fix Issues",
+      actionLabel: "Quick Fix",
       actionIcon: <Zap className="w-4 h-4" />,
     }
   } else if (maturity === "Ready to Optimize") {


### PR DESCRIPTION
## Summary

- **IQ Scanner UC enrichment (#62)**: Before scoring, `scan_space()` now fetches table/column descriptions from Unity Catalog via `WorkspaceClient.tables.get()` and merges them into the space config. Checks 2 (table descriptions) and 3 (column descriptions) now reflect upstream UC metadata even when not inlined in the Genie Space config. Gracefully skips on failure.
- **Duplicate space guard (#67)**: Adds idempotency guards in `_create_space_with_repair()` and the main tool dispatch loop to prevent creating duplicate Genie Spaces when the LLM returns `[generate_config, create_space]` in a single response and the auto-chain races with the explicit tool call.
- **Metric view support in IQ Scanner**: Checks 1, 2, 3, 5, 6, and 9 now count metric views alongside tables. Metric-view-only spaces auto-pass description checks (managed in UC).
- **Fix Agent → Quick Fix rename**: UI-facing terminology updated across frontend, README, AGENTS.md, and docs.
- **`add_measure` alias bug fix**: The `add_measure` action now correctly requires `alias` (not `display_name`) per the Genie API schema.
- **SpaceUrl prop fix**: "Diagnose Space" and "Re-scan" buttons in Create Agent now pass `spaceUrl` through to SpaceDetail, so the hyperlink icon appears immediately.

## Test plan

- [x] `python3 -m pytest backend/tests/ -v` — 336 tests pass
- [x] `cd frontend && npx tsc --noEmit` — 0 errors
- [x] Deploy to workspace → scan a space with UC table/column descriptions but no inline config descriptions → verify checks 2-3 reflect UC coverage
- [x] Deploy → run Create Agent → verify only one space is created (not duplicates)
- [x] Deploy → Create Agent → "Diagnose Space" → verify hyperlink icon appears next to space ID

This pull request was AI-assisted by Isaac.