### PR TITLE
Rewrite CONTRIBUTING.md for board-first contribution flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,11 +24,6 @@ What you expected to happen.
 
 If applicable, add screenshots to help explain the problem.
 
-## Environment
-
-- Browser: [e.g. Chrome 124]
-- Workspace region: [e.g. us-west-2, do NOT include the workspace URL]
-
 ## Additional context
 
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,10 @@ about: Suggest a new feature or improvement for Genie Workbench
 labels: enhancement
 ---
 
+## Roadmap Check
+
+- [ ] I've checked the [Genie Workbench Roadmap](https://github.com/orgs/databricks-solutions/projects/10/views/3) and this feature is not already tracked there.
+
 ## Problem / Motivation
 
 A clear description of the problem you're trying to solve or the need this addresses.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,48 @@
 # Contributing to Genie Workbench
 
-This repository is maintained by Databricks and intended for contributions from Databricks Field Engineers. While the repository is public and meant to help anyone working with Genie Spaces, external contributions are not currently accepted. Feel free to open an issue with bug reports or feature suggestions.
+Genie Workbench is maintained by Databricks Field Engineering. The repository is public so anyone can read, fork, and learn from it, but **pull requests are currently accepted only from Databricks employees**. If you're a Databricks FE and want to pitch in, we'd love the help — start here.
+
+We plan work on the [Genie Workbench Roadmap](https://github.com/orgs/databricks-solutions/projects/10/views/3). Contributions flow from there: **pick an issue, claim it, ship it.**
+
+## Picking Up an Issue
+
+1. Browse the [Roadmap board](https://github.com/orgs/databricks-solutions/projects/10/views/3).
+2. Pick an open issue that isn't already assigned.
+3. **Assign yourself** via the Assignees sidebar. This signals you're working on it so no one duplicates effort.
+4. If you want to sanity-check scope or approach first, comment on the issue or drop a note in **#genie-workbench** on Slack.
+
+If you start on something and realize you can't finish, unassign yourself so someone else can pick it up.
+
+## Branches and PRs
+
+- **Branch name:** `feature/<issue-#>-short-desc` — e.g., `feature/141-contributing-rewrite`.
+- **PR title:** one descriptive sentence — no required prefix. e.g., `Rewrite CONTRIBUTING.md for board-first flow`.
+- **PR description:** link the issue (`Closes #141`), summarize the change, and note what you tested. There is no local dev server — test against a deployed workspace via `./scripts/deploy.sh`.
+- **Target branch:** `main`.
+
+## Suggesting Something New
+
+Not on the board yet? Two options:
+
+- **Small ideas or questions:** drop them in **#genie-workbench** on Slack.
+- **Concrete feature requests:** open a [feature request](../../issues/new?template=feature_request.md). Core contributors triage these ad hoc. Outcomes:
+  - **Added to the Roadmap** — we plan to work on it; the issue joins the board.
+  - **Accepted, unscheduled** — reasonable ask, no plan yet. PRs welcome; otherwise we'll get to it when there's bandwidth.
+  - **Declined** — closed with a comment explaining why.
 
 ## Reporting a Bug
 
 Use [GitHub Issues](../../issues/new?template=bug_report.md) to report bugs.
 
-> **Do not include sensitive information in issues.** This is a public repository. Never include customer names, workspace URLs, access tokens, or any customer-identifiable data in bug reports.
+> **Do not include sensitive information in issues.** This is a public repository. Never include customer names, workspace URLs, access tokens, or any customer-identifiable data.
 
-If your bug involves a customer environment or contains details that cannot be shared publicly, report it in **#genie-workbench** on Slack instead.
+If your bug involves a customer environment or contains details that can't be shared publicly, report it in **#genie-workbench** on Slack instead.
 
-When filing a bug report, please include:
+Please include:
 - A clear description of the problem
-- Steps to reproduce the issue
+- Steps to reproduce
 - Expected vs. actual behavior
 - Browser and workspace region (not the URL)
-
-## Requesting a Feature
-
-Use [GitHub Issues](../../issues/new?template=feature_request.md) to suggest new features or improvements. Include the problem you're trying to solve and any alternatives you've considered.
-
-## Community
-
-Join **#genie-workbench** on Slack for:
-- Questions and discussion
-- Reporting issues that involve sensitive or customer-specific details
-- Sharing feedback and ideas
 
 ## Development Setup
 
@@ -46,25 +63,26 @@ Join **#genie-workbench** on Slack for:
    ./scripts/install.sh
    ```
 
-See the [README](README.md) for full architecture details and environment variable reference.
+See the [README](README.md) for full architecture and environment variable reference.
 
 ## Pull Request Process
 
-1. Create a feature branch from `main`
-2. Make your changes with clear, descriptive commits
+1. Create a `feature/<issue-#>-short-desc` branch from `main`.
+2. Make changes with clear, descriptive commits.
 3. Run the test suite:
    ```bash
    ./scripts/test.sh
    ```
-4. Deploy and test against a real Databricks workspace (there is no local dev server):
+4. Deploy and test against a real Databricks workspace:
    ```bash
    ./scripts/deploy.sh
    ```
-5. Open a PR with:
-   - Brief description of the change
-   - Motivation or linked issue
-   - Testing performed
-6. Address review feedback
+5. Open a PR linking the issue you claimed, describing the change, and noting what you tested.
+6. Address review feedback.
+
+## Community
+
+Join **#genie-workbench** on Slack for questions, discussion, sensitive bug reports, and general feedback.
 
 ## Security
 


### PR DESCRIPTION
## Summary

- Reframes `CONTRIBUTING.md` around the [Genie Workbench Roadmap](https://github.com/orgs/databricks-solutions/projects/10/views/3): primary flow is pick-an-issue → self-assign → branch → PR. Internal-only posture kept, with an inviting tone per the Apr 17 "say yes initially" direction.
- Adds concrete conventions: branch name `feature/<issue-#>-short-desc`, one-sentence descriptive PR title, PR description links the issue and notes what was tested.
- Adds a secondary "Suggesting Something New" path with three triage outcomes (Roadmap / Accepted unscheduled / Declined) for asks not already on the board.
- Adds a "Roadmap Check" checkbox at the top of the feature request issue template.
- Also picks up a small edit to `bug_report.md` (removes the Environment section) that was already in the working tree.

## Testing

- Docs-only change. Rendered the updated `CONTRIBUTING.md` and verified the Roadmap link resolves to view 3 of project 10.
- Verified the feature request template renders the new checkbox as a task item.

Closes #141
Refs #169 (leaving open — David's call per its acceptance criteria whether to close as duplicate)

Note: To fully realize the flow described here, the team still needs to create the `good-first-issue` label and curate the initial set (tracked in #142).

This pull request and its description were written by Isaac.