### PR TITLE
Add User-Agent telemetry to all Databricks SDK calls

### DIFF
--- a/backend/_telemetry.py
+++ b/backend/_telemetry.py
@@ -1,0 +1,4 @@
+"""Databricks SDK telemetry constants for the genie-workbench product."""
+
+PRODUCT_NAME = "genie-workbench"
+PRODUCT_VERSION = "0.1.0"  # Keep in sync with pyproject.toml

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -16,6 +16,8 @@ from contextvars import ContextVar
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.config import Config
 
+from backend._telemetry import PRODUCT_NAME, PRODUCT_VERSION
+
 logger = logging.getLogger(__name__)
 
 # Singleton client for local dev (or fallback when no user token is available)
@@ -55,7 +57,7 @@ def set_obo_user_token(token: str) -> None:
         client_id=None,
         client_secret=None,  # gitleaks:allow
     )
-    client = WorkspaceClient(config=cfg)
+    client = WorkspaceClient(config=cfg, product=PRODUCT_NAME, product_version=PRODUCT_VERSION)
     _obo_client.set(client)
     logger.debug("OBO client set for current request (host=%s, auth=%s)", host, cfg.auth_type)
 
@@ -70,7 +72,7 @@ def _get_default_client() -> WorkspaceClient:
     global _client, _auth_logged
 
     if _client is None:
-        _client = WorkspaceClient()
+        _client = WorkspaceClient(product=PRODUCT_NAME, product_version=PRODUCT_VERSION)
 
         if not _auth_logged:
             logger.info("=== Databricks SDK Authentication ===")

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/_telemetry.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/_telemetry.py
@@ -1,0 +1,5 @@
+"""Databricks SDK telemetry constants for the genie-space-optimizer product."""
+
+from genie_space_optimizer import __version__ as PRODUCT_VERSION
+
+PRODUCT_NAME = "genie-space-optimizer"

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/_workspace_client.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/_workspace_client.py
@@ -1,0 +1,14 @@
+"""Factory for creating telemetry-tagged WorkspaceClient instances."""
+
+from databricks.sdk import WorkspaceClient
+
+from genie_space_optimizer._telemetry import PRODUCT_NAME, PRODUCT_VERSION
+
+
+def make_workspace_client(**kwargs) -> WorkspaceClient:
+    """Create a WorkspaceClient tagged with GSO product telemetry."""
+    return WorkspaceClient(
+        product=PRODUCT_NAME,
+        product_version=PRODUCT_VERSION,
+        **kwargs,
+    )

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/backend/core/_defaults.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/backend/core/_defaults.py
@@ -6,6 +6,8 @@ from contextlib import asynccontextmanager
 from databricks.sdk import WorkspaceClient
 from fastapi import Depends, FastAPI, Request
 
+from genie_space_optimizer._workspace_client import make_workspace_client
+
 from ._base import LifespanDependency
 from ._config import AppConfig, logger
 from ._headers import HeadersDependency
@@ -26,7 +28,7 @@ class _ConfigDependency(LifespanDependency):
 class _WorkspaceClientDependency(LifespanDependency):
     @asynccontextmanager
     async def lifespan(self, app: FastAPI) -> AsyncGenerator[None, None]:
-        app.state.workspace_client = WorkspaceClient()
+        app.state.workspace_client = make_workspace_client()
         yield
 
     @staticmethod
@@ -49,10 +51,10 @@ def _get_user_ws(
             "OBO token not available — falling back to service principal credentials. "
             "User-scoped permissions will not apply."
         )
-        return WorkspaceClient()
+        return make_workspace_client()
 
     host = os.environ.get("DATABRICKS_HOST", "")
-    return WorkspaceClient(
+    return make_workspace_client(
         host=host,
         token=headers.token.get_secret_value(),
         auth_type="pat",

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/backend/core/lakebase.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/backend/core/lakebase.py
@@ -112,7 +112,8 @@ def validate_db(engine: Engine, db_config: DatabaseConfig) -> None:
             f"Validating database connection to instance {db_config.instance_name}"
         )
         try:
-            ws = WorkspaceClient()
+            from genie_space_optimizer._workspace_client import make_workspace_client
+            ws = make_workspace_client()
             ws.database.get_database_instance(db_config.instance_name)
         except NotFound:
             raise ValueError(

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_baseline.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_baseline.py
@@ -200,7 +200,8 @@ _log = partial(_log_base, _TASK_LABEL)
 
 # COMMAND ----------
 
-w = WorkspaceClient()
+from genie_space_optimizer._workspace_client import make_workspace_client
+w = make_workspace_client()
 spark = SparkSession.builder.getOrCreate()
 
 # Read task values from preflight

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_cross_env_deploy.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_cross_env_deploy.py
@@ -152,8 +152,9 @@ _log("Config loaded", keys=list(space_config.keys()))
 
 _banner("Connecting to Target Workspace")
 
+from genie_space_optimizer._workspace_client import make_workspace_client
 target_url = target_workspace_url.rstrip("/")
-target_ws = WorkspaceClient(host=target_url)
+target_ws = make_workspace_client(host=target_url)
 
 current_user = target_ws.current_user.me()
 _log(

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_deploy.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_deploy.py
@@ -125,7 +125,8 @@ _log = partial(_log_base, _TASK_LABEL)
 
 # COMMAND ----------
 
-w = WorkspaceClient()
+from genie_space_optimizer._workspace_client import make_workspace_client
+w = make_workspace_client()
 spark = SparkSession.builder.getOrCreate()
 
 # Read task values from upstream

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_enrichment.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_enrichment.py
@@ -66,7 +66,8 @@ _log = partial(_log_base, _TASK_LABEL)
 
 # COMMAND ----------
 
-w = WorkspaceClient()
+from genie_space_optimizer._workspace_client import make_workspace_client
+w = make_workspace_client()
 spark = SparkSession.builder.getOrCreate()
 
 run_id = dbutils.jobs.taskValues.get(taskKey="preflight", key="run_id")

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_evaluation_only.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_evaluation_only.py
@@ -169,7 +169,8 @@ _log(
 
 # COMMAND ----------
 
-w = WorkspaceClient()
+from genie_space_optimizer._workspace_client import make_workspace_client
+w = make_workspace_client()
 spark = SparkSession.builder.getOrCreate()
 
 import mlflow

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
@@ -149,7 +149,8 @@ _log = partial(_log_base, _TASK_LABEL)
 
 # COMMAND ----------
 
-w = WorkspaceClient()
+from genie_space_optimizer._workspace_client import make_workspace_client
+w = make_workspace_client()
 spark = SparkSession.builder.getOrCreate()
 
 from genie_space_optimizer.common.genie_client import (

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_lever_loop.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_lever_loop.py
@@ -203,7 +203,8 @@ _log = partial(_log_base, _TASK_LABEL)
 
 # COMMAND ----------
 
-w = WorkspaceClient()
+from genie_space_optimizer._workspace_client import make_workspace_client
+w = make_workspace_client()
 spark = SparkSession.builder.getOrCreate()
 
 # Read task values from upstream

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_preflight.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_preflight.py
@@ -256,7 +256,8 @@ _log(
 
 # COMMAND ----------
 
-w = WorkspaceClient()
+from genie_space_optimizer._workspace_client import make_workspace_client
+w = make_workspace_client()
 spark = SparkSession.builder.getOrCreate()
 
 from genie_space_optimizer.common.genie_client import (

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
@@ -6826,7 +6826,8 @@ def optimize_genie_space(
     (e.g. the backend ``start_optimization`` endpoint), so we skip
     ``create_run`` to avoid duplicating the row.
     """
-    w = WorkspaceClient()
+    from genie_space_optimizer._workspace_client import make_workspace_client
+    w = make_workspace_client()
     from genie_space_optimizer.common.genie_client import (
         configure_connection_pool,
         configure_mlflow_connection_pool,

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/optimizer.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/optimizer.py
@@ -17,6 +17,7 @@ from collections import Counter, defaultdict
 from typing import Any
 
 from databricks.sdk import WorkspaceClient
+from genie_space_optimizer._workspace_client import make_workspace_client
 from genie_space_optimizer.optimization.llm_client import (
     _openai_client_cache,
     _resolve_bearer_token,
@@ -91,7 +92,7 @@ def _ws_with_timeout(
     from databricks.sdk.config import Config
 
     if w is None:
-        return WorkspaceClient(config=Config(http_timeout_seconds=timeout))
+        return make_workspace_client(config=Config(http_timeout_seconds=timeout))
 
     cfg_kwargs: dict[str, Any] = {}
     for attr in Config.attributes():
@@ -100,7 +101,7 @@ def _ws_with_timeout(
             cfg_kwargs[attr.name] = val
     cfg_kwargs["http_timeout_seconds"] = timeout
 
-    return WorkspaceClient(
+    return make_workspace_client(
         config=Config(
             credentials_strategy=w.config._credentials_strategy,
             **cfg_kwargs,

--- a/scripts/setup_synced_tables.py
+++ b/scripts/setup_synced_tables.py
@@ -225,7 +225,8 @@ def main():
     print(f"Source: {source_catalog}.{source_schema}")
     print(f"Synced tables: {source_catalog}.{source_schema}.*{SYNCED_SUFFIX}")
 
-    w = WorkspaceClient()
+    from backend._telemetry import PRODUCT_NAME, PRODUCT_VERSION
+    w = WorkspaceClient(product=PRODUCT_NAME, product_version=PRODUCT_VERSION)
 
     # Use explicit warehouse ID if provided, otherwise auto-detect
     if explicit_warehouse_id:


### PR DESCRIPTION
## Summary

- Tag every `WorkspaceClient` with product identifiers so Databricks internal telemetry can track adoption and map workspaces to customers
- Root backend: `genie-workbench/0.1.0`
- GSO package: `genie-space-optimizer/<dynamic version>`
- Factory pattern (`make_workspace_client()`) in the GSO package to keep it DRY across 15 call sites

## Test plan

- [x] `python -c "from backend._telemetry import PRODUCT_NAME, PRODUCT_VERSION; print(f'{PRODUCT_NAME}/{PRODUCT_VERSION}')"` → `genie-workbench/0.1.0`
- [x] Deploy and verify SDK debug logs contain product User-Agent string
- [x] Confirm in Databricks internal telemetry that API calls carry the tagged User-Agent

This pull request was AI-assisted by Isaac.