### PR TITLE
Near-term GSL instruction schema alignment (#87)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,4 +225,4 @@ optimization code, consult the relevant doc for design rationale.
 - **Genie Space best practices**: https://docs.databricks.com/aws/en/genie/best-practices — official guidance on space design, table selection, instructions, and SQL snippets.
   - Read before modifying: `scanner.py` (scoring rules), `prompts_create/`, `plan_builder.py`
 - **GSL instruction schema (near-term)**: `docs/gsl-instruction-schema.md` — section vocabulary and format rules for `instructions.text_instructions[0].content` that the Create Agent and Fix Agent must follow. You MUST read this before modifying Create Agent or Fix Agent prompts.
-  - Read before modifying: `backend/prompts_create/plan_builder.py` (Create Agent prompt), `backend/prompts.py` (Fix Agent prompt), `backend/services/fix_agent.py`, `backend/services/create_agent_tools.py`
+  - Read before modifying: `backend/services/plan_builder.py` (Create Agent parallel-generation prompts), `backend/prompts_create/_plan.py` (Create Agent plan-step prompt template), `backend/prompts.py` (Fix Agent prompt), `backend/services/fix_agent.py`, `backend/services/create_agent_tools.py`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,3 +224,5 @@ optimization code, consult the relevant doc for design rationale.
   - Read before modifying: `fix_agent.py` (`_sanitize_ids`), `genie_creator.py`, `create_agent_tools.py`
 - **Genie Space best practices**: https://docs.databricks.com/aws/en/genie/best-practices — official guidance on space design, table selection, instructions, and SQL snippets.
   - Read before modifying: `scanner.py` (scoring rules), `prompts_create/`, `plan_builder.py`
+- **GSL instruction schema (near-term)**: `docs/gsl-instruction-schema.md` — section vocabulary and format rules for `instructions.text_instructions[0].content` that the Create Agent and Fix Agent must follow. You MUST read this before modifying Create Agent or Fix Agent prompts.
+  - Read before modifying: `backend/prompts_create/plan_builder.py` (Create Agent prompt), `backend/prompts.py` (Fix Agent prompt), `backend/services/fix_agent.py`, `backend/services/create_agent_tools.py`

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -290,7 +290,7 @@ _VALID_FIELD_PATHS_BLOCK = """## Valid Field Paths (ONLY use these exact names p
 - `data_sources.metric_views[N].identifier` — string (same structure as tables)
 
 **instructions:**
-- `instructions.text_instructions[N].content` — array of strings (max 1 per space)
+- `instructions.text_instructions[N].content` — array of strings (max 1 per space). Holds the agent's natural-language guidance organized under canonical GSL `## Section` headers (`## PURPOSE`, `## DISAMBIGUATION`, `## DATA QUALITY NOTES`, `## CONSTRAINTS`, `## Instructions you must follow when providing summaries`). When patching, **preserve every existing `## Section` header** — only edit bullets within a section or add a new section at the correct position. See `docs/gsl-instruction-schema.md`.
 - `instructions.example_question_sqls[N].question` — array of strings
 - `instructions.example_question_sqls[N].sql` — array of strings (each line as element)
 - `instructions.example_question_sqls[N].usage_guidance` — array of strings
@@ -373,6 +373,7 @@ Rules:
 - All string content fields (description, content, sql, question) are arrays of strings
 - Keep values CONCISE — descriptions should be 1-2 sentences, not paragraphs
 - Keep the total JSON response under 4000 tokens to avoid truncation
+- When patching `instructions.text_instructions[N].content`, preserve ALL existing `## Section` headers (e.g. `## PURPOSE`, `## DISAMBIGUATION`, `## CONSTRAINTS`). Only edit bullets within a section, or insert a new section at the correct position in the canonical order (PURPOSE → DISAMBIGUATION → DATA QUALITY NOTES → CONSTRAINTS → Instructions you must follow when providing summaries). If the only way to address the finding is to delete a canonical section, SKIP the patch: emit an entry with `"field_path": ""` and a `rationale` explaining which section would be lost.
 
 Output JSON with this exact structure:
 {{
@@ -426,8 +427,12 @@ If the fix requires changing multiple fields (e.g. adding usage_guidance to seve
 If this finding cannot be fixed via a config patch, return:
 {{"field_path": "", "new_value": null, "rationale": "Explanation"}}
 
+If applying the fix would require ERASING a canonical `## Section` header from `instructions.text_instructions[N].content` (`## PURPOSE`, `## DISAMBIGUATION`, `## DATA QUALITY NOTES`, `## CONSTRAINTS`, or `## Instructions you must follow when providing summaries`), DECLINE the patch by returning:
+{{"decline": true, "rationale": "Applying this fix would erase the ## <SECTION> header, which must be preserved. <what the user should do instead>"}}
+
 Rules:
 - Output ONLY valid JSON. Do NOT include any text, analysis, or explanation outside the JSON.
 - Keep values concise — 1-2 sentences for descriptions.
 - Replace N with actual array indices from the current configuration.
-- Generate AT MOST 50 patches. If the issue affects more items (e.g. 100+ columns need descriptions), fix only the first 50 most important ones. Partial progress is better than a truncated response."""
+- Generate AT MOST 50 patches. If the issue affects more items (e.g. 100+ columns need descriptions), fix only the first 50 most important ones. Partial progress is better than a truncated response.
+- When patching `instructions.text_instructions[N].content`, preserve ALL existing `## Section` headers that are already in the content. Only edit bullets within a section, or insert a new canonical section at the correct position (order: PURPOSE → DISAMBIGUATION → DATA QUALITY NOTES → CONSTRAINTS → Instructions you must follow when providing summaries). If the only way to address the finding is to delete a canonical section, DECLINE the patch using the decline shape above."""

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -416,23 +416,24 @@ def get_fix_agent_single_prompt(
 {_VALID_FIELD_PATHS_BLOCK}
 
 ## Output:
-Respond with ONLY a JSON object — no explanation, no analysis, no markdown, no text before or after.
+Respond with ONLY a JSON object — no explanation, no analysis, no markdown, no text before or after. Pick the FIRST shape below that applies:
 
-If the fix requires changing one field, return:
+1. (Preferred) single-field patch:
 {{"field_path": "exact.path.to.field", "new_value": "the new value", "rationale": "Why this fixes the issue"}}
 
-If the fix requires changing multiple fields (e.g. adding usage_guidance to several entries), return:
+2. Multi-field patch (e.g. adding usage_guidance to several entries):
 {{"patches": [{{"field_path": "path1", "new_value": "val1", "rationale": "reason"}}, {{"field_path": "path2", "new_value": "val2", "rationale": "reason"}}]}}
 
-If this finding cannot be fixed via a config patch, return:
-{{"field_path": "", "new_value": null, "rationale": "Explanation"}}
-
-If applying the fix would require ERASING a canonical `## Section` header from `instructions.text_instructions[N].content` (`## PURPOSE`, `## DISAMBIGUATION`, `## DATA QUALITY NOTES`, `## CONSTRAINTS`, or `## Instructions you must follow when providing summaries`), DECLINE the patch by returning:
+3. GSL section-erasure decline — use this ONLY when the fix would require deleting a canonical `## Section` header from `instructions.text_instructions[N].content` (`## PURPOSE`, `## DISAMBIGUATION`, `## DATA QUALITY NOTES`, `## CONSTRAINTS`, or `## Instructions you must follow when providing summaries`):
 {{"decline": true, "rationale": "Applying this fix would erase the ## <SECTION> header, which must be preserved. <what the user should do instead>"}}
+
+4. Not addressable via config — use this ONLY when the finding truly cannot be fixed by editing any field in the configuration (e.g. it requires runtime changes or user action):
+{{"field_path": "", "new_value": null, "rationale": "Explanation of why no config patch applies"}}
 
 Rules:
 - Output ONLY valid JSON. Do NOT include any text, analysis, or explanation outside the JSON.
 - Keep values concise — 1-2 sentences for descriptions.
 - Replace N with actual array indices from the current configuration.
 - Generate AT MOST 50 patches. If the issue affects more items (e.g. 100+ columns need descriptions), fix only the first 50 most important ones. Partial progress is better than a truncated response.
-- When patching `instructions.text_instructions[N].content`, preserve ALL existing `## Section` headers that are already in the content. Only edit bullets within a section, or insert a new canonical section at the correct position (order: PURPOSE → DISAMBIGUATION → DATA QUALITY NOTES → CONSTRAINTS → Instructions you must follow when providing summaries). If the only way to address the finding is to delete a canonical section, DECLINE the patch using the decline shape above."""
+- When patching `instructions.text_instructions[N].content`, preserve ALL existing `## Section` headers that are already in the content. Only edit bullets within a section, or insert a new canonical section at the correct position (order: PURPOSE → DISAMBIGUATION → DATA QUALITY NOTES → CONSTRAINTS → Instructions you must follow when providing summaries).
+- For GSL `## Section` erasure you MUST DECLINE via shape 3 (`decline: true`) — NEVER use shape 4 (empty `field_path`). Shape 4 is reserved for findings with no config surface at all."""

--- a/backend/prompts_create/_plan.py
+++ b/backend/prompts_create/_plan.py
@@ -53,29 +53,36 @@ The plan should include:
    - **Business rules that span multiple columns/tables**: "an 'active customer' has at least 1 order in the last 90 days AND a non-null email"
    - **Response behavior**: "when results are empty, suggest the user broaden the date range"
 
-   **Format: categorized sections with if-then rules.**
+   **Format: canonical GSL sections.** Use these exact headers, in this order, omitting any that are empty:
 
    ```
-   ## Terminology
+   ## PURPOSE
+   - Answer revenue and customer questions for the FY2024 US retail team.
+   - Audience: merchandising managers — assume retail/e-commerce fluency.
+
+   ## DISAMBIGUATION
    - "revenue" means net revenue (after returns and discounts), NOT gross revenue.
    - "active customer" = customer with at least 1 order in the last 90 days AND a non-null email address.
-
-   ## Default Assumptions
    - When no time range is specified, default to the current calendar year.
-   - When no region is specified, include all regions.
+   - Fiscal quarters: Q1=Feb-Apr, Q2=May-Jul, Q3=Aug-Oct, Q4=Nov-Jan. If the user says "this quarter", use the current fiscal quarter.
 
-   ## Fiscal Calendar
-   - Fiscal quarters: Q1=Feb-Apr, Q2=May-Jul, Q3=Aug-Oct, Q4=Nov-Jan.
-   - If the user says "this quarter", use the current fiscal quarter, not calendar quarter.
-
-   ## Data Quality Warnings
+   ## DATA QUALITY NOTES
    - The `status` column has inconsistent casing ('Active', 'ACTIVE', 'active'). ALWAYS use LOWER(status) when filtering.
    - `discount_code` is 87% NULL — warn the user if results look sparse.
    - `is_premium` stores booleans as strings ('true'/'false') — use LOWER(is_premium) = 'true', not a boolean comparison.
+
+   ## CONSTRAINTS
+   - Never show PII columns (customer_email, customer_phone).
+   - Do not project raw payment tokens.
+
+   ## Instructions you must follow when providing summaries
+   - Round monetary values to 2 decimal places.
+   - Always state the date range used in the summary.
    ```
 
    **Formatting rules:**
-   - **Categorize** under `##` headers (Terminology, Default Assumptions, Fiscal Calendar, Data Quality, etc.)
+   - **Use ONLY the canonical section headers**: `## PURPOSE`, `## DISAMBIGUATION`, `## DATA QUALITY NOTES`, `## CONSTRAINTS`, `## Instructions you must follow when providing summaries`. Keep them in this order. Do not invent new section names (e.g. "Terminology", "Fiscal Calendar") — fold that content into `## DISAMBIGUATION` or `## DATA QUALITY NOTES` as appropriate.
+   - **The summary-behavior header is verbatim** — Databricks's docs call out that exact string as how Genie routes summary-customization behavior. Do not paraphrase it.
    - **Use if-then rules** for conditional behavior: "If the user says X, interpret it as Y"
    - **Use ALWAYS/NEVER** for hard constraints
    - **Put critical rules first** — LLMs have a primacy bias

--- a/backend/references/schema.md
+++ b/backend/references/schema.md
@@ -60,9 +60,14 @@ Reference for `generate_config` and `update_config` tools. The tools handle all 
       {
         "id": "b2c3d4e5f6a70000000000000000000b",
         "content": [
-          "When calculating revenue, sum the order_amount column.\n",
-          "When asked about 'last month', use the previous calendar month.\n",
-          "Round all monetary values to 2 decimal places.\n"
+          "## PURPOSE\n",
+          "- Answer questions about order revenue for FY2024 US retail orders.\n",
+          "\n",
+          "## DISAMBIGUATION\n",
+          "- When asked about 'last month', use the previous calendar month.\n",
+          "\n",
+          "## Instructions you must follow when providing summaries\n",
+          "- Round all monetary values to 2 decimal places.\n"
         ]
       }
     ],
@@ -202,7 +207,7 @@ Reference for `generate_config` and `update_config` tools. The tools handle all 
 
 ### Size limits
 - `version`: Required. Must be `2`.
-- `text_instructions`: Max **1** entry per space. Each content element **must end with `\n`** (the API concatenates without separators — omitting `\n` jams text together).
+- `text_instructions`: Max **1** entry per space. Each content element **must end with `\n`** (the API concatenates without separators — omitting `\n` jams text together). For section vocabulary and format rules (PURPOSE / DISAMBIGUATION / DATA QUALITY NOTES / CONSTRAINTS / summary-behavior), see `docs/gsl-instruction-schema.md`.
 - Max **100** total instructions (each example SQL + each function + 1 for text block).
 - Table identifiers: three-level namespace `catalog.schema.table`.
 - Individual strings: max 25,000 characters.

--- a/backend/services/fix_agent.py
+++ b/backend/services/fix_agent.py
@@ -133,6 +133,23 @@ class FixAgent:
                     }
                     continue
 
+                # Defense-in-depth: the prompt also authorizes a legacy
+                # "not addressable via config" shape ({"field_path": "",
+                # "new_value": null, "rationale": "..."}) that lacks the
+                # `declined` flag. Treat it the same as a decline so the UI
+                # shows a skipped row with rationale instead of a fake fix.
+                if len(patches) == 1 and not patches[0].get("field_path"):
+                    rationale = patches[0].get("rationale") or "No applicable config patch."
+                    logger.info(f"No applicable patch for finding: {finding[:80]} — {rationale[:120]}")
+                    yield {
+                        "status": "skipped",
+                        "field_path": "",
+                        "old_value": None,
+                        "new_value": None,
+                        "rationale": rationale,
+                    }
+                    continue
+
                 finding_patches = []
                 for patch in patches:
                     field_path = patch.get("field_path", "")

--- a/backend/services/fix_agent.py
+++ b/backend/services/fix_agent.py
@@ -63,6 +63,8 @@ class FixAgent:
         Yields dicts with:
             - {"status": "thinking", "message": str}
             - {"status": "patch", "field_path": str, "old_value": any, "new_value": any, "rationale": str}
+            - {"status": "skipped", "field_path": "", "old_value": None, "new_value": None, "rationale": str}
+              (emitted when the agent declines a patch — e.g., the fix would erase a canonical GSL section header)
             - {"status": "applying", "message": str}
             - {"status": "complete", "patches_applied": int, "summary": str, "diff": dict}
             - {"status": "error", "message": str}
@@ -113,6 +115,21 @@ class FixAgent:
                         "old_value": None,
                         "new_value": None,
                         "rationale": "No fix needed or could not determine a patch",
+                    }
+                    continue
+
+                # Agent declined to patch (e.g., fix would erase a canonical GSL
+                # section header in text_instructions). Emit a "skipped" event
+                # carrying the LLM's rationale instead of attempting to apply.
+                if patches[0].get("declined"):
+                    rationale = patches[0].get("rationale") or "Patch declined by agent."
+                    logger.info(f"Fix declined for finding: {finding[:80]} — {rationale[:120]}")
+                    yield {
+                        "status": "skipped",
+                        "field_path": "",
+                        "old_value": None,
+                        "new_value": None,
+                        "rationale": rationale,
                     }
                     continue
 
@@ -220,6 +237,13 @@ def _parse_patches(content: str) -> list[dict]:
     except (json.JSONDecodeError, ValueError) as e:
         logger.warning(f"Failed to parse patch JSON: {e}. Content preview: {content[:300]}")
         return []
+
+    # Handle {"decline": true, "rationale": "..."} — agent refuses to patch because
+    # the fix would erase a canonical GSL section header. Return a single marker
+    # "patch" with declined=True so the caller can emit a skipped event.
+    if result.get("decline") is True:
+        rationale = result.get("rationale") or "Patch declined by agent (no rationale provided)."
+        return [{"field_path": "", "new_value": None, "rationale": rationale, "declined": True}]
 
     # Handle {"patches": [{...}, {...}]} format
     if "patches" in result and isinstance(result["patches"], list):

--- a/backend/services/plan_builder.py
+++ b/backend/services/plan_builder.py
@@ -333,10 +333,20 @@ def _gen_questions_instructions(shared: str) -> dict:
         "1. **suggested_display_name**: A concise, professional name for the Genie Space "
         "(e.g., 'NYC Taxi Revenue Performance', 'TPC-H Sales Analytics', 'Customer Support Dashboard')\n"
         "2. **sample_questions**: EXACTLY 5 natural-language questions a business user would ask\n"
-        "3. **text_instructions**: Domain knowledge for the Genie agent, organized under "
-        "category headers (## Terminology, ## Default Assumptions, ## Data Quality Warnings, etc.)\n\n"
+        "3. **text_instructions**: Domain knowledge for the Genie agent, organized under the "
+        "canonical GSL section headers (see rules below).\n\n"
         "Text instructions should contain ONLY business logic and terminology — NOT SQL formulas, "
-        "filter expressions, or join definitions (those go in other sections).\n"
+        "filter expressions, or join definitions (those go in other sections).\n\n"
+        "**Section vocabulary (use these exact headers, omit any that are empty, keep this order):**\n"
+        "- `## PURPOSE` — one or two bullets stating the space's scope and audience.\n"
+        "- `## DISAMBIGUATION` — clarification-question triggers and term-resolution rules "
+        "(e.g., \"When the user asks about 'customer performance' without a time range, ask them to clarify the period\"; "
+        "\"'Q1' means calendar Q1 unless the user says 'fiscal Q1'\").\n"
+        "- `## DATA QUALITY NOTES` — caveats the model needs to know: NULL handling, known bad rows, "
+        "column semantics not captured in the column description.\n"
+        "- `## CONSTRAINTS` — hard guardrails: what never to show (PII columns, secrets), what not to do.\n"
+        "- `## Instructions you must follow when providing summaries` — summary-customization behavior "
+        "(rounding rules, mandatory caveats). **Use this exact heading — it is Databricks's blessed string.**\n\n"
         "IMPORTANT: Keep text_instructions UNDER 2,000 characters total. Be concise — use bullet points, "
         "not paragraphs. If you have more than 2,000 chars of context, prioritize the most important rules "
         "and drop the rest. Long instructions push out higher-value SQL context in Genie's prompt window.\n"
@@ -345,7 +355,10 @@ def _gen_questions_instructions(shared: str) -> dict:
         "CRITICAL: Only reference category names, tiers, statuses, and labels that appear in the "
         "Column Profiles section below. Do NOT invent terms — use real data values.\n\n"
         "Return ONLY valid JSON:\n"
-        '{"suggested_display_name": "...", "sample_questions": ["..."], "text_instructions": ["## Terminology\\n- ...", "## Default Assumptions\\n- ..."]}\n\n'
+        '{"suggested_display_name": "...", "sample_questions": ["..."], "text_instructions": '
+        '["## PURPOSE\\n- Answer ... for ... users.", '
+        '"## DISAMBIGUATION\\n- When the user says X, interpret as Y.", '
+        '"## CONSTRAINTS\\n- Never show PII columns."]}\n\n'
         f"Context:\n{shared}"
     )
     return _call_llm_section(prompt, max_tokens=3000, section_name="questions/instructions")

--- a/backend/tests/test_dynamic_prompts.py
+++ b/backend/tests/test_dynamic_prompts.py
@@ -194,6 +194,68 @@ def test_all_steps_have_prompts_and_summaries():
         assert len(STEP_SUMMARIES[step]) > 10, f"Summary too short for step: {step}"
 
 
+# --- GSL instruction schema conformance (near-term, epic #87) ---
+# The Create Agent's plan-step prompt and the parallel-generation prompt both
+# must reference the 5 canonical GSL section headers so the agent emits
+# text_instructions that Fix Agent can preserve. See docs/gsl-instruction-schema.md.
+
+CANONICAL_GSL_SECTIONS = [
+    "## PURPOSE",
+    "## DISAMBIGUATION",
+    "## DATA QUALITY NOTES",
+    "## CONSTRAINTS",
+    "## Instructions you must follow when providing summaries",
+]
+
+
+def test_plan_step_prompt_uses_canonical_gsl_sections():
+    plan_prompt = STEP_PROMPTS["plan"]
+    for section in CANONICAL_GSL_SECTIONS:
+        assert section in plan_prompt, (
+            f"Plan-step prompt missing canonical GSL section header: {section!r}. "
+            f"See docs/gsl-instruction-schema.md."
+        )
+
+
+def test_plan_step_prompt_does_not_teach_legacy_sections():
+    """Legacy exemplar headers (## Terminology, ## Default Assumptions, ## Fiscal Calendar,
+    ## Data Quality Warnings) must not appear as instructional examples — they've been
+    replaced by the canonical GSL vocabulary."""
+    plan_prompt = STEP_PROMPTS["plan"]
+    # Each legacy header should not appear as a Markdown section heading in the prompt.
+    for legacy in ["## Terminology", "## Default Assumptions", "## Fiscal Calendar", "## Data Quality Warnings"]:
+        assert legacy not in plan_prompt, (
+            f"Plan-step prompt still teaches legacy section header {legacy!r}. "
+            f"Replace with canonical GSL vocabulary from docs/gsl-instruction-schema.md."
+        )
+
+
+def test_parallel_plan_prompt_uses_canonical_gsl_sections():
+    """The parallel plan generator (_gen_questions_instructions) builds its prompt inline.
+    Capture it by mocking _call_llm_section and assert canonical section names appear."""
+    from backend.services import plan_builder
+
+    captured = {}
+
+    def fake_call(prompt, *, max_tokens, section_name):
+        captured["prompt"] = prompt
+        captured["section_name"] = section_name
+        return {"suggested_display_name": "x", "sample_questions": [], "text_instructions": []}
+
+    original = plan_builder._call_llm_section
+    plan_builder._call_llm_section = fake_call
+    try:
+        plan_builder._gen_questions_instructions("some shared context")
+    finally:
+        plan_builder._call_llm_section = original
+
+    prompt = captured["prompt"]
+    for section in CANONICAL_GSL_SECTIONS:
+        assert section in prompt, (
+            f"_gen_questions_instructions prompt missing canonical GSL section header: {section!r}."
+        )
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     for test in tests:

--- a/backend/tests/test_fix_agent_paths.py
+++ b/backend/tests/test_fix_agent_paths.py
@@ -507,3 +507,40 @@ class TestFixAgentRunSkippedEvent:
         statuses = [e.get("status") for e in events]
         assert "patch" in statuses
         assert "skipped" not in statuses
+
+    @patch("backend.services.fix_agent._apply_config_to_databricks")
+    @patch("backend.services.fix_agent._generate_patches_for_finding")
+    def test_legacy_empty_field_path_emits_skipped_not_patch(self, mock_gen, mock_apply):
+        """If the LLM picks the legacy no-patch shape (empty field_path, no
+        `declined` flag) — e.g. for a GSL section-erasure case where it did not
+        read the decline instruction — run() must still normalize to skipped
+        so the UI surfaces the rationale and phase resolves to 'complete'.
+        Without this guard, the loop yields a synthetic status=patch event
+        with empty field_path, dropping the rationale and flipping the panel
+        to error."""
+        mock_gen.return_value = [{
+            "field_path": "",
+            "new_value": None,
+            "rationale": "Would erase the ## PURPOSE header; no other field covers this finding.",
+        }]
+
+        events = self._collect_events(
+            self._make_agent(),
+            space_id="s1",
+            findings=["text instructions too brief"],
+            space_config={"instructions": {}, "data_sources": {"tables": []}},
+        )
+
+        statuses = [e.get("status") for e in events]
+        assert "skipped" in statuses, f"Expected 'skipped', got {statuses}"
+        # No synthetic patch event with empty field_path
+        patch_events = [e for e in events if e.get("status") == "patch"]
+        assert not patch_events, (
+            f"Legacy empty-field_path shape must not surface as a 'patch' event, "
+            f"got: {patch_events}"
+        )
+        # Rationale is carried through to the skipped event
+        skipped = [e for e in events if e.get("status") == "skipped"]
+        assert "## PURPOSE" in skipped[0]["rationale"]
+        # Nothing was applied to Databricks
+        mock_apply.assert_not_called()

--- a/backend/tests/test_fix_agent_paths.py
+++ b/backend/tests/test_fix_agent_paths.py
@@ -4,12 +4,20 @@ Tests _get_value_at_path(), _set_value_at_path(), _sanitize_ids (pure functions)
 and _apply_config_sync (retry logic, mocked).
 """
 
+import asyncio
+import json
 import re
 from unittest.mock import MagicMock, patch, call
 
 import pytest
 
-from backend.services.fix_agent import _get_value_at_path, _set_value_at_path, _sanitize_ids
+from backend.services.fix_agent import (
+    FixAgent,
+    _get_value_at_path,
+    _parse_patches,
+    _set_value_at_path,
+    _sanitize_ids,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -378,3 +386,124 @@ class TestApplyConfigSyncRetry:
         all_ids = sq_ids + bq_ids
         assert all_ids.count(shared_id) == 1  # kept in sample_questions, removed from benchmarks
         assert len(patched_config["benchmarks"]["questions"]) == 1  # only other_id remains
+
+
+# ---------------------------------------------------------------------------
+# GSL section-header preservation: _parse_patches and run() (near-term, epic #87)
+# ---------------------------------------------------------------------------
+
+class TestParsePatchesDecline:
+    """_parse_patches must handle the decline shape emitted when a fix would
+    erase a canonical GSL section header in text_instructions.content."""
+
+    def test_decline_true_returns_marker_patch(self):
+        content = json.dumps({
+            "decline": True,
+            "rationale": "Applying this fix would erase the ## PURPOSE header.",
+        })
+        patches = _parse_patches(content)
+        assert len(patches) == 1
+        assert patches[0]["declined"] is True
+        assert patches[0]["field_path"] == ""
+        assert patches[0]["new_value"] is None
+        assert "## PURPOSE" in patches[0]["rationale"]
+
+    def test_decline_true_without_rationale_uses_fallback(self):
+        content = json.dumps({"decline": True})
+        patches = _parse_patches(content)
+        assert len(patches) == 1
+        assert patches[0]["declined"] is True
+        assert patches[0]["rationale"]  # non-empty fallback
+
+    def test_decline_false_is_not_a_decline(self):
+        """Only `decline: true` triggers the decline path — `decline: false` is treated
+        as missing; falls through to normal parsing."""
+        content = json.dumps({"decline": False, "field_path": "x.y", "new_value": "v", "rationale": "r"})
+        patches = _parse_patches(content)
+        assert len(patches) == 1
+        assert patches[0].get("declined") is not True
+        assert patches[0]["field_path"] == "x.y"
+
+    def test_normal_patch_unaffected(self):
+        content = json.dumps({"field_path": "x.y", "new_value": "v", "rationale": "r"})
+        patches = _parse_patches(content)
+        assert len(patches) == 1
+        assert patches[0].get("declined") is not True
+        assert patches[0]["field_path"] == "x.y"
+
+    def test_patches_array_unaffected(self):
+        content = json.dumps({"patches": [
+            {"field_path": "a.b", "new_value": "1", "rationale": "r1"},
+            {"field_path": "c.d", "new_value": "2", "rationale": "r2"},
+        ]})
+        patches = _parse_patches(content)
+        assert len(patches) == 2
+        assert all(p.get("declined") is not True for p in patches)
+
+
+class TestFixAgentRunSkippedEvent:
+    """FixAgent.run must emit {status: "skipped", ...} carrying the LLM's rationale
+    when a patch is declined — not try to apply, not report success as a silent no-op."""
+
+    def _make_agent(self) -> FixAgent:
+        agent = FixAgent.__new__(FixAgent)
+        agent.model = "test-model"
+        return agent
+
+    def _collect_events(self, agent: FixAgent, space_id: str, findings: list[str], space_config: dict) -> list[dict]:
+        async def _drain():
+            events = []
+            async for ev in agent.run(space_id=space_id, findings=findings, space_config=space_config):
+                events.append(ev)
+            return events
+        return asyncio.run(_drain())
+
+    @patch("backend.services.fix_agent._apply_config_to_databricks")
+    @patch("backend.services.fix_agent._generate_patches_for_finding")
+    def test_declined_patch_emits_skipped_event(self, mock_gen, mock_apply):
+        mock_gen.return_value = [{
+            "field_path": "",
+            "new_value": None,
+            "rationale": "Applying this fix would erase the ## PURPOSE header.",
+            "declined": True,
+        }]
+        events = self._collect_events(
+            self._make_agent(),
+            space_id="s1",
+            findings=["text instructions too brief"],
+            space_config={"instructions": {}, "data_sources": {"tables": []}},
+        )
+
+        skipped = [e for e in events if e.get("status") == "skipped"]
+        assert len(skipped) == 1, f"Expected one skipped event, got {[e.get('status') for e in events]}"
+        assert "## PURPOSE" in skipped[0]["rationale"]
+        assert skipped[0]["field_path"] == ""
+        # No config was applied
+        mock_apply.assert_not_called()
+
+    @patch("backend.services.fix_agent._apply_config_to_databricks")
+    @patch("backend.services.fix_agent._generate_patches_for_finding")
+    def test_normal_patch_still_emits_patch_event(self, mock_gen, mock_apply):
+        """Smoke: a normal (non-declined) patch is applied and emits status=patch, not skipped."""
+        mock_gen.return_value = [{
+            "field_path": "data_sources.tables[0].description",
+            "new_value": ["New description"],
+            "rationale": "Add description for the orders table.",
+        }]
+        async def noop(space_id, patches):
+            return None
+        mock_apply.side_effect = noop
+
+        events = self._collect_events(
+            self._make_agent(),
+            space_id="s1",
+            findings=["orders table has no description"],
+            space_config={
+                "instructions": {},
+                "data_sources": {"tables": [{"identifier": "c.s.orders"}]},
+            },
+        )
+
+        statuses = [e.get("status") for e in events]
+        assert "patch" in statuses
+        assert "skipped" not in statuses

--- a/backend/tests/test_fix_agent_prompt.py
+++ b/backend/tests/test_fix_agent_prompt.py
@@ -135,6 +135,73 @@ class TestSinglePromptStructure:
 
 
 # ---------------------------------------------------------------------------
+# GSL section-header preservation (near-term, epic #87)
+# ---------------------------------------------------------------------------
+# The Fix Agent must preserve canonical `## Section` headers in
+# text_instructions content and must know how to decline a patch that would
+# erase one. See docs/gsl-instruction-schema.md.
+
+CANONICAL_GSL_SECTIONS = [
+    "## PURPOSE",
+    "## DISAMBIGUATION",
+    "## DATA QUALITY NOTES",
+    "## CONSTRAINTS",
+    "## Instructions you must follow when providing summaries",
+]
+
+
+class TestFixAgentGslSectionPreservation:
+    """Both Fix Agent prompts must teach the LLM to preserve canonical GSL section headers."""
+
+    def test_single_prompt_mentions_all_canonical_sections(self, single_prompt):
+        for section in CANONICAL_GSL_SECTIONS:
+            assert section in single_prompt, (
+                f"Single-finding fix prompt missing canonical GSL section header: {section!r}. "
+                f"See docs/gsl-instruction-schema.md."
+            )
+
+    def test_batch_prompt_mentions_canonical_sections(self, sample_prompt):
+        # The batch prompt only needs to reference the existence of canonical
+        # sections via the _VALID_FIELD_PATHS_BLOCK and its rules block.
+        assert "## PURPOSE" in sample_prompt
+        assert "## CONSTRAINTS" in sample_prompt
+        assert "preserve" in sample_prompt.lower()
+
+    def test_single_prompt_teaches_decline_shape(self, single_prompt):
+        """When a fix would erase a canonical section, the agent must decline, not apply."""
+        assert '"decline": true' in single_prompt
+        assert "DECLINE" in single_prompt
+
+    def test_single_prompt_explains_section_order(self, single_prompt):
+        """The canonical order must be spelled out so the LLM can insert new sections correctly."""
+        assert "PURPOSE" in single_prompt
+        assert "CONSTRAINTS" in single_prompt
+        # The ordering should appear as a sequence (either arrow-separated or similar)
+        idx_purpose = single_prompt.find("PURPOSE")
+        idx_constraints = single_prompt.find("CONSTRAINTS")
+        assert idx_purpose < idx_constraints, (
+            "Canonical ordering should present PURPOSE before CONSTRAINTS in the prompt"
+        )
+
+    def test_batch_prompt_allows_skipping_when_section_would_be_erased(self, sample_prompt):
+        """Batch prompt uses empty field_path + rationale as its skip mechanism."""
+        assert '"field_path"' in sample_prompt
+        # It should explicitly acknowledge that skipping is an option for the section-preservation rule.
+        assert "SKIP" in sample_prompt or "skip the patch" in sample_prompt.lower()
+
+    def test_valid_paths_block_documents_section_preservation(self, single_prompt):
+        """The valid-paths list entry for text_instructions[N].content should remind
+        the LLM to preserve headers (belt-and-suspenders so the rule lands even if
+        the Rules block gets truncated)."""
+        # Find the text_instructions entry and check it explains preservation
+        lines = single_prompt.split("\n")
+        ti_lines = [l for l in lines if "text_instructions[N].content" in l]
+        assert len(ti_lines) >= 1, "Expected text_instructions[N].content path entry"
+        combined = " ".join(ti_lines)
+        assert "preserve" in combined.lower() or "Section" in combined
+
+
+# ---------------------------------------------------------------------------
 # Field path validation
 # ---------------------------------------------------------------------------
 

--- a/docs/gsl-instruction-schema.md
+++ b/docs/gsl-instruction-schema.md
@@ -41,11 +41,11 @@ sections** — do not leave an empty header.
 - **Blank line between sections.**
 - **No SQL inside bullets.** SQL goes in `sql_snippets` (reusable
   expressions and measures) or `example_question_sqls` (full query
-  patterns). This is the scanner's rule at
-  `backend/services/scanner.py::_SQL_IN_TEXT_RE`.
-- **Keep total content ≤ 2,000 characters** (the IQ Scanner's soft
-  threshold at `backend/services/scanner.py` L185–186). Longer blocks
-  push out higher-value SQL context in the Genie prompt window.
+  patterns). This is the scanner's rule — see `_SQL_IN_TEXT_RE` in
+  `backend/services/scanner.py`.
+- **Keep total content ≤ 2,000 characters** — the IQ Scanner's soft
+  threshold in check #4 (text-instructions length). Longer blocks push
+  out higher-value SQL context in the Genie prompt window.
 - **Each bullet should reference a concrete asset** (table, column,
   user phrase) or be a specific behavioral rule. Vague guidance ("be
   helpful", "follow best practices") is an anti-pattern per Databricks.
@@ -135,4 +135,4 @@ shared Python module) is tracked in epic #173.
 - Genie Space serialized schema: <https://docs.databricks.com/aws/en/genie/conversation-api#understanding-the-serialized_space-field>
 - Near-term epic: #87 (this doc + #89 Create Agent + #90 Fix Agent)
 - Full unification epic: #173 (Workbench 0.1)
-- IQ Scanner check this schema supports: `backend/services/scanner.py` check #4 (L170–198)
+- IQ Scanner check this schema supports: `backend/services/scanner.py` check #4 (text-instructions length + SQL-in-text)

--- a/docs/gsl-instruction-schema.md
+++ b/docs/gsl-instruction-schema.md
@@ -1,0 +1,138 @@
+# GSL Instruction Schema
+
+## Why a schema
+
+Three agents write `text_instructions`:
+
+- **Create Agent** — generates the initial block when a user builds a
+  new space.
+- **Fix Agent** — patches the block in response to IQ Scanner findings.
+- **Optimizer (GSO)** — rewrites the block as part of
+  benchmark-driven optimization.
+
+Historically each used a different authoring convention, so a Create
+Agent space with `## Terminology` headers would be overwritten by a
+Fix Agent patch that emitted loose prose, or stripped by an
+optimizer that expected `PURPOSE:` ALL-CAPS headers. This doc is the
+shared vocabulary Create and Fix both target so the output is
+coherent end-to-end. The optimizer migrates to this schema in
+Workbench 0.1 (#91, #173).
+
+## Section vocabulary
+
+Five canonical sections. Present them in this order; **omit empty
+sections** — do not leave an empty header.
+
+| # | Header | What goes here |
+|---|---|---|
+| 1 | `## PURPOSE` | One or two bullets stating the space's scope and audience. |
+| 2 | `## DISAMBIGUATION` | Clarification-question triggers: "When the user asks about X without specifying Y, ask them to clarify Y." Also, term-resolution rules: "'Q1' means calendar Q1 unless the user says 'fiscal Q1'." |
+| 3 | `## DATA QUALITY NOTES` | Caveats about the data the model needs to know: NULL handling, known bad rows, column semantics that aren't in the column description. |
+| 4 | `## CONSTRAINTS` | Hard guardrails: what never to show (PII columns, secrets), what not to do (cross-join, ignore a required filter). |
+| 5 | `## Instructions you must follow when providing summaries` | Summary-customization behavior: rounding rules, mandatory caveats, date-range statements. This header is Databricks's verbatim blessed string — do not paraphrase it. |
+
+## Format rules
+
+- **Markdown `## Header`** for each section.
+- **ALL-CAPS (`## PURPOSE`) or title/sentence case (`## Purpose`) is acceptable.**
+  Prompts and future validators treat them interchangeably. The summary-behavior
+  section stays in sentence case because Databricks docs call that exact string out.
+- **Dash bullets** (`- …`) for each rule. Keep one idea per bullet.
+- **Blank line between sections.**
+- **No SQL inside bullets.** SQL goes in `sql_snippets` (reusable
+  expressions and measures) or `example_question_sqls` (full query
+  patterns). This is the scanner's rule at
+  `backend/services/scanner.py::_SQL_IN_TEXT_RE`.
+- **Keep total content ≤ 2,000 characters** (the IQ Scanner's soft
+  threshold at `backend/services/scanner.py` L185–186). Longer blocks
+  push out higher-value SQL context in the Genie prompt window.
+- **Each bullet should reference a concrete asset** (table, column,
+  user phrase) or be a specific behavioral rule. Vague guidance ("be
+  helpful", "follow best practices") is an anti-pattern per Databricks.
+
+## Verbatim example
+
+```markdown
+## PURPOSE
+- Answer questions about order revenue for FY2024 US retail orders.
+- Users are merchandising managers — assume retail/e-commerce fluency.
+
+## DISAMBIGUATION
+- When the user asks about "customer performance" without a time range, ask them to clarify the period.
+- "Q1" means calendar Q1 unless the user says "fiscal Q1".
+
+## DATA QUALITY NOTES
+- orders.order_amount is NULL for cancelled rows — filter with is_cancelled = false.
+- Returns appear in dim_returns one day after the sale — allow for T+1 reconciliation when joining.
+
+## CONSTRAINTS
+- Never show PII columns (customer_email, customer_phone).
+- Do not project raw payment tokens.
+
+## Instructions you must follow when providing summaries
+- Round percentages to two decimal places.
+- Always state the date range used in the summary.
+```
+
+## What does NOT go in `text_instructions`
+
+Per <https://docs.databricks.com/aws/en/genie/best-practices>,
+`text_instructions` is a last resort. The following content belongs in
+other config layers:
+
+| Content | Target config layer |
+|---|---|
+| Metric / filter / expression definitions (e.g. `revenue = SUM(orders.order_amount)`) | `instructions.sql_snippets` (expressions / measures / filters) |
+| Full example queries and multi-step query patterns | `instructions.example_question_sqls` |
+| Join conditions | `instructions.join_specs` |
+| Table / column documentation | table `description` / `column_configs[].description` / `synonyms` |
+
+Keep `text_instructions` focused on natural-language guidance that
+Genie cannot infer from the structured config.
+
+## Agent-specific behavior
+
+### Create Agent
+
+Emits the section vocabulary above when generating a new space. Each
+section is one or more bullets. Output shape stays
+`content: list[str]` during this near-term pass; migration to the
+canonical single-item `[full_text]` shape is tracked in #177
+(Workbench 0.1).
+
+### Fix Agent
+
+**Must preserve existing section headers when patching.**
+`instructions.text_instructions[N].content` is the only patchable path
+into this block (`backend/prompts.py::_VALID_FIELD_PATHS_BLOCK`). When
+the Fix Agent proposes a patch, it must:
+
+1. Identify the Markdown `## Section` headers already in the content.
+2. Preserve each header in its `new_value`; edit only bullets within
+   a section, or add a new section at the correct position in the
+   order above.
+3. If the only way to address a finding is to delete a canonical
+   section, decline the patch by returning
+   `{"decline": true, "rationale": "..."}` instead.
+
+### Optimizer (GSO) — NOT YET MIGRATED
+
+GSO currently emits a **wider section vocabulary in ALL-CAPS plain
+text** (see
+`packages/genie-space-optimizer/src/genie_space_optimizer/common/config.py`
+`INSTRUCTION_SECTION_ORDER` / `INSTRUCTION_FORMAT_RULES`). The Fix
+Agent's header-preservation rule handles GSO-authored content
+correctly because "preserve existing headers" applies whether they
+are Markdown or ALL-CAPS plain text.
+
+Full GSO alignment (Markdown format, narrower vocabulary, content
+routing to `sql_snippets` / `join_specs` / `example_question_sqls`,
+shared Python module) is tracked in epic #173.
+
+## References
+
+- Databricks best practices: <https://docs.databricks.com/aws/en/genie/best-practices>
+- Genie Space serialized schema: <https://docs.databricks.com/aws/en/genie/conversation-api#understanding-the-serialized_space-field>
+- Near-term epic: #87 (this doc + #89 Create Agent + #90 Fix Agent)
+- Full unification epic: #173 (Workbench 0.1)
+- IQ Scanner check this schema supports: `backend/services/scanner.py` check #4 (L170–198)

--- a/frontend/src/components/FixAgentPanel.tsx
+++ b/frontend/src/components/FixAgentPanel.tsx
@@ -14,6 +14,7 @@ import {
   ChevronDown,
   ChevronRight,
   Info,
+  MinusCircle,
 } from "lucide-react"
 import { streamFixAgent } from "@/lib/api"
 import type { FixPatch } from "@/types"
@@ -21,8 +22,9 @@ import type { FixPatch } from "@/types"
 type Phase = "running" | "applying" | "complete" | "error"
 interface Issue {
   text: string
-  status: "pending" | "fixing" | "fixed" | "error"
+  status: "pending" | "fixing" | "fixed" | "skipped" | "error"
   patch?: FixPatch
+  skipReason?: string
 }
 
 interface FixAgentPanelProps {
@@ -46,6 +48,7 @@ export function FixAgentPanel({ spaceId, displayName, findings, spaceConfig, onC
 
   const abortRef = useRef<(() => void) | null>(null)
   const patchIndexRef = useRef(0)
+  const skipCountRef = useRef(0)
   const phaseRef = useRef<Phase>("running")
 
   // Start fix agent on mount
@@ -94,6 +97,32 @@ export function FixAgentPanel({ spaceId, displayName, findings, spaceConfig, onC
             setStatusMessage(`Applied patch: ${event.field_path || "config update"}`)
             break
 
+          case "skipped":
+            // Agent declined the patch (e.g. would erase a canonical GSL
+            // section header). Advance the index like "patch" so later events
+            // land on the right row, and surface the rationale so the user
+            // knows why nothing was applied.
+            skipCountRef.current++
+            setIssues(prev => {
+              const idx = patchIndexRef.current
+              patchIndexRef.current++
+              return prev.map((item, i) => {
+                if (i === idx) {
+                  return {
+                    ...item,
+                    status: "skipped" as const,
+                    skipReason: event.rationale || "Agent declined to apply this fix.",
+                  }
+                }
+                if (i === idx + 1 && item.status === "pending") {
+                  return { ...item, status: "fixing" as const }
+                }
+                return item
+              })
+            })
+            setStatusMessage("Skipped one fix — see details")
+            break
+
           case "applying":
             setPhase("applying")
             phaseRef.current = "applying"
@@ -102,26 +131,31 @@ export function FixAgentPanel({ spaceId, displayName, findings, spaceConfig, onC
 
           case "complete": {
             const applied = event.patches_applied ?? 0
+            // Leave "skipped" rows alone in both branches so their rationale
+            // stays visible after the run finishes.
             if (applied > 0) {
-              // Only mark remaining as fixed if patches were actually applied
               setIssues(prev => prev.map(item =>
                 item.status === "pending" || item.status === "fixing"
                   ? { ...item, status: "fixed" as const }
                   : item
               ))
             } else {
-              // No patches applied — reset any "fixing" back to pending
               setIssues(prev => prev.map(item =>
                 item.status === "fixing" ? { ...item, status: "pending" as const } : item
               ))
             }
-            const newPhase = applied > 0 ? "complete" : "error"
+            // If all findings were declined (applied===0 but everything ended
+            // up "skipped"), the run still completed — don't flip to "error".
+            const anySkipped = skipCountRef.current > 0
+            const newPhase = applied > 0 || anySkipped ? "complete" : "error"
             setPhase(newPhase)
             phaseRef.current = newPhase
             setSummary(event.summary || (applied > 0
               ? `Applied ${applied} fix(es)`
-              : "Could not generate fixes — try re-scanning first"))
-            if (applied === 0) setErrorMessage(event.summary || "No patches could be generated")
+              : anySkipped
+                ? "All fixes were declined — see details"
+                : "Could not generate fixes — try re-scanning first"))
+            if (applied === 0 && !anySkipped) setErrorMessage(event.summary || "No patches could be generated")
             break
           }
 
@@ -232,9 +266,9 @@ export function FixAgentPanel({ spaceId, displayName, findings, spaceConfig, onC
         {issues.map((issue, idx) => (
           <div key={idx}>
             <button
-              onClick={() => issue.patch && setExpandedIdx(expandedIdx === idx ? null : idx)}
+              onClick={() => (issue.patch || issue.skipReason) && setExpandedIdx(expandedIdx === idx ? null : idx)}
               className={`flex items-start gap-3 w-full text-left py-2 px-2 rounded-lg transition-colors ${
-                issue.patch ? "hover:bg-surface-secondary cursor-pointer" : "cursor-default"
+                issue.patch || issue.skipReason ? "hover:bg-surface-secondary cursor-pointer" : "cursor-default"
               }`}
             >
               {/* Status icon */}
@@ -246,6 +280,10 @@ export function FixAgentPanel({ spaceId, displayName, findings, spaceConfig, onC
                 ) : issue.status === "fixing" ? (
                   <div className="w-5 h-5 rounded-full bg-accent/15 flex items-center justify-center">
                     <Loader2 className="w-3 h-3 text-accent animate-spin" />
+                  </div>
+                ) : issue.status === "skipped" ? (
+                  <div className="w-5 h-5 rounded-full bg-amber-500/20 flex items-center justify-center">
+                    <MinusCircle className="w-3 h-3 text-amber-400" />
                   </div>
                 ) : issue.status === "error" ? (
                   <div className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center">
@@ -261,7 +299,10 @@ export function FixAgentPanel({ spaceId, displayName, findings, spaceConfig, onC
               {/* Issue text */}
               <div className="flex-1 min-w-0">
                 <p className={`text-sm ${
-                  issue.status === "fixed" ? "text-secondary" : issue.status === "error" ? "text-red-400" : "text-primary"
+                  issue.status === "fixed" ? "text-secondary"
+                    : issue.status === "skipped" ? "text-secondary"
+                    : issue.status === "error" ? "text-red-400"
+                    : "text-primary"
                 }`}>
                   {issue.text}
                 </p>
@@ -272,6 +313,15 @@ export function FixAgentPanel({ spaceId, displayName, findings, spaceConfig, onC
                       : <ChevronRight className="w-3 h-3 text-muted" />
                     }
                     <span className="text-xs text-muted font-mono">{issue.patch.field_path}</span>
+                  </div>
+                )}
+                {issue.skipReason && (
+                  <div className="flex items-center gap-1 mt-0.5">
+                    {expandedIdx === idx
+                      ? <ChevronDown className="w-3 h-3 text-muted" />
+                      : <ChevronRight className="w-3 h-3 text-muted" />
+                    }
+                    <span className="text-xs text-amber-400">Skipped — tap for reason</span>
                   </div>
                 )}
               </div>
@@ -288,6 +338,13 @@ export function FixAgentPanel({ spaceId, displayName, findings, spaceConfig, onC
                   {" → "}
                   <span className="text-emerald-400">{formatValue(issue.patch.new_value)}</span>
                 </div>
+              </div>
+            )}
+
+            {/* Expanded skip rationale */}
+            {expandedIdx === idx && issue.skipReason && (
+              <div className="ml-10 mb-2 px-3 py-2 bg-amber-500/5 border border-amber-500/20 rounded-lg text-xs space-y-1">
+                <p className="text-amber-300/90">{issue.skipReason}</p>
               </div>
             )}
           </div>

--- a/frontend/src/components/FixAgentPanel.tsx
+++ b/frontend/src/components/FixAgentPanel.tsx
@@ -70,31 +70,59 @@ export function FixAgentPanel({ spaceId, displayName, findings, spaceConfig, onC
             break
 
           case "patch":
-            // Advance the next pending/fixing issue to "fixed"
-            setIssues(prev => {
-              const idx = patchIndexRef.current
-              patchIndexRef.current++
-              return prev.map((item, i) => {
-                if (i === idx) {
-                  return {
-                    ...item,
-                    status: "fixed" as const,
-                    patch: event.field_path ? {
-                      field_path: event.field_path,
-                      old_value: event.old_value,
-                      new_value: event.new_value,
-                      rationale: event.rationale || "",
-                    } : undefined,
+            // If the backend emits an empty field_path, the LLM couldn't
+            // produce a config change — route to the skipped rendering path
+            // so the rationale survives and phase resolves to "complete".
+            if (!event.field_path) {
+              skipCountRef.current++
+              setIssues(prev => {
+                const idx = patchIndexRef.current
+                patchIndexRef.current++
+                return prev.map((item, i) => {
+                  if (i === idx) {
+                    return {
+                      ...item,
+                      status: "skipped" as const,
+                      skipReason: event.rationale || "Agent could not generate a patch.",
+                    }
                   }
-                }
-                // Mark the next one as "fixing"
-                if (i === idx + 1 && item.status === "pending") {
-                  return { ...item, status: "fixing" as const }
-                }
-                return item
+                  if (i === idx + 1 && item.status === "pending") {
+                    return { ...item, status: "fixing" as const }
+                  }
+                  return item
+                })
               })
-            })
-            setStatusMessage(`Applied patch: ${event.field_path || "config update"}`)
+              setStatusMessage("Skipped one fix — see details")
+              break
+            }
+            // Advance the next pending/fixing issue to "fixed"
+            {
+              const fieldPath = event.field_path
+              setIssues(prev => {
+                const idx = patchIndexRef.current
+                patchIndexRef.current++
+                return prev.map((item, i) => {
+                  if (i === idx) {
+                    return {
+                      ...item,
+                      status: "fixed" as const,
+                      patch: {
+                        field_path: fieldPath,
+                        old_value: event.old_value,
+                        new_value: event.new_value,
+                        rationale: event.rationale || "",
+                      },
+                    }
+                  }
+                  // Mark the next one as "fixing"
+                  if (i === idx + 1 && item.status === "pending") {
+                    return { ...item, status: "fixing" as const }
+                  }
+                  return item
+                })
+              })
+              setStatusMessage(`Applied patch: ${fieldPath}`)
+            }
             break
 
           case "skipped":
@@ -196,6 +224,7 @@ export function FixAgentPanel({ spaceId, displayName, findings, spaceConfig, onC
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const fixedCount = issues.filter(i => i.status === "fixed").length
+  const progressCount = issues.filter(i => i.status === "fixed" || i.status === "skipped").length
   const totalCount = issues.length
   // Detect if any finding mentions 50+ columns needing descriptions
   const hasBulkColumns = findings.some(f => {
@@ -255,7 +284,7 @@ export function FixAgentPanel({ spaceId, displayName, findings, spaceConfig, onC
               className={`h-full rounded-full transition-all duration-500 ${
                 phase === "complete" ? "bg-emerald-500" : phase === "error" ? "bg-red-400" : "bg-accent"
               }`}
-              style={{ width: `${phase === "complete" ? 100 : (fixedCount / totalCount) * 100}%` }}
+              style={{ width: `${phase === "complete" ? 100 : (progressCount / totalCount) * 100}%` }}
             />
           </div>
         )}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -85,7 +85,7 @@ export interface FixPatch {
 }
 
 export interface FixAgentEvent {
-  status: "thinking" | "patch" | "applying" | "complete" | "error"
+  status: "thinking" | "patch" | "skipped" | "applying" | "complete" | "error"
   message?: string
   field_path?: string
   old_value?: unknown


### PR DESCRIPTION
## Summary

Near-term pass of epic #87 for the Level Up (May) milestone. Introduces a lightweight schema-guidance doc and aligns Create Agent + Fix Agent on a Databricks-blessed section vocabulary so freshly created spaces and Quick-Fix patches produce coherent `text_instructions` instead of three drifting conventions.

Full unification (shared Python module, GSO refactor, content routing, conformance CI) tracked in follow-on epic #173 for Workbench 0.1.

## Changes

### Phase 1 — schema note (#88)
- New `docs/gsl-instruction-schema.md` defining the 5-section canonical vocabulary: `## PURPOSE`, `## DISAMBIGUATION`, `## DATA QUALITY NOTES`, `## CONSTRAINTS`, `## Instructions you must follow when providing summaries` (the last is Databricks's verbatim blessed heading per https://docs.databricks.com/aws/en/genie/best-practices)
- Cross-linked from root `AGENTS.md` with a must-read annotation
- `backend/references/schema.md` example rewritten to show canonical headers, pointer sentence added

### Phase 2 — Create Agent vocabulary (#89)
- `backend/services/plan_builder.py::_gen_questions_instructions` prompt teaches the 5 canonical headers with the blessed summary heading verbatim
- `backend/prompts_create/_plan.py` exemplar and formatting rules rewritten around canonical sections
- Content shape (per-line `list[str]`) stays unchanged; single-item `[full_text]` migration tracked in #177

### Phase 3 — Fix Agent header preservation (#90)
- Both Fix Agent prompts require preserving every existing `## Section` header when patching `text_instructions[N].content`
- New `{"decline": true, "rationale": "..."}` output shape for the single-finding prompt when a fix would require erasing a canonical section
- `_parse_patches` detects the decline shape; `FixAgent.run` emits `status="skipped"` with the LLM's rationale — no config applied

### Scope split (Phase 0, pre-PR bookkeeping)
Issue-management reflected before code changes: #91 moved from Level Up (May) to Workbench 0.1 under the new epic #173; four new children filed (#174 shared module, #175 GSO content-routing, #176 legacy migration, #177 Create Agent content-shape).

## Test plan

- [ ] `pytest backend/tests/test_dynamic_prompts.py backend/tests/test_genie_creator.py backend/tests/test_fix_agent_prompt.py backend/tests/test_fix_agent_paths.py` — all pass locally (3 pre-existing `pytest-asyncio` env failures unrelated to this PR)
- [ ] Deploy with `./scripts/deploy.sh --update`
- [ ] Create a new space via Create Agent; inspect `text_instructions[0].content` — confirm canonical headers present, ≤ 2k chars
- [ ] Run Quick Fix on a seeded space with `## PURPOSE` + `## CONSTRAINTS`; confirm patch preserves both headers
- [ ] Seed a contrived finding where the only fix would erase a canonical section; confirm SSE stream emits `status="skipped"` with the LLM's rationale and no config is applied

Closes #88, #89, #90. Scopes down #87 (children #91/#92 plus new bookkeeping tracked under #173 for Workbench 0.1).

This pull request and its description were written by Isaac.