### PR TITLE
Add Deploy tab: cross-workspace Genie Space deployment with catalog remapping

### DIFF
--- a/backend/routers/auto_optimize.py
+++ b/backend/routers/auto_optimize.py
@@ -883,6 +883,58 @@ async def trigger(body: TriggerRequest, request: Request):
         raise HTTPException(status_code=500, detail="Failed to start optimization job.")
 
 
+class DeployRequest(BaseModel):
+    target_workspace_url: str
+    target_space_id: str | None = None
+    catalog_map: dict[str, str] | None = None
+
+
+@router.post("/runs/{run_id}/deploy")
+async def deploy_run(run_id: RunId, body: DeployRequest):
+    """Trigger cross-workspace deployment for a completed optimization run."""
+    if not _is_configured():
+        raise HTTPException(status_code=503, detail="Auto-Optimize is not configured.")
+
+    # Load run to get UC model info
+    run = await gso_lakebase.load_gso_run(run_id)
+    if not run and _is_configured():
+        config = _build_gso_config()
+        run = _fetch_run_via_sql(run_id, config)
+    if not run:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    status = run.get("status", "")
+    terminal = {"CONVERGED", "STALLED", "MAX_ITERATIONS", "APPLIED"}
+    if status not in terminal:
+        raise HTTPException(status_code=400, detail=f"Run is {status} — can only deploy terminal runs")
+
+    # Get model name/version from the run's finalize output
+    model_name = run.get("uc_model_name") or run.get("model_name")
+    model_version = run.get("uc_model_version") or run.get("model_version")
+    if not model_name or not model_version:
+        raise HTTPException(status_code=400, detail="Run has no registered UC model — cannot deploy")
+
+    try:
+        import json as _json
+        from genie_space_optimizer.backend.job_launcher import ensure_deployment_job
+        sp_ws = get_service_principal_client()
+        config = _build_gso_config()
+
+        job_run_id = ensure_deployment_job(
+            ws=sp_ws,
+            job_id=config.job_id,
+            model_name=model_name,
+            model_version=str(model_version),
+            target_workspace_url=body.target_workspace_url,
+            target_space_id=body.target_space_id or "",
+            catalog_map=_json.dumps(body.catalog_map) if body.catalog_map else "",
+        )
+        return {"jobRunId": str(job_run_id), "status": "DEPLOYING"}
+    except Exception as e:
+        logger.exception("Failed to trigger deployment: %s", e)
+        raise HTTPException(status_code=500, detail=f"Deployment failed: {e}")
+
+
 # ---------------------------------------------------------------------------
 # Pipeline step definitions — group raw sub-stages into 6 logical steps
 # (Ported from Genie Space Optimizer's map_stages_to_steps)

--- a/backend/routers/auto_optimize.py
+++ b/backend/routers/auto_optimize.py
@@ -889,49 +889,48 @@ class DeployRequest(BaseModel):
     catalog_map: dict[str, str] | None = None
 
 
-@router.post("/runs/{run_id}/deploy")
-async def deploy_run(run_id: RunId, body: DeployRequest):
-    """Trigger cross-workspace deployment for a completed optimization run."""
-    if not _is_configured():
-        raise HTTPException(status_code=503, detail="Auto-Optimize is not configured.")
+@router.post("/spaces/{space_id}/deploy")
+async def deploy_space(space_id: str, body: DeployRequest):
+    """Deploy a Genie Space config to a target workspace.
 
-    # Load run to get UC model info
-    run = await gso_lakebase.load_gso_run(run_id)
-    if not run and _is_configured():
-        config = _build_gso_config()
-        run = _fetch_run_via_sql(run_id, config)
-    if not run:
-        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+    Fetches the current space config, applies catalog remapping, and
+    PATCHes it to the target workspace. No UC model or optimization run
+    required — works with any Genie Space.
+    """
+    import json as _json
 
-    status = run.get("status", "")
-    terminal = {"CONVERGED", "STALLED", "MAX_ITERATIONS", "APPLIED"}
-    if status not in terminal:
-        raise HTTPException(status_code=400, detail=f"Run is {status} — can only deploy terminal runs")
-
-    # Get model name/version from the run's finalize output
-    model_name = run.get("uc_model_name") or run.get("model_name")
-    model_version = run.get("uc_model_version") or run.get("model_version")
-    if not model_name or not model_version:
-        raise HTTPException(status_code=400, detail="Run has no registered UC model — cannot deploy")
-
+    # 1. Fetch source space config
     try:
-        import json as _json
-        from genie_space_optimizer.backend.job_launcher import ensure_deployment_job
-        sp_ws = get_service_principal_client()
-        config = _build_gso_config()
-
-        job_run_id = ensure_deployment_job(
-            ws=sp_ws,
-            job_id=config.job_id,
-            model_name=model_name,
-            model_version=str(model_version),
-            target_workspace_url=body.target_workspace_url,
-            target_space_id=body.target_space_id or "",
-            catalog_map=_json.dumps(body.catalog_map) if body.catalog_map else "",
-        )
-        return {"jobRunId": str(job_run_id), "status": "DEPLOYING"}
+        from backend.services.genie_client import get_serialized_space
+        space_config = get_serialized_space(genie_space_id=space_id)
     except Exception as e:
-        logger.exception("Failed to trigger deployment: %s", e)
+        raise HTTPException(status_code=400, detail=f"Failed to fetch space config: {e}")
+
+    # 2. Apply catalog remapping
+    if body.catalog_map:
+        remapped = 0
+        for key in ("tables", "metric_views"):
+            for src in space_config.get("data_sources", {}).get(key, []):
+                ident = src.get("identifier", "")
+                parts = ident.replace("`", "").split(".")
+                if len(parts) >= 3 and parts[0] in body.catalog_map:
+                    parts[0] = body.catalog_map[parts[0]]
+                    src["identifier"] = ".".join(parts)
+                    remapped += 1
+        logger.info("Remapped %d catalog references for deploy", remapped)
+
+    # 3. PATCH to target workspace
+    try:
+        from databricks.sdk import WorkspaceClient
+        target_ws = WorkspaceClient(host=body.target_workspace_url.rstrip("/"))
+        target_space = body.target_space_id or space_id
+
+        from genie_space_optimizer.common.genie_client import patch_space_config
+        result = patch_space_config(target_ws, target_space, space_config)
+
+        return {"status": "DEPLOYED", "targetSpaceId": target_space, "targetUrl": body.target_workspace_url}
+    except Exception as e:
+        logger.exception("Failed to deploy to target workspace: %s", e)
         raise HTTPException(status_code=500, detail=f"Deployment failed: {e}")
 
 

--- a/backend/routers/auto_optimize.py
+++ b/backend/routers/auto_optimize.py
@@ -919,10 +919,21 @@ async def deploy_space(space_id: str, body: DeployRequest):
                     remapped += 1
         logger.info("Remapped %d catalog references for deploy", remapped)
 
-    # 3. PATCH to target workspace
+    # 3. PATCH to target workspace (use OBO token so user's identity authenticates)
     try:
         from databricks.sdk import WorkspaceClient
-        target_ws = WorkspaceClient(host=body.target_workspace_url.rstrip("/"))
+        from databricks.sdk.config import Config
+        from backend.services.auth import get_workspace_client
+        obo_ws = get_workspace_client()
+        obo_token = obo_ws.config.token
+        target_cfg = Config(
+            host=body.target_workspace_url.rstrip("/"),
+            token=obo_token,
+            auth_type="pat",
+            client_id=None,
+            client_secret=None,
+        )
+        target_ws = WorkspaceClient(config=target_cfg)
         target_space = body.target_space_id or space_id
 
         from genie_space_optimizer.common.genie_client import patch_space_config

--- a/backend/routers/auto_optimize.py
+++ b/backend/routers/auto_optimize.py
@@ -919,9 +919,8 @@ async def deploy_space(space_id: str, body: DeployRequest):
                     remapped += 1
         logger.info("Remapped %d catalog references for deploy", remapped)
 
-    # 3. PATCH to target workspace using the app's SP credentials.
-    #    The SP must be registered in the target workspace with CAN_MANAGE
-    #    on the target Genie Space.
+    # 3. Connect to target workspace using the app's SP credentials.
+    #    The SP must be registered in the target workspace.
     try:
         from databricks.sdk import WorkspaceClient
         sp_ws = get_service_principal_client()
@@ -930,12 +929,50 @@ async def deploy_space(space_id: str, body: DeployRequest):
             client_id=sp_ws.config.client_id,
             client_secret=sp_ws.config.client_secret,
         )
-        target_space = body.target_space_id or space_id
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to connect to target workspace: {e}")
 
-        from genie_space_optimizer.common.genie_client import patch_space_config
-        result = patch_space_config(target_ws, target_space, space_config)
+    # 4. Deploy: PATCH existing space or CREATE new one
+    try:
+        if body.target_space_id:
+            # Update existing space
+            from genie_space_optimizer.common.genie_client import patch_space_config
+            patch_space_config(target_ws, body.target_space_id, space_config)
+            target_space = body.target_space_id
+            logger.info("PATCHed existing space %s in target workspace", target_space)
+        else:
+            # Create new space in target workspace
+            from backend.services.genie_client import get_genie_space
+            source_space = get_genie_space(genie_space_id=space_id)
+            display_name = source_space.get("title", "Deployed Genie Space")
 
-        return {"status": "DEPLOYED", "targetSpaceId": target_space, "targetUrl": body.target_workspace_url}
+            # Find a warehouse in the target workspace
+            warehouses = list(target_ws.warehouses.list())
+            if not warehouses:
+                raise ValueError("No SQL warehouse found in target workspace")
+            target_warehouse_id = warehouses[0].id
+
+            response = target_ws.api_client.do(
+                method="POST",
+                path="/api/2.0/genie/spaces",
+                body={
+                    "title": display_name,
+                    "description": f"Deployed from source workspace (space {space_id})",
+                    "parent_path": "/Shared/",
+                    "warehouse_id": target_warehouse_id,
+                    "serialized_space": _json.dumps(space_config),
+                },
+            )
+            target_space = response.get("space_id", "")
+            logger.info("Created new space %s in target workspace", target_space)
+
+        target_host = body.target_workspace_url.rstrip("/")
+        return {
+            "status": "DEPLOYED",
+            "targetSpaceId": target_space,
+            "targetUrl": target_host,
+            "spaceUrl": f"{target_host}/genie/rooms/{target_space}",
+        }
     except Exception as e:
         logger.exception("Failed to deploy to target workspace: %s", e)
         raise HTTPException(status_code=500, detail=f"Deployment failed: {e}")

--- a/backend/routers/auto_optimize.py
+++ b/backend/routers/auto_optimize.py
@@ -61,6 +61,8 @@ class TriggerRequest(BaseModel):
     apply_mode: str = "genie_config"
     levers: list[int] | None = None
     deploy_target: str | None = None
+    deploy_space_id: str | None = None
+    catalog_map: dict[str, str] | None = None
 
 
 class SchemaAccessStatus(BaseModel):
@@ -857,6 +859,8 @@ async def trigger(body: TriggerRequest, request: Request):
             apply_mode=body.apply_mode,
             levers=body.levers,
             deploy_target=body.deploy_target,
+            deploy_space_id=body.deploy_space_id,
+            catalog_map=body.catalog_map,
         )
         return {
             "runId": result.run_id,

--- a/backend/routers/auto_optimize.py
+++ b/backend/routers/auto_optimize.py
@@ -1166,6 +1166,7 @@ async def get_run(run_id: RunId):
         "levers": levers,
         "links": links,
         "convergenceReason": run.get("convergence_reason"),
+        "deployTarget": run.get("deploy_target") or None,
         "deploymentStatus": run.get("deploy_status"),
         "labelingSessionUrl": run.get("labeling_session_url") or None,
         "labelingSessionName": run.get("labeling_session_name") or None,

--- a/backend/routers/auto_optimize.py
+++ b/backend/routers/auto_optimize.py
@@ -919,21 +919,17 @@ async def deploy_space(space_id: str, body: DeployRequest):
                     remapped += 1
         logger.info("Remapped %d catalog references for deploy", remapped)
 
-    # 3. PATCH to target workspace (use OBO token so user's identity authenticates)
+    # 3. PATCH to target workspace using the app's SP credentials.
+    #    The SP must be registered in the target workspace with CAN_MANAGE
+    #    on the target Genie Space.
     try:
         from databricks.sdk import WorkspaceClient
-        from databricks.sdk.config import Config
-        from backend.services.auth import get_workspace_client
-        obo_ws = get_workspace_client()
-        obo_token = obo_ws.config.token
-        target_cfg = Config(
+        sp_ws = get_service_principal_client()
+        target_ws = WorkspaceClient(
             host=body.target_workspace_url.rstrip("/"),
-            token=obo_token,
-            auth_type="pat",
-            client_id=None,
-            client_secret=None,
+            client_id=sp_ws.config.client_id,
+            client_secret=sp_ws.config.client_secret,
         )
-        target_ws = WorkspaceClient(config=target_cfg)
         target_space = body.target_space_id or space_id
 
         from genie_space_optimizer.common.genie_client import patch_space_config

--- a/frontend/src/components/auto-optimize/OptimizationConfig.tsx
+++ b/frontend/src/components/auto-optimize/OptimizationConfig.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { AlertTriangle, ChevronDown, ChevronRight, Plus, Rocket, Trash2, Upload } from "lucide-react"
+import { AlertTriangle, Rocket } from "lucide-react"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import { triggerAutoOptimize } from "@/lib/api"
@@ -33,12 +33,6 @@ export function OptimizationConfig({ spaceId, onStarted, onTriggerStart, onTrigg
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  // Deployment config
-  const [deployExpanded, setDeployExpanded] = useState(false)
-  const [deployTarget, setDeployTarget] = useState("")
-  const [deploySpaceId, setDeploySpaceId] = useState("")
-  const [catalogMappings, setCatalogMappings] = useState<{ source: string; target: string }[]>([])
-
   const hasHealthIssues = (healthIssues?.length ?? 0) > 0
   const canStart = permissions?.can_start === true && !hasHealthIssues
 
@@ -56,18 +50,10 @@ export function OptimizationConfig({ spaceId, onStarted, onTriggerStart, onTrigg
     setError(null)
     onTriggerStart?.()
     try {
-      const catalogMap = catalogMappings.reduce<Record<string, string>>((acc, m) => {
-        if (m.source.trim() && m.target.trim()) acc[m.source.trim()] = m.target.trim()
-        return acc
-      }, {})
-
       const result = await triggerAutoOptimize({
         space_id: spaceId,
         apply_mode: applyMode,
         levers: Array.from(selectedLevers).sort(),
-        deploy_target: deployTarget.trim() || undefined,
-        deploy_space_id: deploySpaceId.trim() || undefined,
-        catalog_map: Object.keys(catalogMap).length > 0 ? catalogMap : undefined,
       })
       onStarted(result.runId)
     } catch (e) {
@@ -116,99 +102,6 @@ export function OptimizationConfig({ spaceId, onStarted, onTriggerStart, onTrigg
               ))}
             </div>
           </div>
-        </div>
-
-        {/* Deployment (collapsible) */}
-        <div className="border border-default rounded-lg">
-          <button
-            type="button"
-            onClick={() => setDeployExpanded(!deployExpanded)}
-            className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-secondary hover:text-primary transition-colors"
-          >
-            {deployExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-            <Upload className="w-4 h-4" />
-            Cross-Workspace Deployment
-            {deployTarget && <span className="ml-2 text-xs text-accent font-normal">Configured</span>}
-          </button>
-          {deployExpanded && (
-            <div className="px-4 pb-4 space-y-3 border-t border-default pt-3">
-              <p className="text-xs text-muted">
-                After optimization, deploy the optimized config to a target workspace. Leave blank to skip deployment.
-              </p>
-
-              <div className="space-y-1">
-                <label className="text-xs font-medium text-muted">Target workspace URL</label>
-                <input
-                  type="url"
-                  value={deployTarget}
-                  onChange={(e) => setDeployTarget(e.target.value)}
-                  placeholder="https://my-prod-workspace.cloud.databricks.com"
-                  className="w-full px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
-                />
-              </div>
-
-              <div className="space-y-1">
-                <label className="text-xs font-medium text-muted">Target space ID <span className="text-muted font-normal">(optional — creates new if blank)</span></label>
-                <input
-                  type="text"
-                  value={deploySpaceId}
-                  onChange={(e) => setDeploySpaceId(e.target.value)}
-                  placeholder="01f1347d7f1516ceaea7e5853166498f"
-                  className="w-full px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <label className="text-xs font-medium text-muted">Catalog mapping <span className="text-muted font-normal">(source → target)</span></label>
-                  <button
-                    type="button"
-                    onClick={() => setCatalogMappings([...catalogMappings, { source: "", target: "" }])}
-                    className="flex items-center gap-1 text-xs text-accent hover:text-accent/80 transition-colors"
-                  >
-                    <Plus className="w-3 h-3" /> Add mapping
-                  </button>
-                </div>
-                {catalogMappings.map((m, i) => (
-                  <div key={i} className="flex items-center gap-2">
-                    <input
-                      type="text"
-                      value={m.source}
-                      onChange={(e) => {
-                        const next = [...catalogMappings]
-                        next[i] = { ...next[i], source: e.target.value }
-                        setCatalogMappings(next)
-                      }}
-                      placeholder="dev_catalog"
-                      className="flex-1 px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
-                    />
-                    <span className="text-xs text-muted">→</span>
-                    <input
-                      type="text"
-                      value={m.target}
-                      onChange={(e) => {
-                        const next = [...catalogMappings]
-                        next[i] = { ...next[i], target: e.target.value }
-                        setCatalogMappings(next)
-                      }}
-                      placeholder="prod_catalog"
-                      className="flex-1 px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setCatalogMappings(catalogMappings.filter((_, j) => j !== i))}
-                      className="text-muted hover:text-danger transition-colors"
-                    >
-                      <Trash2 className="w-3.5 h-3.5" />
-                    </button>
-                  </div>
-                ))}
-                {catalogMappings.length === 0 && (
-                  <p className="text-xs text-muted italic">No catalog mappings — table references will be used as-is</p>
-                )}
-              </div>
-            </div>
-          )}
         </div>
 
         {/* Health Issues */}

--- a/frontend/src/components/auto-optimize/OptimizationConfig.tsx
+++ b/frontend/src/components/auto-optimize/OptimizationConfig.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { AlertTriangle, Rocket } from "lucide-react"
+import { AlertTriangle, ChevronDown, ChevronRight, Plus, Rocket, Trash2, Upload } from "lucide-react"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import { triggerAutoOptimize } from "@/lib/api"
@@ -33,6 +33,12 @@ export function OptimizationConfig({ spaceId, onStarted, onTriggerStart, onTrigg
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Deployment config
+  const [deployExpanded, setDeployExpanded] = useState(false)
+  const [deployTarget, setDeployTarget] = useState("")
+  const [deploySpaceId, setDeploySpaceId] = useState("")
+  const [catalogMappings, setCatalogMappings] = useState<{ source: string; target: string }[]>([])
+
   const hasHealthIssues = (healthIssues?.length ?? 0) > 0
   const canStart = permissions?.can_start === true && !hasHealthIssues
 
@@ -50,10 +56,18 @@ export function OptimizationConfig({ spaceId, onStarted, onTriggerStart, onTrigg
     setError(null)
     onTriggerStart?.()
     try {
+      const catalogMap = catalogMappings.reduce<Record<string, string>>((acc, m) => {
+        if (m.source.trim() && m.target.trim()) acc[m.source.trim()] = m.target.trim()
+        return acc
+      }, {})
+
       const result = await triggerAutoOptimize({
         space_id: spaceId,
         apply_mode: applyMode,
         levers: Array.from(selectedLevers).sort(),
+        deploy_target: deployTarget.trim() || undefined,
+        deploy_space_id: deploySpaceId.trim() || undefined,
+        catalog_map: Object.keys(catalogMap).length > 0 ? catalogMap : undefined,
       })
       onStarted(result.runId)
     } catch (e) {
@@ -102,6 +116,99 @@ export function OptimizationConfig({ spaceId, onStarted, onTriggerStart, onTrigg
               ))}
             </div>
           </div>
+        </div>
+
+        {/* Deployment (collapsible) */}
+        <div className="border border-default rounded-lg">
+          <button
+            type="button"
+            onClick={() => setDeployExpanded(!deployExpanded)}
+            className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-secondary hover:text-primary transition-colors"
+          >
+            {deployExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+            <Upload className="w-4 h-4" />
+            Cross-Workspace Deployment
+            {deployTarget && <span className="ml-2 text-xs text-accent font-normal">Configured</span>}
+          </button>
+          {deployExpanded && (
+            <div className="px-4 pb-4 space-y-3 border-t border-default pt-3">
+              <p className="text-xs text-muted">
+                After optimization, deploy the optimized config to a target workspace. Leave blank to skip deployment.
+              </p>
+
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-muted">Target workspace URL</label>
+                <input
+                  type="url"
+                  value={deployTarget}
+                  onChange={(e) => setDeployTarget(e.target.value)}
+                  placeholder="https://my-prod-workspace.cloud.databricks.com"
+                  className="w-full px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-muted">Target space ID <span className="text-muted font-normal">(optional — creates new if blank)</span></label>
+                <input
+                  type="text"
+                  value={deploySpaceId}
+                  onChange={(e) => setDeploySpaceId(e.target.value)}
+                  placeholder="01f1347d7f1516ceaea7e5853166498f"
+                  className="w-full px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <label className="text-xs font-medium text-muted">Catalog mapping <span className="text-muted font-normal">(source → target)</span></label>
+                  <button
+                    type="button"
+                    onClick={() => setCatalogMappings([...catalogMappings, { source: "", target: "" }])}
+                    className="flex items-center gap-1 text-xs text-accent hover:text-accent/80 transition-colors"
+                  >
+                    <Plus className="w-3 h-3" /> Add mapping
+                  </button>
+                </div>
+                {catalogMappings.map((m, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <input
+                      type="text"
+                      value={m.source}
+                      onChange={(e) => {
+                        const next = [...catalogMappings]
+                        next[i] = { ...next[i], source: e.target.value }
+                        setCatalogMappings(next)
+                      }}
+                      placeholder="dev_catalog"
+                      className="flex-1 px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+                    />
+                    <span className="text-xs text-muted">→</span>
+                    <input
+                      type="text"
+                      value={m.target}
+                      onChange={(e) => {
+                        const next = [...catalogMappings]
+                        next[i] = { ...next[i], target: e.target.value }
+                        setCatalogMappings(next)
+                      }}
+                      placeholder="prod_catalog"
+                      className="flex-1 px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setCatalogMappings(catalogMappings.filter((_, j) => j !== i))}
+                      className="text-muted hover:text-danger transition-colors"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                ))}
+                {catalogMappings.length === 0 && (
+                  <p className="text-xs text-muted italic">No catalog mappings — table references will be used as-is</p>
+                )}
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Health Issues */}

--- a/frontend/src/components/auto-optimize/RunDetailView.tsx
+++ b/frontend/src/components/auto-optimize/RunDetailView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { ArrowLeft, Cog, UserCheck, ExternalLink, Upload, CheckCircle2, Clock, AlertTriangle } from "lucide-react"
+import { ArrowLeft, ChevronDown, ChevronRight, Cog, UserCheck, ExternalLink, Plus, Rocket, Trash2, Upload, CheckCircle2, Clock, AlertTriangle } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { ScoreSummary } from "@/components/auto-optimize/ScoreSummary"
@@ -9,6 +9,7 @@ import { PipelineDetailsModal } from "@/components/auto-optimize/PipelineDetails
 import {
   getAutoOptimizeRun,
   getAutoOptimizeQuestionResults,
+  deployOptimizationRun,
 } from "@/lib/api"
 import type { GSOPipelineRun, GSOQuestionDetail } from "@/types"
 
@@ -18,6 +19,21 @@ interface RunDetailViewProps {
 }
 
 type EvalTab = "baseline" | "final"
+
+const DEPLOY_STORAGE_KEY = "genie-workbench:deploy-config"
+const TERMINAL_STATUSES = new Set(["CONVERGED", "STALLED", "MAX_ITERATIONS", "APPLIED"])
+
+function loadDeployConfig(): { targetUrl: string; spaceId: string; catalogMappings: { source: string; target: string }[] } {
+  try {
+    const raw = localStorage.getItem(DEPLOY_STORAGE_KEY)
+    if (raw) return JSON.parse(raw)
+  } catch {}
+  return { targetUrl: "", spaceId: "", catalogMappings: [] }
+}
+
+function saveDeployConfig(config: { targetUrl: string; spaceId: string; catalogMappings: { source: string; target: string }[] }) {
+  localStorage.setItem(DEPLOY_STORAGE_KEY, JSON.stringify(config))
+}
 
 const STATUS_VARIANT: Record<string, "default" | "success" | "warning" | "danger" | "info" | "secondary"> = {
   CONVERGED: "success",
@@ -39,6 +55,15 @@ export function RunDetailView({ runId, onBack }: RunDetailViewProps) {
   const [finalQuestions, setFinalQuestions] = useState<GSOQuestionDetail[]>([])
   const [selectedQuestionId, setSelectedQuestionId] = useState<string | null>(null)
   const [showPipeline, setShowPipeline] = useState(false)
+
+  // Deploy dialog state
+  const [deployOpen, setDeployOpen] = useState(false)
+  const [deployTargetUrl, setDeployTargetUrl] = useState("")
+  const [deploySpaceId, setDeploySpaceId] = useState("")
+  const [deployCatalogMappings, setDeployCatalogMappings] = useState<{ source: string; target: string }[]>([])
+  const [deploying, setDeploying] = useState(false)
+  const [deployError, setDeployError] = useState<string | null>(null)
+  const [deploySuccess, setDeploySuccess] = useState(false)
 
   useEffect(() => {
     getAutoOptimizeRun(runId)
@@ -157,8 +182,8 @@ export function RunDetailView({ runId, onBack }: RunDetailViewProps) {
         </div>
       )}
 
-      {/* Deployment Status Banner */}
-      {run.deployTarget && (
+      {/* Deployment Status Banner (when already deployed) */}
+      {run.deployTarget && run.deploymentStatus && (
         <div className={`flex items-start gap-3 rounded-lg border px-4 py-3 ${
           run.deploymentStatus === "DEPLOYED"
             ? "border-emerald-500/30 bg-emerald-500/5"
@@ -170,41 +195,137 @@ export function RunDetailView({ runId, onBack }: RunDetailViewProps) {
             <CheckCircle2 className="mt-0.5 h-5 w-5 text-emerald-600 shrink-0" />
           ) : run.deploymentStatus === "FAILED" ? (
             <AlertTriangle className="mt-0.5 h-5 w-5 text-red-600 shrink-0" />
-          ) : run.deploymentStatus === "PENDING_APPROVAL" ? (
-            <Clock className="mt-0.5 h-5 w-5 text-blue-600 shrink-0" />
           ) : (
-            <Upload className="mt-0.5 h-5 w-5 text-blue-600 shrink-0" />
+            <Clock className="mt-0.5 h-5 w-5 text-blue-600 shrink-0" />
           )}
           <div className="flex-1">
             <h3 className={`text-sm font-semibold ${
-              run.deploymentStatus === "DEPLOYED"
-                ? "text-emerald-900 dark:text-emerald-300"
-                : run.deploymentStatus === "FAILED"
-                  ? "text-red-900 dark:text-red-300"
-                  : "text-blue-900 dark:text-blue-300"
+              run.deploymentStatus === "DEPLOYED" ? "text-emerald-900 dark:text-emerald-300"
+                : run.deploymentStatus === "FAILED" ? "text-red-900 dark:text-red-300"
+                : "text-blue-900 dark:text-blue-300"
             }`}>
-              {run.deploymentStatus === "DEPLOYED"
-                ? "Deployed to target workspace"
-                : run.deploymentStatus === "PENDING_APPROVAL"
-                  ? "Deployment awaiting approval"
-                  : run.deploymentStatus === "FAILED"
-                    ? "Deployment failed"
-                    : `Deployment: ${run.deploymentStatus ?? "configured"}`}
+              {run.deploymentStatus === "DEPLOYED" ? "Deployed to target workspace"
+                : run.deploymentStatus === "PENDING_APPROVAL" ? "Deployment awaiting approval"
+                : run.deploymentStatus === "FAILED" ? "Deployment failed"
+                : `Deployment: ${run.deploymentStatus}`}
             </h3>
-            <p className="mt-0.5 text-xs text-muted">
-              Target: {run.deployTarget}
-            </p>
+            <p className="mt-0.5 text-xs text-muted">Target: {run.deployTarget}</p>
           </div>
           {run.deploymentStatus === "DEPLOYED" && (
-            <a
-              href={run.deployTarget}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border border-emerald-500/30 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10 transition-colors"
-            >
-              Open Workspace
-              <ExternalLink className="h-3.5 w-3.5" />
+            <a href={run.deployTarget} target="_blank" rel="noopener noreferrer"
+              className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border border-emerald-500/30 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10 transition-colors">
+              Open Workspace <ExternalLink className="h-3.5 w-3.5" />
             </a>
+          )}
+        </div>
+      )}
+
+      {/* Deploy to Workspace — on-demand for completed runs */}
+      {TERMINAL_STATUSES.has(run.status) && !run.deploymentStatus && (
+        <div className="border border-default rounded-lg">
+          <button type="button"
+            onClick={() => {
+              if (!deployOpen) {
+                const saved = loadDeployConfig()
+                setDeployTargetUrl(saved.targetUrl)
+                setDeploySpaceId(saved.spaceId)
+                setDeployCatalogMappings(saved.catalogMappings)
+              }
+              setDeployOpen(!deployOpen)
+            }}
+            className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-secondary hover:text-primary transition-colors"
+          >
+            {deployOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+            <Upload className="w-4 h-4" />
+            Deploy to Workspace
+            {deploySuccess && <span className="ml-2 text-xs text-emerald-600 font-normal">Triggered</span>}
+          </button>
+          {deployOpen && (
+            <div className="px-4 pb-4 space-y-3 border-t border-default pt-3">
+              <p className="text-xs text-muted">
+                Deploy this optimized config to another workspace. Previous settings are remembered.
+              </p>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-muted">Target workspace URL</label>
+                <input type="url" value={deployTargetUrl}
+                  onChange={(e) => setDeployTargetUrl(e.target.value)}
+                  placeholder="https://my-prod-workspace.cloud.databricks.com"
+                  className="w-full px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent" />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-muted">Target space ID <span className="font-normal">(optional)</span></label>
+                <input type="text" value={deploySpaceId}
+                  onChange={(e) => setDeploySpaceId(e.target.value)}
+                  placeholder="01f1347d7f1516ceaea7e5853166498f"
+                  className="w-full px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent" />
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <label className="text-xs font-medium text-muted">Catalog mapping <span className="font-normal">(source → target)</span></label>
+                  <button type="button"
+                    onClick={() => setDeployCatalogMappings([...deployCatalogMappings, { source: "", target: "" }])}
+                    className="flex items-center gap-1 text-xs text-accent hover:text-accent/80 transition-colors">
+                    <Plus className="w-3 h-3" /> Add mapping
+                  </button>
+                </div>
+                {deployCatalogMappings.map((m, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <input type="text" value={m.source}
+                      onChange={(e) => { const next = [...deployCatalogMappings]; next[i] = { ...next[i], source: e.target.value }; setDeployCatalogMappings(next) }}
+                      placeholder="dev_catalog"
+                      className="flex-1 px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent" />
+                    <span className="text-xs text-muted">→</span>
+                    <input type="text" value={m.target}
+                      onChange={(e) => { const next = [...deployCatalogMappings]; next[i] = { ...next[i], target: e.target.value }; setDeployCatalogMappings(next) }}
+                      placeholder="prod_catalog"
+                      className="flex-1 px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent" />
+                    <button type="button" onClick={() => setDeployCatalogMappings(deployCatalogMappings.filter((_, j) => j !== i))}
+                      className="text-muted hover:text-danger transition-colors">
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                ))}
+                {deployCatalogMappings.length === 0 && (
+                  <p className="text-xs text-muted italic">No catalog mappings — table references will be used as-is</p>
+                )}
+              </div>
+              {deployError && (
+                <div className="rounded-lg bg-danger/10 border border-danger/20 px-3 py-2 text-xs text-danger">{deployError}</div>
+              )}
+              {deploySuccess && (
+                <div className="rounded-lg bg-emerald-500/10 border border-emerald-500/20 px-3 py-2 text-xs text-emerald-700 dark:text-emerald-300">
+                  Deployment job triggered successfully.
+                </div>
+              )}
+              <button
+                onClick={async () => {
+                  if (!deployTargetUrl.trim()) { setDeployError("Target workspace URL is required"); return }
+                  setDeploying(true); setDeployError(null); setDeploySuccess(false)
+                  const catalogMap = deployCatalogMappings.reduce<Record<string, string>>((acc, m) => {
+                    if (m.source.trim() && m.target.trim()) acc[m.source.trim()] = m.target.trim()
+                    return acc
+                  }, {})
+                  try {
+                    await deployOptimizationRun(runId, {
+                      target_workspace_url: deployTargetUrl.trim(),
+                      target_space_id: deploySpaceId.trim() || undefined,
+                      catalog_map: Object.keys(catalogMap).length > 0 ? catalogMap : undefined,
+                    })
+                    saveDeployConfig({ targetUrl: deployTargetUrl.trim(), spaceId: deploySpaceId.trim(), catalogMappings: deployCatalogMappings })
+                    setDeploySuccess(true)
+                  } catch (e) {
+                    setDeployError(e instanceof Error ? e.message : "Deployment failed")
+                  } finally {
+                    setDeploying(false)
+                  }
+                }}
+                disabled={deploying || !deployTargetUrl.trim()}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-accent text-white font-medium text-sm hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                <Rocket className="w-4 h-4" />
+                {deploying ? "Deploying..." : "Deploy"}
+              </button>
+            </div>
           )}
         </div>
       )}

--- a/frontend/src/components/auto-optimize/RunDetailView.tsx
+++ b/frontend/src/components/auto-optimize/RunDetailView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { ArrowLeft, ChevronDown, ChevronRight, Cog, UserCheck, ExternalLink, Plus, Rocket, Trash2, Upload, CheckCircle2, Clock, AlertTriangle } from "lucide-react"
+import { ArrowLeft, Cog, UserCheck, ExternalLink, Upload, CheckCircle2, Clock, AlertTriangle } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { ScoreSummary } from "@/components/auto-optimize/ScoreSummary"
@@ -9,7 +9,6 @@ import { PipelineDetailsModal } from "@/components/auto-optimize/PipelineDetails
 import {
   getAutoOptimizeRun,
   getAutoOptimizeQuestionResults,
-  deployOptimizationRun,
 } from "@/lib/api"
 import type { GSOPipelineRun, GSOQuestionDetail } from "@/types"
 
@@ -19,21 +18,6 @@ interface RunDetailViewProps {
 }
 
 type EvalTab = "baseline" | "final"
-
-const DEPLOY_STORAGE_KEY = "genie-workbench:deploy-config"
-const TERMINAL_STATUSES = new Set(["CONVERGED", "STALLED", "MAX_ITERATIONS", "APPLIED"])
-
-function loadDeployConfig(): { targetUrl: string; spaceId: string; catalogMappings: { source: string; target: string }[] } {
-  try {
-    const raw = localStorage.getItem(DEPLOY_STORAGE_KEY)
-    if (raw) return JSON.parse(raw)
-  } catch {}
-  return { targetUrl: "", spaceId: "", catalogMappings: [] }
-}
-
-function saveDeployConfig(config: { targetUrl: string; spaceId: string; catalogMappings: { source: string; target: string }[] }) {
-  localStorage.setItem(DEPLOY_STORAGE_KEY, JSON.stringify(config))
-}
 
 const STATUS_VARIANT: Record<string, "default" | "success" | "warning" | "danger" | "info" | "secondary"> = {
   CONVERGED: "success",
@@ -55,15 +39,6 @@ export function RunDetailView({ runId, onBack }: RunDetailViewProps) {
   const [finalQuestions, setFinalQuestions] = useState<GSOQuestionDetail[]>([])
   const [selectedQuestionId, setSelectedQuestionId] = useState<string | null>(null)
   const [showPipeline, setShowPipeline] = useState(false)
-
-  // Deploy dialog state
-  const [deployOpen, setDeployOpen] = useState(false)
-  const [deployTargetUrl, setDeployTargetUrl] = useState("")
-  const [deploySpaceId, setDeploySpaceId] = useState("")
-  const [deployCatalogMappings, setDeployCatalogMappings] = useState<{ source: string; target: string }[]>([])
-  const [deploying, setDeploying] = useState(false)
-  const [deployError, setDeployError] = useState<string | null>(null)
-  const [deploySuccess, setDeploySuccess] = useState(false)
 
   useEffect(() => {
     getAutoOptimizeRun(runId)
@@ -220,115 +195,6 @@ export function RunDetailView({ runId, onBack }: RunDetailViewProps) {
         </div>
       )}
 
-      {/* Deploy to Workspace — on-demand for completed runs */}
-      {TERMINAL_STATUSES.has(run.status) && !run.deploymentStatus && (
-        <div className="border border-default rounded-lg">
-          <button type="button"
-            onClick={() => {
-              if (!deployOpen) {
-                const saved = loadDeployConfig()
-                setDeployTargetUrl(saved.targetUrl)
-                setDeploySpaceId(saved.spaceId)
-                setDeployCatalogMappings(saved.catalogMappings)
-              }
-              setDeployOpen(!deployOpen)
-            }}
-            className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-secondary hover:text-primary transition-colors"
-          >
-            {deployOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-            <Upload className="w-4 h-4" />
-            Deploy to Workspace
-            {deploySuccess && <span className="ml-2 text-xs text-emerald-600 font-normal">Triggered</span>}
-          </button>
-          {deployOpen && (
-            <div className="px-4 pb-4 space-y-3 border-t border-default pt-3">
-              <p className="text-xs text-muted">
-                Deploy this optimized config to another workspace. Previous settings are remembered.
-              </p>
-              <div className="space-y-1">
-                <label className="text-xs font-medium text-muted">Target workspace URL</label>
-                <input type="url" value={deployTargetUrl}
-                  onChange={(e) => setDeployTargetUrl(e.target.value)}
-                  placeholder="https://my-prod-workspace.cloud.databricks.com"
-                  className="w-full px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent" />
-              </div>
-              <div className="space-y-1">
-                <label className="text-xs font-medium text-muted">Target space ID <span className="font-normal">(optional)</span></label>
-                <input type="text" value={deploySpaceId}
-                  onChange={(e) => setDeploySpaceId(e.target.value)}
-                  placeholder="01f1347d7f1516ceaea7e5853166498f"
-                  className="w-full px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent" />
-              </div>
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <label className="text-xs font-medium text-muted">Catalog mapping <span className="font-normal">(source → target)</span></label>
-                  <button type="button"
-                    onClick={() => setDeployCatalogMappings([...deployCatalogMappings, { source: "", target: "" }])}
-                    className="flex items-center gap-1 text-xs text-accent hover:text-accent/80 transition-colors">
-                    <Plus className="w-3 h-3" /> Add mapping
-                  </button>
-                </div>
-                {deployCatalogMappings.map((m, i) => (
-                  <div key={i} className="flex items-center gap-2">
-                    <input type="text" value={m.source}
-                      onChange={(e) => { const next = [...deployCatalogMappings]; next[i] = { ...next[i], source: e.target.value }; setDeployCatalogMappings(next) }}
-                      placeholder="dev_catalog"
-                      className="flex-1 px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent" />
-                    <span className="text-xs text-muted">→</span>
-                    <input type="text" value={m.target}
-                      onChange={(e) => { const next = [...deployCatalogMappings]; next[i] = { ...next[i], target: e.target.value }; setDeployCatalogMappings(next) }}
-                      placeholder="prod_catalog"
-                      className="flex-1 px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent" />
-                    <button type="button" onClick={() => setDeployCatalogMappings(deployCatalogMappings.filter((_, j) => j !== i))}
-                      className="text-muted hover:text-danger transition-colors">
-                      <Trash2 className="w-3.5 h-3.5" />
-                    </button>
-                  </div>
-                ))}
-                {deployCatalogMappings.length === 0 && (
-                  <p className="text-xs text-muted italic">No catalog mappings — table references will be used as-is</p>
-                )}
-              </div>
-              {deployError && (
-                <div className="rounded-lg bg-danger/10 border border-danger/20 px-3 py-2 text-xs text-danger">{deployError}</div>
-              )}
-              {deploySuccess && (
-                <div className="rounded-lg bg-emerald-500/10 border border-emerald-500/20 px-3 py-2 text-xs text-emerald-700 dark:text-emerald-300">
-                  Deployment job triggered successfully.
-                </div>
-              )}
-              <button
-                onClick={async () => {
-                  if (!deployTargetUrl.trim()) { setDeployError("Target workspace URL is required"); return }
-                  setDeploying(true); setDeployError(null); setDeploySuccess(false)
-                  const catalogMap = deployCatalogMappings.reduce<Record<string, string>>((acc, m) => {
-                    if (m.source.trim() && m.target.trim()) acc[m.source.trim()] = m.target.trim()
-                    return acc
-                  }, {})
-                  try {
-                    await deployOptimizationRun(runId, {
-                      target_workspace_url: deployTargetUrl.trim(),
-                      target_space_id: deploySpaceId.trim() || undefined,
-                      catalog_map: Object.keys(catalogMap).length > 0 ? catalogMap : undefined,
-                    })
-                    saveDeployConfig({ targetUrl: deployTargetUrl.trim(), spaceId: deploySpaceId.trim(), catalogMappings: deployCatalogMappings })
-                    setDeploySuccess(true)
-                  } catch (e) {
-                    setDeployError(e instanceof Error ? e.message : "Deployment failed")
-                  } finally {
-                    setDeploying(false)
-                  }
-                }}
-                disabled={deploying || !deployTargetUrl.trim()}
-                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-accent text-white font-medium text-sm hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                <Rocket className="w-4 h-4" />
-                {deploying ? "Deploying..." : "Deploy"}
-              </button>
-            </div>
-          )}
-        </div>
-      )}
 
       {/* Tabs */}
       <div className="flex gap-1 border-b border-default">

--- a/frontend/src/components/auto-optimize/RunDetailView.tsx
+++ b/frontend/src/components/auto-optimize/RunDetailView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { ArrowLeft, Cog, UserCheck, ExternalLink, Upload, CheckCircle2, Clock, AlertTriangle } from "lucide-react"
+import { ArrowLeft, Cog, UserCheck, ExternalLink, CheckCircle2, Clock, AlertTriangle } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { ScoreSummary } from "@/components/auto-optimize/ScoreSummary"

--- a/frontend/src/components/auto-optimize/RunDetailView.tsx
+++ b/frontend/src/components/auto-optimize/RunDetailView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { ArrowLeft, Cog, UserCheck, ExternalLink } from "lucide-react"
+import { ArrowLeft, Cog, UserCheck, ExternalLink, Upload, CheckCircle2, Clock, AlertTriangle } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { ScoreSummary } from "@/components/auto-optimize/ScoreSummary"
@@ -154,6 +154,58 @@ export function RunDetailView({ runId, onBack }: RunDetailViewProps) {
             Open Review Session
             <ExternalLink className="h-3.5 w-3.5" />
           </a>
+        </div>
+      )}
+
+      {/* Deployment Status Banner */}
+      {run.deployTarget && (
+        <div className={`flex items-start gap-3 rounded-lg border px-4 py-3 ${
+          run.deploymentStatus === "DEPLOYED"
+            ? "border-emerald-500/30 bg-emerald-500/5"
+            : run.deploymentStatus === "FAILED"
+              ? "border-red-500/30 bg-red-500/5"
+              : "border-blue-500/30 bg-blue-500/5"
+        }`}>
+          {run.deploymentStatus === "DEPLOYED" ? (
+            <CheckCircle2 className="mt-0.5 h-5 w-5 text-emerald-600 shrink-0" />
+          ) : run.deploymentStatus === "FAILED" ? (
+            <AlertTriangle className="mt-0.5 h-5 w-5 text-red-600 shrink-0" />
+          ) : run.deploymentStatus === "PENDING_APPROVAL" ? (
+            <Clock className="mt-0.5 h-5 w-5 text-blue-600 shrink-0" />
+          ) : (
+            <Upload className="mt-0.5 h-5 w-5 text-blue-600 shrink-0" />
+          )}
+          <div className="flex-1">
+            <h3 className={`text-sm font-semibold ${
+              run.deploymentStatus === "DEPLOYED"
+                ? "text-emerald-900 dark:text-emerald-300"
+                : run.deploymentStatus === "FAILED"
+                  ? "text-red-900 dark:text-red-300"
+                  : "text-blue-900 dark:text-blue-300"
+            }`}>
+              {run.deploymentStatus === "DEPLOYED"
+                ? "Deployed to target workspace"
+                : run.deploymentStatus === "PENDING_APPROVAL"
+                  ? "Deployment awaiting approval"
+                  : run.deploymentStatus === "FAILED"
+                    ? "Deployment failed"
+                    : `Deployment: ${run.deploymentStatus ?? "configured"}`}
+            </h3>
+            <p className="mt-0.5 text-xs text-muted">
+              Target: {run.deployTarget}
+            </p>
+          </div>
+          {run.deploymentStatus === "DEPLOYED" && (
+            <a
+              href={run.deployTarget}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border border-emerald-500/30 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10 transition-colors"
+            >
+              Open Workspace
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          )}
         </div>
       )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -410,8 +410,8 @@ export async function triggerAutoOptimize(request: GSOTriggerRequest): Promise<G
 export async function deploySpace(
   spaceId: string,
   config: { target_workspace_url: string; target_space_id?: string; catalog_map?: Record<string, string> }
-): Promise<{ status: string; targetSpaceId: string; targetUrl: string }> {
-  return fetchWithTimeout<{ status: string; targetSpaceId: string; targetUrl: string }>(
+): Promise<{ status: string; targetSpaceId: string; targetUrl: string; spaceUrl?: string }> {
+  return fetchWithTimeout<{ status: string; targetSpaceId: string; targetUrl: string; spaceUrl?: string }>(
     `${API_BASE}/auto-optimize/spaces/${spaceId}/deploy`,
     {
       method: "POST",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -407,6 +407,21 @@ export async function triggerAutoOptimize(request: GSOTriggerRequest): Promise<G
   )
 }
 
+export async function deployOptimizationRun(
+  runId: string,
+  config: { target_workspace_url: string; target_space_id?: string; catalog_map?: Record<string, string> }
+): Promise<{ jobRunId: string; status: string }> {
+  return fetchWithTimeout<{ jobRunId: string; status: string }>(
+    `${API_BASE}/auto-optimize/runs/${runId}/deploy`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(config),
+    },
+    LONG_TIMEOUT
+  )
+}
+
 export async function getAutoOptimizeRun(runId: string): Promise<GSOPipelineRun> {
   return fetchWithTimeout<GSOPipelineRun>(`${API_BASE}/auto-optimize/runs/${runId}`)
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -407,12 +407,12 @@ export async function triggerAutoOptimize(request: GSOTriggerRequest): Promise<G
   )
 }
 
-export async function deployOptimizationRun(
-  runId: string,
+export async function deploySpace(
+  spaceId: string,
   config: { target_workspace_url: string; target_space_id?: string; catalog_map?: Record<string, string> }
-): Promise<{ jobRunId: string; status: string }> {
-  return fetchWithTimeout<{ jobRunId: string; status: string }>(
-    `${API_BASE}/auto-optimize/runs/${runId}/deploy`,
+): Promise<{ status: string; targetSpaceId: string; targetUrl: string }> {
+  return fetchWithTimeout<{ status: string; targetSpaceId: string; targetUrl: string }>(
+    `${API_BASE}/auto-optimize/spaces/${spaceId}/deploy`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/frontend/src/pages/DeployTab.tsx
+++ b/frontend/src/pages/DeployTab.tsx
@@ -39,7 +39,7 @@ export function DeployTab({ spaceId }: DeployTabProps) {
 
   const [deploying, setDeploying] = useState(false)
   const [deployError, setDeployError] = useState<string | null>(null)
-  const [deploySuccess, setDeploySuccess] = useState<{ targetUrl: string; targetSpaceId: string } | null>(null)
+  const [deploySuccess, setDeploySuccess] = useState<{ targetUrl: string; targetSpaceId: string; spaceUrl?: string } | null>(null)
 
   // Load config from localStorage on mount
   useEffect(() => {
@@ -67,7 +67,7 @@ export function DeployTab({ spaceId }: DeployTabProps) {
         catalog_map: Object.keys(catalogMap).length > 0 ? catalogMap : undefined,
       })
       saveDeployConfig({ targetUrl: targetUrl.trim(), spaceId: targetSpaceId.trim(), catalogMappings })
-      setDeploySuccess({ targetUrl: result.targetUrl, targetSpaceId: result.targetSpaceId })
+      setDeploySuccess({ targetUrl: result.targetUrl, targetSpaceId: result.targetSpaceId, spaceUrl: result.spaceUrl })
     } catch (e) {
       const msg = e instanceof Error ? e.message : typeof e === "object" ? JSON.stringify(e) : String(e)
       setDeployError(msg || "Deployment failed")
@@ -190,12 +190,12 @@ export function DeployTab({ spaceId }: DeployTabProps) {
             </p>
           </div>
           <a
-            href={deploySuccess.targetUrl}
+            href={deploySuccess.spaceUrl || deploySuccess.targetUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border border-emerald-500/30 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10 transition-colors"
           >
-            Open Workspace
+            {deploySuccess.spaceUrl ? "Open Genie Space" : "Open Workspace"}
             <ExternalLink className="h-3.5 w-3.5" />
           </a>
         </div>

--- a/frontend/src/pages/DeployTab.tsx
+++ b/frontend/src/pages/DeployTab.tsx
@@ -96,8 +96,8 @@ export function DeployTab({ spaceId }: DeployTabProps) {
             <ul className="list-disc ml-4 space-y-0.5">
               <li>The app's service principal must be registered in the target workspace</li>
               <li>The SP needs permission to create Genie Spaces (or CAN_MANAGE on the target space if updating)</li>
-              <li>Target catalog and tables must exist in the target workspace (e.g. <code className="text-accent">prod_bank.retail.*</code>)</li>
-              <li>The SP needs SELECT on the target catalog's tables</li>
+              <li>The referenced catalogs must be accessible from the target workspace (shared metastore, or configured in target metastore)</li>
+              <li>The SP needs <code className="text-accent">USE_CATALOG</code>, <code className="text-accent">USE_SCHEMA</code>, and <code className="text-accent">SELECT</code> on the referenced tables</li>
             </ul>
           </div>
 

--- a/frontend/src/pages/DeployTab.tsx
+++ b/frontend/src/pages/DeployTab.tsx
@@ -93,7 +93,8 @@ export function DeployTab({ spaceId }: DeployTabProps) {
       saveDeployConfig({ targetUrl: targetUrl.trim(), spaceId: targetSpaceId.trim(), catalogMappings })
       setDeploySuccess(true)
     } catch (e) {
-      setDeployError(e instanceof Error ? e.message : "Deployment failed")
+      const msg = e instanceof Error ? e.message : typeof e === "object" ? JSON.stringify(e) : String(e)
+      setDeployError(msg || "Deployment failed")
     } finally {
       setDeploying(false)
     }

--- a/frontend/src/pages/DeployTab.tsx
+++ b/frontend/src/pages/DeployTab.tsx
@@ -1,0 +1,294 @@
+/**
+ * DeployTab — Cross-workspace deployment for optimized Genie Spaces.
+ * Shows deployment config (remembered via localStorage), completed runs to deploy, and deployment status.
+ */
+import { useState, useEffect } from "react"
+import { CheckCircle2, ExternalLink, Plus, Rocket, Trash2, Upload } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { getAutoOptimizeRunsForSpace, deployOptimizationRun } from "@/lib/api"
+import type { GSORunSummary } from "@/types"
+
+const DEPLOY_STORAGE_KEY = "genie-workbench:deploy-config"
+const TERMINAL_STATUSES = new Set(["CONVERGED", "STALLED", "MAX_ITERATIONS", "APPLIED"])
+
+interface DeployConfig {
+  targetUrl: string
+  spaceId: string
+  catalogMappings: { source: string; target: string }[]
+}
+
+function loadDeployConfig(): DeployConfig {
+  try {
+    const raw = localStorage.getItem(DEPLOY_STORAGE_KEY)
+    if (raw) return JSON.parse(raw)
+  } catch {}
+  return { targetUrl: "", spaceId: "", catalogMappings: [] }
+}
+
+function saveDeployConfig(config: DeployConfig) {
+  localStorage.setItem(DEPLOY_STORAGE_KEY, JSON.stringify(config))
+}
+
+interface DeployTabProps {
+  spaceId: string
+}
+
+export function DeployTab({ spaceId }: DeployTabProps) {
+  // Config state (loaded from localStorage)
+  const [targetUrl, setTargetUrl] = useState("")
+  const [targetSpaceId, setTargetSpaceId] = useState("")
+  const [catalogMappings, setCatalogMappings] = useState<{ source: string; target: string }[]>([])
+
+  // Runs
+  const [runs, setRuns] = useState<GSORunSummary[]>([])
+  const [runsLoading, setRunsLoading] = useState(true)
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
+
+  // Deploy state
+  const [deploying, setDeploying] = useState(false)
+  const [deployError, setDeployError] = useState<string | null>(null)
+  const [deploySuccess, setDeploySuccess] = useState(false)
+
+  // Load config from localStorage on mount
+  useEffect(() => {
+    const saved = loadDeployConfig()
+    setTargetUrl(saved.targetUrl)
+    setTargetSpaceId(saved.spaceId)
+    setCatalogMappings(saved.catalogMappings)
+  }, [])
+
+  // Fetch completed runs
+  useEffect(() => {
+    setRunsLoading(true)
+    getAutoOptimizeRunsForSpace(spaceId)
+      .then((allRuns) => {
+        const completed = allRuns.filter((r) => TERMINAL_STATUSES.has(r.status))
+        setRuns(completed)
+        if (completed.length > 0 && !selectedRunId) {
+          setSelectedRunId(completed[0].run_id)
+        }
+      })
+      .catch(() => setRuns([]))
+      .finally(() => setRunsLoading(false))
+  }, [spaceId])
+
+  async function handleDeploy() {
+    if (!selectedRunId || !targetUrl.trim()) return
+    setDeploying(true)
+    setDeployError(null)
+    setDeploySuccess(false)
+
+    const catalogMap = catalogMappings.reduce<Record<string, string>>((acc, m) => {
+      if (m.source.trim() && m.target.trim()) acc[m.source.trim()] = m.target.trim()
+      return acc
+    }, {})
+
+    try {
+      await deployOptimizationRun(selectedRunId, {
+        target_workspace_url: targetUrl.trim(),
+        target_space_id: targetSpaceId.trim() || undefined,
+        catalog_map: Object.keys(catalogMap).length > 0 ? catalogMap : undefined,
+      })
+      saveDeployConfig({ targetUrl: targetUrl.trim(), spaceId: targetSpaceId.trim(), catalogMappings })
+      setDeploySuccess(true)
+    } catch (e) {
+      setDeployError(e instanceof Error ? e.message : "Deployment failed")
+    } finally {
+      setDeploying(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Deployment Config */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Upload className="w-5 h-5" />
+            Deploy to Workspace
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-xs text-muted">
+            Deploy an optimized Genie Space config to a target workspace. Settings are remembered for next time.
+          </p>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-muted">Target workspace URL</label>
+              <input
+                type="url"
+                value={targetUrl}
+                onChange={(e) => setTargetUrl(e.target.value)}
+                placeholder="https://my-prod-workspace.cloud.databricks.com"
+                className="w-full px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-muted">
+                Target space ID <span className="font-normal">(optional — updates existing space)</span>
+              </label>
+              <input
+                type="text"
+                value={targetSpaceId}
+                onChange={(e) => setTargetSpaceId(e.target.value)}
+                placeholder="01f1347d7f1516ceaea7e5853166498f"
+                className="w-full px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-xs font-medium text-muted">
+                Catalog mapping <span className="font-normal">(source → target)</span>
+              </label>
+              <button
+                type="button"
+                onClick={() => setCatalogMappings([...catalogMappings, { source: "", target: "" }])}
+                className="flex items-center gap-1 text-xs text-accent hover:text-accent/80 transition-colors"
+              >
+                <Plus className="w-3 h-3" /> Add mapping
+              </button>
+            </div>
+            {catalogMappings.map((m, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={m.source}
+                  onChange={(e) => {
+                    const next = [...catalogMappings]
+                    next[i] = { ...next[i], source: e.target.value }
+                    setCatalogMappings(next)
+                  }}
+                  placeholder="dev_catalog"
+                  className="flex-1 px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+                />
+                <span className="text-xs text-muted">→</span>
+                <input
+                  type="text"
+                  value={m.target}
+                  onChange={(e) => {
+                    const next = [...catalogMappings]
+                    next[i] = { ...next[i], target: e.target.value }
+                    setCatalogMappings(next)
+                  }}
+                  placeholder="prod_catalog"
+                  className="flex-1 px-3 py-1.5 text-sm border border-default rounded-lg bg-elevated text-primary placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+                />
+                <button
+                  type="button"
+                  onClick={() => setCatalogMappings(catalogMappings.filter((_, j) => j !== i))}
+                  className="text-muted hover:text-danger transition-colors"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            ))}
+            {catalogMappings.length === 0 && (
+              <p className="text-xs text-muted italic">No catalog mappings — table references will be used as-is</p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Select a completed run */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Select a completed run to deploy</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {runsLoading ? (
+            <p className="text-sm text-muted py-4 text-center">Loading optimization runs...</p>
+          ) : runs.length === 0 ? (
+            <p className="text-sm text-muted py-4 text-center">
+              No completed optimization runs yet. Run an optimization first on the Optimize tab.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {runs.map((run) => (
+                <button
+                  key={run.run_id}
+                  onClick={() => setSelectedRunId(run.run_id)}
+                  className={`w-full flex items-center justify-between px-4 py-3 rounded-lg border text-left transition-colors ${
+                    selectedRunId === run.run_id
+                      ? "border-accent bg-accent/5"
+                      : "border-default hover:bg-elevated"
+                  }`}
+                >
+                  <div className="flex items-center gap-3">
+                    <div className={`w-2 h-2 rounded-full ${
+                      selectedRunId === run.run_id ? "bg-accent" : "bg-muted"
+                    }`} />
+                    <div>
+                      <span className="text-sm text-primary">
+                        {run.started_at ? new Date(run.started_at).toLocaleDateString(undefined, {
+                          day: "numeric", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit",
+                        }) : "Unknown date"}
+                      </span>
+                      <p className="text-xs text-muted mt-0.5">
+                        {run.triggered_by || "system"}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Badge variant={run.status === "CONVERGED" ? "success" : "warning"}>
+                      {run.status}
+                    </Badge>
+                    {run.best_accuracy != null && (
+                      <span className="text-sm font-semibold text-primary">
+                        {Math.round(run.best_accuracy * 100)}%
+                      </span>
+                    )}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Deploy button + status */}
+      {deployError && (
+        <div className="rounded-lg bg-danger/10 border border-danger/20 px-4 py-3 text-sm text-danger">
+          {deployError}
+        </div>
+      )}
+
+      {deploySuccess && (
+        <div className="flex items-start gap-3 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-4 py-3">
+          <CheckCircle2 className="mt-0.5 h-5 w-5 text-emerald-600 shrink-0" />
+          <div className="flex-1">
+            <h3 className="text-sm font-semibold text-emerald-900 dark:text-emerald-300">
+              Deployment job triggered
+            </h3>
+            <p className="mt-0.5 text-xs text-muted">
+              Target: {targetUrl}
+            </p>
+          </div>
+          {targetUrl && (
+            <a
+              href={targetUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border border-emerald-500/30 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10 transition-colors"
+            >
+              Open Workspace
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          )}
+        </div>
+      )}
+
+      <button
+        onClick={handleDeploy}
+        disabled={deploying || !selectedRunId || !targetUrl.trim()}
+        className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-accent text-white font-semibold hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        <Rocket className="w-4 h-4" />
+        {deploying ? "Deploying..." : "Deploy Selected Run"}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/DeployTab.tsx
+++ b/frontend/src/pages/DeployTab.tsx
@@ -91,6 +91,16 @@ export function DeployTab({ spaceId }: DeployTabProps) {
             Deploy this Genie Space's current config to a target workspace. Catalog references are remapped automatically. Settings are remembered for next time.
           </p>
 
+          <div className="rounded-lg bg-surface-secondary border border-default px-4 py-3 text-xs text-muted space-y-1">
+            <p className="font-medium text-secondary">Prerequisites</p>
+            <ul className="list-disc ml-4 space-y-0.5">
+              <li>The app's service principal must be registered in the target workspace</li>
+              <li>The SP needs permission to create Genie Spaces (or CAN_MANAGE on the target space if updating)</li>
+              <li>Target catalog and tables must exist in the target workspace (e.g. <code className="text-accent">prod_bank.retail.*</code>)</li>
+              <li>The SP needs SELECT on the target catalog's tables</li>
+            </ul>
+          </div>
+
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-1">
               <label className="text-xs font-medium text-muted">Target workspace URL</label>

--- a/frontend/src/pages/DeployTab.tsx
+++ b/frontend/src/pages/DeployTab.tsx
@@ -1,16 +1,14 @@
 /**
- * DeployTab — Cross-workspace deployment for optimized Genie Spaces.
- * Shows deployment config (remembered via localStorage), completed runs to deploy, and deployment status.
+ * DeployTab — Cross-workspace deployment for Genie Spaces.
+ * Deploys the current space config to a target workspace with optional catalog remapping.
+ * Settings are remembered via localStorage.
  */
 import { useState, useEffect } from "react"
 import { CheckCircle2, ExternalLink, Plus, Rocket, Trash2, Upload } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-import { getAutoOptimizeRunsForSpace, deployOptimizationRun } from "@/lib/api"
-import type { GSORunSummary } from "@/types"
+import { deploySpace } from "@/lib/api"
 
 const DEPLOY_STORAGE_KEY = "genie-workbench:deploy-config"
-const TERMINAL_STATUSES = new Set(["CONVERGED", "STALLED", "MAX_ITERATIONS", "APPLIED"])
 
 interface DeployConfig {
   targetUrl: string
@@ -35,20 +33,13 @@ interface DeployTabProps {
 }
 
 export function DeployTab({ spaceId }: DeployTabProps) {
-  // Config state (loaded from localStorage)
   const [targetUrl, setTargetUrl] = useState("")
   const [targetSpaceId, setTargetSpaceId] = useState("")
   const [catalogMappings, setCatalogMappings] = useState<{ source: string; target: string }[]>([])
 
-  // Runs
-  const [runs, setRuns] = useState<GSORunSummary[]>([])
-  const [runsLoading, setRunsLoading] = useState(true)
-  const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
-
-  // Deploy state
   const [deploying, setDeploying] = useState(false)
   const [deployError, setDeployError] = useState<string | null>(null)
-  const [deploySuccess, setDeploySuccess] = useState(false)
+  const [deploySuccess, setDeploySuccess] = useState<{ targetUrl: string; targetSpaceId: string } | null>(null)
 
   // Load config from localStorage on mount
   useEffect(() => {
@@ -58,26 +49,11 @@ export function DeployTab({ spaceId }: DeployTabProps) {
     setCatalogMappings(saved.catalogMappings)
   }, [])
 
-  // Fetch completed runs
-  useEffect(() => {
-    setRunsLoading(true)
-    getAutoOptimizeRunsForSpace(spaceId)
-      .then((allRuns) => {
-        const completed = allRuns.filter((r) => TERMINAL_STATUSES.has(r.status))
-        setRuns(completed)
-        if (completed.length > 0 && !selectedRunId) {
-          setSelectedRunId(completed[0].run_id)
-        }
-      })
-      .catch(() => setRuns([]))
-      .finally(() => setRunsLoading(false))
-  }, [spaceId])
-
   async function handleDeploy() {
-    if (!selectedRunId || !targetUrl.trim()) return
+    if (!targetUrl.trim()) return
     setDeploying(true)
     setDeployError(null)
-    setDeploySuccess(false)
+    setDeploySuccess(null)
 
     const catalogMap = catalogMappings.reduce<Record<string, string>>((acc, m) => {
       if (m.source.trim() && m.target.trim()) acc[m.source.trim()] = m.target.trim()
@@ -85,13 +61,13 @@ export function DeployTab({ spaceId }: DeployTabProps) {
     }, {})
 
     try {
-      await deployOptimizationRun(selectedRunId, {
+      const result = await deploySpace(spaceId, {
         target_workspace_url: targetUrl.trim(),
         target_space_id: targetSpaceId.trim() || undefined,
         catalog_map: Object.keys(catalogMap).length > 0 ? catalogMap : undefined,
       })
       saveDeployConfig({ targetUrl: targetUrl.trim(), spaceId: targetSpaceId.trim(), catalogMappings })
-      setDeploySuccess(true)
+      setDeploySuccess({ targetUrl: result.targetUrl, targetSpaceId: result.targetSpaceId })
     } catch (e) {
       const msg = e instanceof Error ? e.message : typeof e === "object" ? JSON.stringify(e) : String(e)
       setDeployError(msg || "Deployment failed")
@@ -112,7 +88,7 @@ export function DeployTab({ spaceId }: DeployTabProps) {
         </CardHeader>
         <CardContent className="space-y-4">
           <p className="text-xs text-muted">
-            Deploy an optimized Genie Space config to a target workspace. Settings are remembered for next time.
+            Deploy this Genie Space's current config to a target workspace. Catalog references are remapped automatically. Settings are remembered for next time.
           </p>
 
           <div className="grid grid-cols-2 gap-4">
@@ -194,101 +170,45 @@ export function DeployTab({ spaceId }: DeployTabProps) {
         </CardContent>
       </Card>
 
-      {/* Select a completed run */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Select a completed run to deploy</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {runsLoading ? (
-            <p className="text-sm text-muted py-4 text-center">Loading optimization runs...</p>
-          ) : runs.length === 0 ? (
-            <p className="text-sm text-muted py-4 text-center">
-              No completed optimization runs yet. Run an optimization first on the Optimize tab.
-            </p>
-          ) : (
-            <div className="space-y-2">
-              {runs.map((run) => (
-                <button
-                  key={run.run_id}
-                  onClick={() => setSelectedRunId(run.run_id)}
-                  className={`w-full flex items-center justify-between px-4 py-3 rounded-lg border text-left transition-colors ${
-                    selectedRunId === run.run_id
-                      ? "border-accent bg-accent/5"
-                      : "border-default hover:bg-elevated"
-                  }`}
-                >
-                  <div className="flex items-center gap-3">
-                    <div className={`w-2 h-2 rounded-full ${
-                      selectedRunId === run.run_id ? "bg-accent" : "bg-muted"
-                    }`} />
-                    <div>
-                      <span className="text-sm text-primary">
-                        {run.started_at ? new Date(run.started_at).toLocaleDateString(undefined, {
-                          day: "numeric", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit",
-                        }) : "Unknown date"}
-                      </span>
-                      <p className="text-xs text-muted mt-0.5">
-                        {run.triggered_by || "system"}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <Badge variant={run.status === "CONVERGED" ? "success" : "warning"}>
-                      {run.status}
-                    </Badge>
-                    {run.best_accuracy != null && (
-                      <span className="text-sm font-semibold text-primary">
-                        {Math.round(run.best_accuracy * 100)}%
-                      </span>
-                    )}
-                  </div>
-                </button>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Deploy button + status */}
+      {/* Error */}
       {deployError && (
         <div className="rounded-lg bg-danger/10 border border-danger/20 px-4 py-3 text-sm text-danger">
           {deployError}
         </div>
       )}
 
+      {/* Success */}
       {deploySuccess && (
         <div className="flex items-start gap-3 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-4 py-3">
           <CheckCircle2 className="mt-0.5 h-5 w-5 text-emerald-600 shrink-0" />
           <div className="flex-1">
             <h3 className="text-sm font-semibold text-emerald-900 dark:text-emerald-300">
-              Deployment job triggered
+              Deployed successfully
             </h3>
             <p className="mt-0.5 text-xs text-muted">
-              Target: {targetUrl}
+              Space config deployed to {deploySuccess.targetUrl} (space: {deploySuccess.targetSpaceId})
             </p>
           </div>
-          {targetUrl && (
-            <a
-              href={targetUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border border-emerald-500/30 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10 transition-colors"
-            >
-              Open Workspace
-              <ExternalLink className="h-3.5 w-3.5" />
-            </a>
-          )}
+          <a
+            href={deploySuccess.targetUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border border-emerald-500/30 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10 transition-colors"
+          >
+            Open Workspace
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
         </div>
       )}
 
+      {/* Deploy button */}
       <button
         onClick={handleDeploy}
-        disabled={deploying || !selectedRunId || !targetUrl.trim()}
+        disabled={deploying || !targetUrl.trim()}
         className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-accent text-white font-semibold hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
       >
         <Rocket className="w-4 h-4" />
-        {deploying ? "Deploying..." : "Deploy Selected Run"}
+        {deploying ? "Deploying..." : "Deploy to Target Workspace"}
       </button>
     </div>
   )

--- a/frontend/src/pages/SpaceDetail.tsx
+++ b/frontend/src/pages/SpaceDetail.tsx
@@ -4,7 +4,7 @@
  * Score tab includes an inline FixAgentPanel that slides in from the right.
  */
 import { useState, useEffect, useRef } from "react"
-import { ArrowLeft, Star, BarChart2, Clock, ExternalLink, Rocket, Play, Zap, ChevronDown, ChevronRight, Settings, RefreshCw } from "lucide-react"
+import { ArrowLeft, Star, BarChart2, Clock, ExternalLink, Rocket, Play, Upload, Zap, ChevronDown, ChevronRight, Settings, RefreshCw } from "lucide-react"
 import { scanSpace, toggleStar, getSpaceHistory, getSpaceDetail, getActiveRunForSpace } from "@/lib/api"
 import { MATURITY_COLORS, getOptimizationLabel } from "@/lib/utils"
 import type { ScanResult, ScoreHistoryPoint, OptimizationEvent } from "@/types"
@@ -13,10 +13,11 @@ import { HistoryTab } from "./HistoryTab"
 import { useAnalysis } from "@/hooks/useAnalysis"
 import { SpaceOverview } from "@/components/SpaceOverview"
 import { AutoOptimizeTab } from "@/components/auto-optimize/AutoOptimizeTab"
+import { DeployTab } from "./DeployTab"
 import { FixAgentPanel } from "@/components/FixAgentPanel"
 
-type Tab = "score" | "optimize" | "history"
-const VALID_TABS: readonly string[] = ["score", "optimize", "history"]
+type Tab = "score" | "optimize" | "history" | "deploy"
+const VALID_TABS: readonly string[] = ["score", "optimize", "history", "deploy"]
 
 interface SpaceDetailProps {
   spaceId: string
@@ -162,6 +163,7 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
     { id: "score", label: "Score", icon: <BarChart2 className="w-4 h-4" /> },
     { id: "optimize", label: "Optimize", icon: <Rocket className="w-4 h-4" /> },
     { id: "history", label: "History", icon: <Clock className="w-4 h-4" /> },
+    { id: "deploy", label: "Deploy", icon: <Upload className="w-4 h-4" /> },
   ]
 
   // Determine contextual action(s) based on scan results
@@ -321,6 +323,9 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
 
         {activeTab === "history" && (
           <HistoryTab history={history} optimizationEvents={optimizationEvents} isLoading={isLoadingHistory} />
+        )}
+        {activeTab === "deploy" && (
+          <DeployTab spaceId={spaceId} />
         )}
       </div>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -264,6 +264,8 @@ export interface GSOTriggerRequest {
   apply_mode?: "genie_config" | "uc_artifact" | "both"
   levers?: number[]
   deploy_target?: string
+  deploy_space_id?: string
+  catalog_map?: Record<string, string>
 }
 
 export interface GSOTriggerResponse {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -399,6 +399,7 @@ export interface GSOPipelineRun {
   levers: GSOLeverStatus[]
   links: GSOResourceLink[]
   convergenceReason: string | null
+  deployTarget: string | null
   deploymentStatus: string | null
   labelingSessionUrl: string | null
   labelingSessionName: string | null

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/backend/job_launcher.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/backend/job_launcher.py
@@ -363,6 +363,8 @@ def submit_optimization(
     triggered_by: str = "",
     experiment_name: str = "",
     deploy_target: str = "",
+    deploy_space_id: str = "",
+    catalog_map: str = "",
     warehouse_id: str = "",
     target_benchmark_count: str = "",
 ) -> tuple[str, int]:
@@ -393,6 +395,8 @@ def submit_optimization(
                 "triggered_by": triggered_by,
                 "experiment_name": experiment_name,
                 "deploy_target": deploy_target,
+                "deploy_space_id": deploy_space_id,
+                "catalog_map": catalog_map,
                 "warehouse_id": warehouse_id,
                 "target_benchmark_count": target_benchmark_count,
             },

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/integration/trigger.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/integration/trigger.py
@@ -45,6 +45,8 @@ def trigger_optimization(
     apply_mode: str = "genie_config",
     levers: list[int] | None = None,
     deploy_target: str | None = None,
+    deploy_space_id: str | None = None,
+    catalog_map: dict[str, str] | None = None,
 ) -> TriggerResult:
     """Trigger a GSO optimization run using SQL Warehouse for state management.
 
@@ -227,6 +229,8 @@ def trigger_optimization(
             triggered_by=caller_email,
             experiment_name=experiment_name or "",
             deploy_target=deploy_target or "",
+            deploy_space_id=deploy_space_id or "",
+            catalog_map=json.dumps(catalog_map) if catalog_map else "",
             warehouse_id=config.warehouse_id or "",
         )
 

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_cross_env_deploy.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_cross_env_deploy.py
@@ -56,11 +56,13 @@ dbutils.widgets.text("model_name", "", "UC Model Name")
 dbutils.widgets.text("model_version", "", "Model Version")
 dbutils.widgets.text("target_workspace_url", "", "Target Workspace URL")
 dbutils.widgets.text("target_space_id", "", "Target Space ID")
+dbutils.widgets.text("catalog_map", "", "Catalog Mapping (JSON)")
 
 model_name = dbutils.widgets.get("model_name").strip()
 model_version = dbutils.widgets.get("model_version").strip()
 target_workspace_url = dbutils.widgets.get("target_workspace_url").strip()
 target_space_id = dbutils.widgets.get("target_space_id").strip()
+catalog_map_raw = dbutils.widgets.get("catalog_map").strip()
 
 _banner("Resolved Parameters")
 _log(
@@ -138,6 +140,29 @@ if not space_config:
     )
 
 _log("Config loaded", keys=list(space_config.keys()))
+
+# Remap catalog references if catalog_map is provided
+catalog_map: dict[str, str] = {}
+if catalog_map_raw:
+    try:
+        catalog_map = json.loads(catalog_map_raw)
+    except json.JSONDecodeError:
+        _log("WARNING: Could not parse catalog_map JSON, skipping remapping", raw=catalog_map_raw)
+
+if catalog_map:
+    _banner("Remapping Catalog References")
+    remapped = 0
+    for source_list_key in ("tables", "metric_views"):
+        for src in space_config.get("data_sources", {}).get(source_list_key, []):
+            ident = src.get("identifier", "")
+            parts = ident.replace("`", "").split(".")
+            if len(parts) >= 3 and parts[0] in catalog_map:
+                old_ident = ident
+                parts[0] = catalog_map[parts[0]]
+                src["identifier"] = ".".join(parts)
+                _log("Remapped", old=old_ident, new=src["identifier"])
+                remapped += 1
+    _log("Catalog remapping complete", remapped=remapped, mappings=catalog_map)
 
 # COMMAND ----------
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -592,12 +592,24 @@ if lakebase_db:
         }
     }
 
-print(json.dumps({'user_api_scopes': scopes, 'resources': list(by_name.values())}))
+resources_list = list(by_name.values())
+print(json.dumps({'user_api_scopes': scopes, 'resources': resources_list}) + '|||' + json.dumps({'resources': resources_list}))
 ")
-databricks api patch "/api/2.0/apps/$APP_NAME" \
-    --profile "$PROFILE" --json "$PATCH_PAYLOAD" 2>/dev/null && \
-    echo "  ✓ App scopes and resources configured" || \
-    echo "  ⚠ Could not configure app scopes/resources"
+
+# Split into scopes+resources and resources-only payloads
+PATCH_WITH_SCOPES="${PATCH_PAYLOAD%%|||*}"
+PATCH_RESOURCES_ONLY="${PATCH_PAYLOAD##*|||}"
+
+# Try with scopes first; if workspace doesn't support token passthrough, retry resources-only
+if databricks api patch "/api/2.0/apps/$APP_NAME" \
+    --profile "$PROFILE" --json "$PATCH_WITH_SCOPES" 2>/dev/null; then
+    echo "  ✓ App scopes and resources configured"
+elif databricks api patch "/api/2.0/apps/$APP_NAME" \
+    --profile "$PROFILE" --json "$PATCH_RESOURCES_ONLY" 2>/dev/null; then
+    echo "  ✓ App resources configured (user_api_scopes not supported on this workspace)"
+else
+    echo "  ⚠ Could not configure app resources"
+fi
 
 databricks apps deploy "$APP_NAME" --profile "$PROFILE" \
     --source-code-path "$WS_PATH" --no-wait


### PR DESCRIPTION
## Summary

- **Deploy tab** — new top-level tab (Score → Optimize → History → Deploy) for deploying Genie Space configs to target workspaces
- **Catalog remapping** — remap table identifiers during deploy (e.g. `dev_bank.retail.*` → `prod_bank.retail.*`)
- **Create or update** — creates a new Genie Space in the target workspace when no target space ID is provided; PATCHes an existing space when an ID is given
- **Remembered config** — target workspace URL, space ID, and catalog mappings are persisted in localStorage across sessions
- **deploy.sh fix** — fallback when `user_api_scopes` not supported on workspace (was silently dropping all resources including sql-warehouse and postgres)
- **Prerequisites UI** — documents SP registration, catalog access, and UC grant requirements on the Deploy tab

## Architecture

```
User clicks Deploy → POST /api/auto-optimize/spaces/{id}/deploy
  → Fetch source space config (Genie API)
  → Remap catalog references (in-memory)
  → Connect to target workspace (SP credentials)
  → CREATE new space or PATCH existing space (target Genie API)
  → Return space URL
```

The app's SP must be registered in the target workspace. No UC model or optimization run required — works with any Genie Space.

## Test plan

- [x] Deploy tab renders with 4 tabs (Score, Optimize, History, Deploy)
- [x] Config fields pre-fill from localStorage on revisit
- [x] Deploy with target space ID → PATCHes existing space
- [x] Deploy without target space ID → creates new space
- [x] Catalog remapping transforms identifiers correctly
- [x] Error messages display properly (auth failures, permission errors)
- [x] TypeScript compiles with zero errors
- [ ] Full E2E: deploy from dev workspace to prod workspace with catalog remapping

This pull request was AI-assisted by Isaac.