### PR TITLE
Add Feedback sub-tab to AdminDashboard

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -76,6 +76,7 @@ from backend.watch.routers import (
     watch_cost_router,
     watch_dashboards_router,
     watch_evals_router,
+    watch_feedback_router,
     watch_resources_router,
     watch_settings_router,
     watch_spaces_router,
@@ -215,6 +216,7 @@ app.include_router(auto_optimize_router)
 app.include_router(watch_spaces_router)
 app.include_router(watch_cost_router)
 app.include_router(watch_usage_router)
+app.include_router(watch_feedback_router)
 app.include_router(watch_resources_router)
 app.include_router(watch_evals_router)
 app.include_router(watch_settings_router)

--- a/backend/watch/models.py
+++ b/backend/watch/models.py
@@ -172,6 +172,15 @@ class FeedbackTabResponse(BaseModel):
     events: list[FeedbackEvent] = Field(default_factory=list)
 
 
+class FeedbackMessageComment(BaseModel):
+    """A user-typed comment attached to a Genie message. Sourced lazily from
+    the Genie Conversation API when a user expands a feedback event."""
+    message_comment_id: str
+    content: str
+    created_at: datetime
+    user_id: Optional[int] = None
+
+
 # ─── Resources ────────────────────────────────────────────────────────────
 
 

--- a/backend/watch/models.py
+++ b/backend/watch/models.py
@@ -7,7 +7,7 @@ shadow workbench types (e.g. `WatchSpaceSummary` vs workbench's own).
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -96,6 +96,10 @@ class FeedbackEvent(BaseModel):
     comment: Optional[str] = None
     message_id: Optional[str] = None
     conversation_id: Optional[str] = None
+    # Populated by the all-spaces feedback endpoint. Single-space callers
+    # (e.g. /spaces/{id}/feedback) leave these as None.
+    space_id: Optional[str] = None
+    space_title: Optional[str] = None
 
 
 class FeedbackSummary(BaseModel):
@@ -131,6 +135,41 @@ class TopQuery(BaseModel):
     total_duration_ms: Optional[int] = None
     execution_status: Optional[str] = None
     statement_text: Optional[str] = None
+
+
+# ─── Feedback tab (workspace-wide aggregation) ────────────────────────────
+
+
+class FeedbackTabSummary(BaseModel):
+    positive: int = 0
+    negative: int = 0
+    total: int = 0
+    neg_rate_pct: float = 0.0
+
+
+class FeedbackTrendPoint(BaseModel):
+    day: date
+    positive: int = 0
+    negative: int = 0
+
+
+class FeedbackSpaceRow(BaseModel):
+    space_id: str
+    title: Optional[str] = None
+    owner_email: Optional[str] = None
+    positive: int = 0
+    negative: int = 0
+    total: int = 0
+    neg_rate_pct: float = 0.0
+    last_feedback_at: Optional[datetime] = None
+
+
+class FeedbackTabResponse(BaseModel):
+    days: int
+    summary: FeedbackTabSummary
+    trend: list[FeedbackTrendPoint] = Field(default_factory=list)
+    per_space: list[FeedbackSpaceRow] = Field(default_factory=list)
+    events: list[FeedbackEvent] = Field(default_factory=list)
 
 
 # ─── Resources ────────────────────────────────────────────────────────────

--- a/backend/watch/routers/__init__.py
+++ b/backend/watch/routers/__init__.py
@@ -4,6 +4,7 @@ from backend.watch.routers.admin import router as watch_admin_router
 from backend.watch.routers.cost import router as watch_cost_router
 from backend.watch.routers.dashboards import router as watch_dashboards_router
 from backend.watch.routers.evals import router as watch_evals_router
+from backend.watch.routers.feedback import router as watch_feedback_router
 from backend.watch.routers.resources import router as watch_resources_router
 from backend.watch.routers.settings import router as watch_settings_router
 from backend.watch.routers.spaces import router as watch_spaces_router
@@ -14,6 +15,7 @@ __all__ = [
     "watch_cost_router",
     "watch_dashboards_router",
     "watch_evals_router",
+    "watch_feedback_router",
     "watch_resources_router",
     "watch_settings_router",
     "watch_spaces_router",

--- a/backend/watch/routers/feedback.py
+++ b/backend/watch/routers/feedback.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 
@@ -22,11 +23,18 @@ from backend.services import lakebase
 from backend.watch._validators import validate_days
 from backend.watch.models import (
     FeedbackEvent,
+    FeedbackMessageComment,
     FeedbackSpaceRow,
     FeedbackTabResponse,
     FeedbackTabSummary,
     FeedbackTrendPoint,
 )
+
+# Hard cap on number of comments returned per message. The Genie API
+# occasionally returns near-duplicate comments (we've observed the same
+# content recorded with ~ms-apart timestamps); we dedupe in-router but
+# also limit total just in case.
+COMMENTS_MAX_PER_MESSAGE = 20
 from backend.watch.services import genie_client, system_tables
 
 logger = logging.getLogger(__name__)
@@ -184,3 +192,62 @@ async def get_feedback(
         per_space=per_space,
         events=events,
     ).model_dump(mode="json")
+
+
+# 32-char lowercase hex — same shape as validate_space_id, reused here for
+# conversation_id and message_id.
+_HEX_32_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _validate_hex_id(value: str, name: str) -> str:
+    v = (value or "").strip().lower()
+    if not _HEX_32_RE.match(v):
+        from fastapi import HTTPException
+        raise HTTPException(status_code=400, detail=f"Invalid {name}: {value!r}")
+    return v
+
+
+@router.get("/feedback/comments")
+async def get_feedback_comments(
+    space_id: str = Query(...),
+    conversation_id: str = Query(...),
+    message_id: str = Query(...),
+) -> list[dict]:
+    """Lazy fetch of user-typed comments for a single Genie message.
+
+    Called when a user expands an event card in the Feedback tab.
+    Returns deduplicated, non-empty comments sorted oldest-first.
+    """
+    sid = _validate_hex_id(space_id, "space_id")
+    cid = _validate_hex_id(conversation_id, "conversation_id")
+    mid = _validate_hex_id(message_id, "message_id")
+
+    raw = await asyncio.to_thread(
+        _safe, genie_client.list_message_comments, sid, cid, mid
+    )
+
+    seen_content: set[str] = set()
+    out: list[FeedbackMessageComment] = []
+    for c in raw:
+        if len(out) >= COMMENTS_MAX_PER_MESSAGE:
+            break
+        content = (c.get("content") or "").strip()
+        if not content or content in seen_content:
+            continue
+        seen_content.add(content)
+        ts = c.get("created_timestamp")
+        if ts:
+            try:
+                created_at = datetime.fromtimestamp(int(ts) / 1000, tz=timezone.utc)
+            except (TypeError, ValueError):
+                created_at = datetime.now(tz=timezone.utc)
+        else:
+            created_at = datetime.now(tz=timezone.utc)
+        out.append(FeedbackMessageComment(
+            message_comment_id=c.get("message_comment_id") or "",
+            content=content,
+            created_at=created_at,
+            user_id=c.get("user_id"),
+        ))
+    out.sort(key=lambda c: c.created_at)
+    return [c.model_dump(mode="json") for c in out]

--- a/backend/watch/routers/feedback.py
+++ b/backend/watch/routers/feedback.py
@@ -1,0 +1,186 @@
+"""Watch feedback router: workspace-wide feedback aggregation.
+
+Returns a bundled response (summary + daily trend + per-space rollup + event
+feed) read from `system.access.audit`. Workspace boundary is enforced by
+intersecting audit results with the spaces visible to the app SP in this
+workspace (same pattern as backend.watch.routers.spaces.list_spaces).
+The daily trend is derived from the workspace-filtered event feed, so it
+inherits the same boundary; for very high-volume windows it may undercount
+older days. The summary is always accurate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+
+from fastapi import APIRouter, Query
+
+from backend.services import lakebase
+from backend.watch._validators import validate_days
+from backend.watch.models import (
+    FeedbackEvent,
+    FeedbackSpaceRow,
+    FeedbackTabResponse,
+    FeedbackTabSummary,
+    FeedbackTrendPoint,
+)
+from backend.watch.services import genie_client, system_tables
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/watch")
+
+
+def _safe(fn, *args, **kwargs):
+    try:
+        return fn(*args, **kwargs)
+    except Exception as e:
+        logger.warning("%s failed: %s", fn.__name__, e)
+        return []
+
+
+def _coerce_date(value) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).date()
+    except Exception:
+        return None
+
+
+@router.get("/feedback")
+async def get_feedback(
+    days: int = Query(7, ge=1, le=365),
+    limit: int = Query(500, ge=1, le=2000),
+) -> dict:
+    days = validate_days(days, default=7)
+
+    # Workspace boundary: live Genie listing with Lakebase fallback.
+    spaces = await asyncio.to_thread(_safe, genie_client.list_genie_spaces)
+    if not spaces:
+        spaces = await lakebase.watch_list_cached_spaces() or []
+
+    visible: dict[str, dict] = {}
+    for s in spaces:
+        sid = s.get("id") or s.get("space_id")
+        if sid:
+            visible[sid] = s
+
+    if not visible:
+        return FeedbackTabResponse(
+            days=days,
+            summary=FeedbackTabSummary(),
+            trend=[],
+            per_space=[],
+            events=[],
+        ).model_dump(mode="json")
+
+    # Two parallel system-table queries — each result is TTL-cached for 5 min.
+    # Trend is derived from event_rows below so it inherits the workspace filter.
+    per_space_rows, event_rows = await asyncio.gather(
+        asyncio.to_thread(_safe, system_tables.feedback_summary_all_spaces, days=days),
+        asyncio.to_thread(_safe, system_tables.feedback_events_all_spaces, days=days, limit=limit),
+    )
+
+    # Intersect with visible-spaces set (workspace boundary).
+    per_space_rows = [r for r in per_space_rows if r.get("space_id") in visible]
+    event_rows = [r for r in event_rows if r.get("space_id") in visible]
+
+    # Compute last_feedback_at per space from the (already newest-first) event feed.
+    last_seen: dict[str, datetime] = {}
+    for e in event_rows:
+        sid = e.get("space_id")
+        et = e.get("event_time")
+        if sid and et and (sid not in last_seen or et > last_seen[sid]):
+            last_seen[sid] = et
+
+    # Build per_space rows (only spaces with feedback in the window).
+    per_space: list[FeedbackSpaceRow] = []
+    for r in per_space_rows:
+        sid = r["space_id"]
+        live = visible.get(sid) or {}
+        pos = int(r.get("pos") or 0)
+        neg = int(r.get("neg") or 0)
+        total = int(r.get("total") or 0)
+        if total == 0:
+            continue
+        neg_rate = (neg / total) * 100.0 if total else 0.0
+        per_space.append(FeedbackSpaceRow(
+            space_id=sid,
+            title=live.get("display_name") or live.get("title"),
+            owner_email=(live.get("creator") or {}).get("user_name") or live.get("owner_email"),
+            positive=pos,
+            negative=neg,
+            total=total,
+            neg_rate_pct=round(neg_rate, 1),
+            last_feedback_at=last_seen.get(sid),
+        ))
+    per_space.sort(key=lambda r: (r.negative, r.total), reverse=True)
+
+    # Trend: derived from the (workspace-filtered) event_rows so the trend
+    # respects the workspace boundary. Fill missing days with zeros.
+    # Note: capped at `limit` events; for very high-volume windows the trend
+    # may undercount older days. The summary (from per_space_rows) is always
+    # accurate.
+    daily_map: dict[date, dict[str, int]] = defaultdict(lambda: {"pos": 0, "neg": 0})
+    for e in event_rows:
+        day_val = _coerce_date(e.get("event_time"))
+        if day_val is None:
+            continue
+        rating = (e.get("rating") or "").upper()
+        if rating == "POSITIVE":
+            daily_map[day_val]["pos"] += 1
+        elif rating == "NEGATIVE":
+            daily_map[day_val]["neg"] += 1
+    today = datetime.now(timezone.utc).date()
+    trend: list[FeedbackTrendPoint] = []
+    for i in range(days, 0, -1):
+        d = today - timedelta(days=i - 1)
+        v = daily_map.get(d, {"pos": 0, "neg": 0})
+        trend.append(FeedbackTrendPoint(day=d, positive=v["pos"], negative=v["neg"]))
+
+    # Summary computed from the workspace-filtered per_space rows
+    # (NOT daily_rows, which are metastore-wide before filtering).
+    total_pos = sum(r.positive for r in per_space)
+    total_neg = sum(r.negative for r in per_space)
+    total = total_pos + total_neg
+    neg_rate = (total_neg / total) * 100.0 if total else 0.0
+    summary = FeedbackTabSummary(
+        positive=total_pos,
+        negative=total_neg,
+        total=total,
+        neg_rate_pct=round(neg_rate, 1),
+    )
+
+    # Enrich event rows with space title.
+    events: list[FeedbackEvent] = []
+    for e in event_rows:
+        et = e.get("event_time")
+        if et is None:
+            continue
+        sid = e.get("space_id")
+        live = visible.get(sid) or {}
+        events.append(FeedbackEvent(
+            event_time=et,
+            user_email=e.get("user_email"),
+            rating=e.get("rating"),
+            comment=e.get("comment"),
+            message_id=e.get("message_id"),
+            conversation_id=e.get("conversation_id"),
+            space_id=sid,
+            space_title=live.get("display_name") or live.get("title"),
+        ))
+
+    return FeedbackTabResponse(
+        days=days,
+        summary=summary,
+        trend=trend,
+        per_space=per_space,
+        events=events,
+    ).model_dump(mode="json")

--- a/backend/watch/services/genie_client.py
+++ b/backend/watch/services/genie_client.py
@@ -201,3 +201,33 @@ def list_space_permissions(genie_space_id: str) -> dict:
                     path=f"/api/2.0/permissions/genie/{genie_space_id}",
                 )
         raise
+
+
+def list_message_comments(
+    space_id: str, conversation_id: str, message_id: str
+) -> list[dict]:
+    """Fetch user-typed comments attached to a Genie message.
+
+    Used by the Feedback tab to surface free-text feedback that audit logs
+    don't carry (audit only logs IDs, not content). Returns the raw
+    `comments` array from the Genie API; the router dedupes / filters empty
+    content / sorts.
+    """
+    if not (space_id and conversation_id and message_id):
+        raise ValueError("space_id, conversation_id, and message_id are required")
+    path = (
+        f"/api/2.0/genie/spaces/{space_id}"
+        f"/conversations/{conversation_id}"
+        f"/messages/{message_id}/comments"
+    )
+    client = get_workspace_client()
+    try:
+        resp = client.api_client.do(method="GET", path=path)
+        return resp.get("comments", []) or []
+    except Exception as e:
+        if _is_scope_error(e):
+            sp = get_service_principal_client()
+            if sp is not client:
+                resp = sp.api_client.do(method="GET", path=path)
+                return resp.get("comments", []) or []
+        raise

--- a/backend/watch/services/system_tables.py
+++ b/backend/watch/services/system_tables.py
@@ -440,12 +440,21 @@ def top_expensive_queries(space_id: str, days: int = 7, limit: int = 20) -> list
 
 
 # ─── Feedback ─────────────────────────────────────────────────────────────
+#
+# The audit log stores `feedback_rating` as 'THUMBS_UP' / 'THUMBS_DOWN'.
+# All feedback queries normalize these to 'POSITIVE' / 'NEGATIVE' so callers
+# (routers, summary aggregations, frontend filters) can use a single
+# canonical vocabulary.
 
 _FEEDBACK_PER_SPACE_SQL = """
 SELECT event_time,
        user_identity.email AS user_email,
        request_params.space_id AS space_id,
-       request_params.feedback_rating AS rating,
+       CASE
+         WHEN request_params.feedback_rating = 'THUMBS_UP'   THEN 'POSITIVE'
+         WHEN request_params.feedback_rating = 'THUMBS_DOWN' THEN 'NEGATIVE'
+         ELSE request_params.feedback_rating
+       END AS rating,
        request_params.comment AS comment,
        request_params.message_id AS message_id,
        request_params.conversation_id AS conversation_id
@@ -469,8 +478,8 @@ def feedback_per_space(space_id: str, days: int = 30, limit: int = 200) -> list[
 
 _FEEDBACK_SUMMARY_SQL = """
 SELECT request_params.space_id AS space_id,
-       SUM(CASE WHEN request_params.feedback_rating = 'POSITIVE' THEN 1 ELSE 0 END) AS pos,
-       SUM(CASE WHEN request_params.feedback_rating = 'NEGATIVE' THEN 1 ELSE 0 END) AS neg,
+       SUM(CASE WHEN request_params.feedback_rating = 'THUMBS_UP'   THEN 1 ELSE 0 END) AS pos,
+       SUM(CASE WHEN request_params.feedback_rating = 'THUMBS_DOWN' THEN 1 ELSE 0 END) AS neg,
        COUNT(*) AS total
 FROM system.access.audit
 WHERE service_name = 'aibiGenie'
@@ -489,7 +498,11 @@ _FEEDBACK_EVENTS_ALL_SQL = """
 SELECT event_time,
        user_identity.email AS user_email,
        request_params.space_id AS space_id,
-       request_params.feedback_rating AS rating,
+       CASE
+         WHEN request_params.feedback_rating = 'THUMBS_UP'   THEN 'POSITIVE'
+         WHEN request_params.feedback_rating = 'THUMBS_DOWN' THEN 'NEGATIVE'
+         ELSE request_params.feedback_rating
+       END AS rating,
        request_params.comment AS comment,
        request_params.message_id AS message_id,
        request_params.conversation_id AS conversation_id

--- a/backend/watch/services/system_tables.py
+++ b/backend/watch/services/system_tables.py
@@ -475,6 +475,7 @@ SELECT request_params.space_id AS space_id,
 FROM system.access.audit
 WHERE service_name = 'aibiGenie'
   AND action_name = 'updateConversationMessageFeedback'
+  AND request_params.feedback_rating IS NOT NULL
   AND event_time >= current_date() - :days
 GROUP BY 1
 """
@@ -482,6 +483,33 @@ GROUP BY 1
 
 def feedback_summary_all_spaces(days: int = 7) -> list[dict[str, Any]]:
     return _run(_FEEDBACK_SUMMARY_SQL, [_p("days", days, "INT")])
+
+
+_FEEDBACK_EVENTS_ALL_SQL = """
+SELECT event_time,
+       user_identity.email AS user_email,
+       request_params.space_id AS space_id,
+       request_params.feedback_rating AS rating,
+       request_params.comment AS comment,
+       request_params.message_id AS message_id,
+       request_params.conversation_id AS conversation_id
+FROM system.access.audit
+WHERE service_name = 'aibiGenie'
+  AND action_name = 'updateConversationMessageFeedback'
+  AND request_params.space_id IS NOT NULL
+  AND request_params.feedback_rating IS NOT NULL
+  AND event_time >= current_date() - :days
+ORDER BY event_time DESC
+LIMIT :limit
+"""
+
+
+def feedback_events_all_spaces(days: int = 7, limit: int = 500) -> list[dict[str, Any]]:
+    return _run(_FEEDBACK_EVENTS_ALL_SQL, [
+        _p("days", days, "INT"),
+        _p("limit", limit, "INT"),
+    ])
+
 
 
 # ─── Lineage / executed resources ─────────────────────────────────────────

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -5,7 +5,7 @@
 import { Suspense, lazy, useEffect, useState } from "react"
 import {
   TrendingUp, TrendingDown, AlertTriangle, Award, BarChart2, RefreshCw,
-  LayoutGrid, DollarSign, Database, Settings as SettingsIcon,
+  LayoutGrid, DollarSign, Database, Settings as SettingsIcon, MessageSquare,
 } from "lucide-react"
 import { getAdminDashboard, getLeaderboard, getAlerts } from "@/lib/api"
 import { getScoreColor, MATURITY_COLORS } from "@/lib/utils"
@@ -23,8 +23,10 @@ const WatchResourceRollup = lazy(() =>
   import("@/watch/pages/ResourceRollup").then(m => ({ default: m.ResourceRollup })))
 const WatchSettings = lazy(() =>
   import("@/watch/pages/Settings").then(m => ({ default: m.Settings })))
+const WatchFeedback = lazy(() =>
+  import("@/watch/pages/Feedback").then(m => ({ default: m.Feedback })))
 
-type AdminSubTab = "overview" | "spaces" | "cost" | "resources" | "settings"
+type AdminSubTab = "overview" | "spaces" | "cost" | "feedback" | "resources" | "settings"
 
 interface AdminDashboardProps {
   onSelectSpace?: (spaceId: string, displayName: string) => void
@@ -52,6 +54,7 @@ const SUB_TABS: { id: AdminSubTab; label: string; icon: React.ReactNode }[] = [
   { id: "overview",  label: "Overview",  icon: <BarChart2 className="w-4 h-4" /> },
   { id: "spaces",    label: "Spaces",    icon: <LayoutGrid className="w-4 h-4" /> },
   { id: "cost",      label: "Cost",      icon: <DollarSign className="w-4 h-4" /> },
+  { id: "feedback",  label: "Feedback",  icon: <MessageSquare className="w-4 h-4" /> },
   { id: "resources", label: "Resources", icon: <Database className="w-4 h-4" /> },
   { id: "settings",  label: "Settings",  icon: <SettingsIcon className="w-4 h-4" /> },
 ]
@@ -285,6 +288,12 @@ export function AdminDashboard({ onSelectSpace, initialSubTab }: AdminDashboardP
       {subTab === "cost" && (
         <Suspense fallback={<SubTabFallback />}>
           <WatchCostExplorer onOpenSpace={(sid) => { setSubTab("spaces"); setWatchDrillId(sid) }} />
+        </Suspense>
+      )}
+
+      {subTab === "feedback" && (
+        <Suspense fallback={<SubTabFallback />}>
+          <WatchFeedback onOpenSpace={(sid) => { setSubTab("spaces"); setWatchDrillId(sid) }} />
         </Suspense>
       )}
 

--- a/frontend/src/watch/components/LoadingCard.tsx
+++ b/frontend/src/watch/components/LoadingCard.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+import { Card } from '@/components/ui/card'
+
+export function LoadingCard() {
+  const [elapsed, setElapsed] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => setElapsed(e => e + 1), 1000)
+    return () => clearInterval(id)
+  }, [])
+  return (
+    <Card className="p-6 text-center">
+      <p className="font-medium">Loading… ({elapsed}s)</p>
+      <p className="mt-2 text-xs text-muted">
+        First load runs a fresh system-table query (typically 30–60s on a busy warehouse).
+        Subsequent visits within 5 min are cached and load instantly.
+      </p>
+    </Card>
+  )
+}

--- a/frontend/src/watch/components/SimpleBars.tsx
+++ b/frontend/src/watch/components/SimpleBars.tsx
@@ -1,0 +1,30 @@
+export function SimpleBars({
+  data,
+  formatY,
+  colorClass = 'bg-blue-500',
+}: {
+  data: { x: string; y: number }[]
+  formatY?: (v: number) => string
+  colorClass?: string
+}) {
+  const max = Math.max(1, ...data.map(d => d.y))
+  return (
+    <div className="space-y-1">
+      {data.map((d, i) => (
+        <div key={i} className="flex items-center gap-2 text-xs">
+          <span className="w-16 shrink-0 text-muted">{d.x}</span>
+          <div className="h-3 flex-1 rounded bg-elevated">
+            <div
+              className={`h-3 rounded ${colorClass}`}
+              style={{ width: `${(d.y / max) * 100}%` }}
+            />
+          </div>
+          <span className="w-16 shrink-0 text-right tabular-nums">
+            {formatY ? formatY(d.y) : d.y.toLocaleString()}
+          </span>
+        </div>
+      ))}
+      {!data.length && <p className="text-xs text-muted">No data.</p>}
+    </div>
+  )
+}

--- a/frontend/src/watch/components/Stat.tsx
+++ b/frontend/src/watch/components/Stat.tsx
@@ -1,0 +1,10 @@
+import { Card } from '@/components/ui/card'
+
+export function Stat({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <Card className="p-4">
+      <p className="text-xs uppercase text-muted">{label}</p>
+      <p className="mt-1 text-2xl font-semibold">{value}</p>
+    </Card>
+  )
+}

--- a/frontend/src/watch/lib/api.ts
+++ b/frontend/src/watch/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   EvalRun,
   EvalSummary,
   FeedbackEvent,
+  FeedbackMessageComment,
   FeedbackTabResponse,
   HealthStatus,
   ResourceGraph,
@@ -110,6 +111,17 @@ export const getSpaceFeedback = (spaceId: string, days = 30, limit = 200) =>
 
 export const getFeedback = (days = 7, limit = 500) =>
   fetchJson<FeedbackTabResponse>(`/feedback?days=${days}&limit=${limit}`)
+
+export const getFeedbackComments = (
+  spaceId: string,
+  conversationId: string,
+  messageId: string,
+) =>
+  fetchJson<FeedbackMessageComment[]>(
+    `/feedback/comments?space_id=${encodeURIComponent(spaceId)}` +
+      `&conversation_id=${encodeURIComponent(conversationId)}` +
+      `&message_id=${encodeURIComponent(messageId)}`,
+  )
 
 // ── Resources ───────────────────────────────────────────────────────────────
 

--- a/frontend/src/watch/lib/api.ts
+++ b/frontend/src/watch/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   EvalRun,
   EvalSummary,
   FeedbackEvent,
+  FeedbackTabResponse,
   HealthStatus,
   ResourceGraph,
   ResourceRollupItem,
@@ -106,6 +107,9 @@ export const getSpaceFeedback = (spaceId: string, days = 30, limit = 200) =>
   fetchJson<FeedbackEvent[]>(
     `/spaces/${spaceId}/feedback?days=${days}&limit=${limit}`,
   )
+
+export const getFeedback = (days = 7, limit = 500) =>
+  fetchJson<FeedbackTabResponse>(`/feedback?days=${days}&limit=${limit}`)
 
 // ── Resources ───────────────────────────────────────────────────────────────
 

--- a/frontend/src/watch/pages/Feedback.tsx
+++ b/frontend/src/watch/pages/Feedback.tsx
@@ -1,0 +1,376 @@
+import { useMemo, useState } from 'react'
+import {
+  AlertCircle, ChevronDown, ChevronUp, ExternalLink, ThumbsDown, ThumbsUp,
+} from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
+import { LoadingCard } from '@/watch/components/LoadingCard'
+import { SimpleBars } from '@/watch/components/SimpleBars'
+import { Stat } from '@/watch/components/Stat'
+import { useCachedFetch } from '@/watch/lib/cache'
+import { formatDate, formatDay, formatInt } from '@/watch/lib/format'
+import { genieSpaceUrl } from '@/watch/lib/genie'
+import * as api from '@/watch/lib/api'
+import type { FeedbackTabResponse, HealthStatus } from '@/watch/types/api'
+
+interface Props {
+  onOpenSpace: (spaceId: string) => void
+}
+
+type SortKey =
+  | 'negative'
+  | 'positive'
+  | 'total'
+  | 'neg_rate_pct'
+  | 'last_feedback_at'
+type RatingFilter = 'all' | 'POSITIVE' | 'NEGATIVE'
+
+export function Feedback({ onOpenSpace }: Props) {
+  const [days, setDays] = useState<7 | 30 | 90>(7)
+  const [ratingFilter, setRatingFilter] = useState<RatingFilter>('all')
+  const [spaceFilter, setSpaceFilter] = useState<string | null>(null)
+  const [sortKey, setSortKey] = useState<SortKey>('negative')
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
+  const [expandedKey, setExpandedKey] = useState<string | null>(null)
+
+  const { data, error } = useCachedFetch<FeedbackTabResponse>(
+    `feedback:${days}`,
+    () => api.getFeedback(days),
+    [days],
+  )
+  const { data: health } = useCachedFetch<HealthStatus>('health', () => api.getHealth())
+
+  const sortedRollup = useMemo(() => {
+    if (!data) return null
+    const dir = sortDir === 'asc' ? 1 : -1
+    return [...data.per_space].sort((a, b) => {
+      switch (sortKey) {
+        case 'negative':
+          return (a.negative - b.negative) * dir
+        case 'positive':
+          return (a.positive - b.positive) * dir
+        case 'total':
+          return (a.total - b.total) * dir
+        case 'neg_rate_pct':
+          return (a.neg_rate_pct - b.neg_rate_pct) * dir
+        case 'last_feedback_at': {
+          const av = a.last_feedback_at ? new Date(a.last_feedback_at).getTime() : 0
+          const bv = b.last_feedback_at ? new Date(b.last_feedback_at).getTime() : 0
+          return (av - bv) * dir
+        }
+      }
+    })
+  }, [data, sortKey, sortDir])
+
+  const filteredEvents = useMemo(() => {
+    if (!data) return null
+    return data.events.filter(e => {
+      if (ratingFilter !== 'all' && (e.rating || '').toUpperCase() !== ratingFilter) return false
+      if (spaceFilter && e.space_id !== spaceFilter) return false
+      return true
+    })
+  }, [data, ratingFilter, spaceFilter])
+
+  function toggleSort(k: SortKey) {
+    if (k === sortKey) setSortDir(d => (d === 'asc' ? 'desc' : 'asc'))
+    else {
+      setSortKey(k)
+      setSortDir('desc')
+    }
+  }
+
+  if (error) {
+    return (
+      <Card className="border-red-500/30 bg-red-500/10 p-3 text-sm text-red-400">
+        {error}
+      </Card>
+    )
+  }
+  if (!data) return <LoadingCard />
+
+  const hasFeedback = data.summary.total > 0
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Feedback</h1>
+          <p className="text-sm text-muted">
+            Workspace-wide thumbs up/down on Genie Space responses.
+          </p>
+        </div>
+        <select
+          value={days}
+          onChange={e => { setDays(Number(e.target.value) as 7 | 30 | 90); setSpaceFilter(null) }}
+          className="rounded border border-default bg-elevated px-2 py-1 text-sm"
+        >
+          <option value={7}>last 7 days</option>
+          <option value={30}>last 30 days</option>
+          <option value={90}>last 90 days</option>
+        </select>
+      </div>
+
+      {!hasFeedback && (
+        <Card className="p-6 text-center">
+          <p className="font-medium">No feedback recorded in the last {data.days} days.</p>
+          <p className="mt-2 text-xs text-muted">
+            Feedback appears here after end users react to Genie responses with thumbs up or
+            thumbs down. Audit events lag up to 4 hours.
+          </p>
+        </Card>
+      )}
+
+      {hasFeedback && (
+        <>
+          <Card className="border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-400">
+            <AlertCircle className="mr-1 inline" size={14} />
+            Feedback events appear with up to 4 hours of audit-log latency.
+          </Card>
+
+          <div className="grid gap-3 sm:grid-cols-4">
+            <Stat label={`Total (${data.days}d)`} value={formatInt(data.summary.total)} />
+            <Stat
+              label="Positive"
+              value={<span className="text-emerald-400">{formatInt(data.summary.positive)}</span>}
+            />
+            <Stat
+              label="Negative"
+              value={<span className="text-red-400">{formatInt(data.summary.negative)}</span>}
+            />
+            <Stat label="Negative rate" value={`${data.summary.neg_rate_pct.toFixed(1)}%`} />
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            <Card className="p-4">
+              <h3 className="mb-2 text-sm font-medium uppercase text-muted">Daily positive</h3>
+              <SimpleBars
+                data={data.trend.map(p => ({ x: formatDay(p.day), y: p.positive }))}
+                colorClass="bg-emerald-500"
+              />
+            </Card>
+            <Card className="p-4">
+              <h3 className="mb-2 text-sm font-medium uppercase text-muted">Daily negative</h3>
+              <SimpleBars
+                data={data.trend.map(p => ({ x: formatDay(p.day), y: p.negative }))}
+                colorClass="bg-red-500"
+              />
+            </Card>
+          </div>
+
+          <Card className="overflow-hidden p-0">
+            <div className="border-b border-default px-4 py-3">
+              <h3 className="text-sm font-medium uppercase text-muted">By space</h3>
+            </div>
+            <table className="w-full text-sm">
+              <thead className="border-b border-default bg-elevated text-left text-xs uppercase text-muted">
+                <tr>
+                  <th className="px-4 py-2">Space</th>
+                  <th className="px-4 py-2">Owner</th>
+                  <Th onClick={() => toggleSort('positive')} active={sortKey === 'positive'} dir={sortDir}>Positive</Th>
+                  <Th onClick={() => toggleSort('negative')} active={sortKey === 'negative'} dir={sortDir}>Negative</Th>
+                  <Th onClick={() => toggleSort('total')} active={sortKey === 'total'} dir={sortDir}>Total</Th>
+                  <Th onClick={() => toggleSort('neg_rate_pct')} active={sortKey === 'neg_rate_pct'} dir={sortDir}>Neg %</Th>
+                  <Th onClick={() => toggleSort('last_feedback_at')} active={sortKey === 'last_feedback_at'} dir={sortDir}>Last</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedRollup?.map(r => (
+                  <tr
+                    key={r.space_id}
+                    tabIndex={0}
+                    role="button"
+                    className="cursor-pointer border-t border-default/50 hover:bg-elevated/50 focus:bg-elevated/50 focus:outline-none"
+                    onClick={() => onOpenSpace(r.space_id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        onOpenSpace(r.space_id)
+                      }
+                    }}
+                  >
+                    <td className="px-4 py-2">
+                      <div className="text-sm font-medium">{r.title || '(untitled)'}</div>
+                      <div className="font-mono text-xs text-muted">{r.space_id}</div>
+                    </td>
+                    <td className="px-4 py-2 text-muted">{r.owner_email || '—'}</td>
+                    <td className="px-4 py-2 tabular-nums text-emerald-400">{formatInt(r.positive)}</td>
+                    <td className="px-4 py-2 tabular-nums text-red-400">{formatInt(r.negative)}</td>
+                    <td className="px-4 py-2 tabular-nums">{formatInt(r.total)}</td>
+                    <td className="px-4 py-2 tabular-nums">{r.neg_rate_pct.toFixed(1)}%</td>
+                    <td className="px-4 py-2 text-muted">{formatDate(r.last_feedback_at)}</td>
+                  </tr>
+                ))}
+                {sortedRollup && sortedRollup.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="p-6 text-center text-muted">
+                      No spaces with feedback in this window.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </Card>
+
+          <Card className="p-4">
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+              <h3 className="text-sm font-medium uppercase text-muted">Recent feedback</h3>
+              <div className="flex flex-wrap items-center gap-2">
+                <RatingButton current={ratingFilter} value="all" onClick={setRatingFilter}>
+                  All
+                </RatingButton>
+                <RatingButton current={ratingFilter} value="POSITIVE" onClick={setRatingFilter}>
+                  <ThumbsUp size={12} /> Positive
+                </RatingButton>
+                <RatingButton current={ratingFilter} value="NEGATIVE" onClick={setRatingFilter}>
+                  <ThumbsDown size={12} /> Negative
+                </RatingButton>
+                <select
+                  value={spaceFilter ?? ''}
+                  onChange={e => setSpaceFilter(e.target.value || null)}
+                  className="rounded border border-default bg-elevated px-2 py-1 text-xs"
+                >
+                  <option value="">All spaces</option>
+                  {data.per_space.map(s => (
+                    <option key={s.space_id} value={s.space_id}>
+                      {s.title || s.space_id.slice(0, 12)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <ul className="space-y-2">
+              {filteredEvents?.map((e, i) => {
+                const key = `${e.space_id ?? ''}|${e.message_id ?? e.event_time}|${i}`
+                const expanded = expandedKey === key
+                const isPositive = (e.rating || '').toUpperCase() === 'POSITIVE'
+                return (
+                  <li key={key} className="rounded border border-default">
+                    <button
+                      type="button"
+                      aria-expanded={expanded}
+                      className="flex w-full items-start gap-3 p-3 text-left hover:bg-elevated/30"
+                      onClick={() => setExpandedKey(expanded ? null : key)}
+                    >
+                      <Badge
+                        className={
+                          isPositive
+                            ? 'border-emerald-500/30 bg-emerald-500/20 text-emerald-400'
+                            : 'border-red-500/30 bg-red-500/20 text-red-400'
+                        }
+                      >
+                        {isPositive ? <ThumbsUp size={12} /> : <ThumbsDown size={12} />}
+                      </Badge>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center justify-between text-xs">
+                          <span className="truncate">
+                            <span className="font-medium">
+                              {e.space_title || e.space_id?.slice(0, 12) || '?'}
+                            </span>
+                            <span className="ml-2 text-muted">
+                              {e.user_email || 'unknown user'}
+                            </span>
+                          </span>
+                          <span className="ml-2 shrink-0 text-muted">{formatDate(e.event_time)}</span>
+                        </div>
+                        {e.comment && (
+                          <p className="mt-1 text-sm text-muted">
+                            {expanded
+                              ? e.comment
+                              : e.comment.slice(0, 120) + (e.comment.length > 120 ? '…' : '')}
+                          </p>
+                        )}
+                      </div>
+                      {expanded ? (
+                        <ChevronUp size={16} className="text-muted" />
+                      ) : (
+                        <ChevronDown size={16} className="text-muted" />
+                      )}
+                    </button>
+                    {expanded && (
+                      <div className="border-t border-default px-3 py-2 text-xs">
+                        <div className="grid gap-1 sm:grid-cols-2">
+                          <div>
+                            <span className="text-muted">message_id:</span>{' '}
+                            <code className="font-mono">{e.message_id || '—'}</code>
+                          </div>
+                          <div>
+                            <span className="text-muted">conversation_id:</span>{' '}
+                            <code className="font-mono">{e.conversation_id || '—'}</code>
+                          </div>
+                        </div>
+                        {e.space_id && (
+                          <a
+                            href={genieSpaceUrl(e.space_id, health?.workspace_host ?? null)}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="mt-2 inline-flex items-center gap-1 text-xs text-accent hover:underline"
+                          >
+                            <ExternalLink size={12} /> Open in Databricks
+                          </a>
+                        )}
+                      </div>
+                    )}
+                  </li>
+                )
+              })}
+              {filteredEvents && filteredEvents.length === 0 && (
+                <li className="p-6 text-center text-muted">No events match these filters.</li>
+              )}
+            </ul>
+          </Card>
+        </>
+      )}
+    </div>
+  )
+}
+
+function Th({
+  children, onClick, active, dir, align = 'left',
+}: {
+  children: React.ReactNode
+  onClick?: () => void
+  active?: boolean
+  dir?: 'asc' | 'desc'
+  align?: 'left' | 'right'
+}) {
+  return (
+    <th
+      className={`px-4 py-2 ${onClick ? 'cursor-pointer select-none hover:text-fg' : ''} ${
+        align === 'right' ? 'text-right' : ''
+      }`}
+      onClick={onClick}
+    >
+      {children}
+      {active ? <span className="ml-1">{dir === 'asc' ? '▲' : '▼'}</span> : null}
+    </th>
+  )
+}
+
+function RatingButton({
+  current,
+  value,
+  onClick,
+  children,
+}: {
+  current: RatingFilter
+  value: RatingFilter
+  onClick: (v: RatingFilter) => void
+  children: React.ReactNode
+}) {
+  const active = current === value
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(value)}
+      className={`flex items-center gap-1 rounded border px-2 py-1 text-xs ${
+        active
+          ? 'border-accent bg-accent/10 text-accent'
+          : 'border-default bg-elevated text-muted hover:text-fg'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/watch/pages/Feedback.tsx
+++ b/frontend/src/watch/pages/Feedback.tsx
@@ -1,18 +1,22 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
-  AlertCircle, ChevronDown, ChevronUp, ExternalLink, ThumbsDown, ThumbsUp,
+  AlertCircle, ChevronDown, ChevronUp, ExternalLink, Loader2, ThumbsDown, ThumbsUp, X,
 } from 'lucide-react'
 
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
 import { LoadingCard } from '@/watch/components/LoadingCard'
-import { SimpleBars } from '@/watch/components/SimpleBars'
 import { Stat } from '@/watch/components/Stat'
-import { useCachedFetch } from '@/watch/lib/cache'
-import { formatDate, formatDay, formatInt } from '@/watch/lib/format'
+import { getCached, putCached, useCachedFetch } from '@/watch/lib/cache'
+import { formatDate, formatInt } from '@/watch/lib/format'
 import { genieSpaceUrl } from '@/watch/lib/genie'
 import * as api from '@/watch/lib/api'
-import type { FeedbackTabResponse, HealthStatus } from '@/watch/types/api'
+import type {
+  FeedbackMessageComment,
+  FeedbackSpaceRow,
+  FeedbackTabResponse,
+  HealthStatus,
+} from '@/watch/types/api'
 
 interface Props {
   onOpenSpace: (spaceId: string) => void
@@ -33,8 +37,25 @@ export function Feedback({ onOpenSpace }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>('negative')
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
   const [expandedKey, setExpandedKey] = useState<string | null>(null)
+  const eventsRef = useRef<HTMLDivElement>(null)
 
-  const { data, error } = useCachedFetch<FeedbackTabResponse>(
+  // Set the space filter (event feed narrows). On stacked layouts (below the
+  // lg breakpoint where the events section sits below the rollup), smooth-
+  // scroll the events into view. On lg+ side-by-side layouts the section is
+  // already next to the rollup, so no scroll is needed and any scroll feels
+  // like jitter.
+  function selectSpace(spaceId: string) {
+    setSpaceFilter(spaceId)
+    const sideBySide =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(min-width: 1024px)').matches
+    if (sideBySide) return
+    setTimeout(() => {
+      eventsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }, 50)
+  }
+
+  const { data, error, loading } = useCachedFetch<FeedbackTabResponse>(
     `feedback:${days}`,
     () => api.getFeedback(days),
     [days],
@@ -72,6 +93,26 @@ export function Feedback({ onOpenSpace }: Props) {
     })
   }, [data, ratingFilter, spaceFilter])
 
+  // Twin headline charts: top 10 spaces by raw positive count and by raw
+  // negative count within the selected time window. Bar length is the count
+  // (normalized to the chart's max), so visualizations are volume-agnostic —
+  // a low-feedback workspace gets short bars but the structure still reads.
+  const topByPositive = useMemo(() => {
+    if (!data) return []
+    return [...data.per_space]
+      .filter(s => s.positive > 0)
+      .sort((a, b) => b.positive - a.positive)
+      .slice(0, 10)
+  }, [data])
+
+  const topByNegative = useMemo(() => {
+    if (!data) return []
+    return [...data.per_space]
+      .filter(s => s.negative > 0)
+      .sort((a, b) => b.negative - a.negative)
+      .slice(0, 10)
+  }, [data])
+
   function toggleSort(k: SortKey) {
     if (k === sortKey) setSortDir(d => (d === 'asc' ? 'desc' : 'asc'))
     else {
@@ -100,15 +141,23 @@ export function Feedback({ onOpenSpace }: Props) {
             Workspace-wide thumbs up/down on Genie Space responses.
           </p>
         </div>
-        <select
-          value={days}
-          onChange={e => { setDays(Number(e.target.value) as 7 | 30 | 90); setSpaceFilter(null) }}
-          className="rounded border border-default bg-elevated px-2 py-1 text-sm"
-        >
-          <option value={7}>last 7 days</option>
-          <option value={30}>last 30 days</option>
-          <option value={90}>last 90 days</option>
-        </select>
+        <div className="flex items-center gap-2">
+          {loading && data && (
+            <span className="flex items-center gap-1 text-xs text-muted">
+              <Loader2 size={12} className="animate-spin" />
+              Refreshing…
+            </span>
+          )}
+          <select
+            value={days}
+            onChange={e => { setDays(Number(e.target.value) as 7 | 30 | 90); setSpaceFilter(null) }}
+            className="rounded border border-default bg-elevated px-2 py-1 text-sm"
+          >
+            <option value={7}>last 7 days</option>
+            <option value={30}>last 30 days</option>
+            <option value={90}>last 90 days</option>
+          </select>
+        </div>
       </div>
 
       {!hasFeedback && (
@@ -142,68 +191,96 @@ export function Feedback({ onOpenSpace }: Props) {
           </div>
 
           <div className="grid gap-3 md:grid-cols-2">
-            <Card className="p-4">
-              <h3 className="mb-2 text-sm font-medium uppercase text-muted">Daily positive</h3>
-              <SimpleBars
-                data={data.trend.map(p => ({ x: formatDay(p.day), y: p.positive }))}
-                colorClass="bg-emerald-500"
-              />
-            </Card>
-            <Card className="p-4">
-              <h3 className="mb-2 text-sm font-medium uppercase text-muted">Daily negative</h3>
-              <SimpleBars
-                data={data.trend.map(p => ({ x: formatDay(p.day), y: p.negative }))}
-                colorClass="bg-red-500"
-              />
-            </Card>
+            <CountChartCard
+              title="Most positive feedback"
+              subtitle={`Top 10 spaces by 👍 count over the last ${data.days} days. Click a row to filter the reviews below.`}
+              rows={topByPositive}
+              valueFn={s => s.positive}
+              barColor="bg-emerald-500"
+              labelColor="text-emerald-400"
+              activeId={spaceFilter}
+              onSelect={selectSpace}
+              emptyText="No positive feedback in this window."
+            />
+            <CountChartCard
+              title="Most negative feedback"
+              subtitle={`Top 10 spaces by 👎 count over the last ${data.days} days. Click a row to filter the reviews below.`}
+              rows={topByNegative}
+              valueFn={s => s.negative}
+              barColor="bg-red-500"
+              labelColor="text-red-400"
+              activeId={spaceFilter}
+              onSelect={selectSpace}
+              emptyText="No negative feedback in this window."
+            />
           </div>
 
+          <div className="grid gap-4 lg:grid-cols-2">
           <Card className="overflow-hidden p-0">
             <div className="border-b border-default px-4 py-3">
               <h3 className="text-sm font-medium uppercase text-muted">By space</h3>
+              <p className="mt-0.5 text-xs text-muted">
+                Click a row to see that space's feedback. Click <ExternalLink size={10} className="inline" /> to open the space details.
+              </p>
             </div>
             <table className="w-full text-sm">
               <thead className="border-b border-default bg-elevated text-left text-xs uppercase text-muted">
                 <tr>
                   <th className="px-4 py-2">Space</th>
-                  <th className="px-4 py-2">Owner</th>
                   <Th onClick={() => toggleSort('positive')} active={sortKey === 'positive'} dir={sortDir}>Positive</Th>
                   <Th onClick={() => toggleSort('negative')} active={sortKey === 'negative'} dir={sortDir}>Negative</Th>
-                  <Th onClick={() => toggleSort('total')} active={sortKey === 'total'} dir={sortDir}>Total</Th>
                   <Th onClick={() => toggleSort('neg_rate_pct')} active={sortKey === 'neg_rate_pct'} dir={sortDir}>Neg %</Th>
                   <Th onClick={() => toggleSort('last_feedback_at')} active={sortKey === 'last_feedback_at'} dir={sortDir}>Last</Th>
+                  <th className="px-2 py-2" aria-label="Open space details"></th>
                 </tr>
               </thead>
               <tbody>
-                {sortedRollup?.map(r => (
+                {sortedRollup?.map(r => {
+                  const isActive = spaceFilter === r.space_id
+                  return (
                   <tr
                     key={r.space_id}
                     tabIndex={0}
                     role="button"
-                    className="cursor-pointer border-t border-default/50 hover:bg-elevated/50 focus:bg-elevated/50 focus:outline-none"
-                    onClick={() => onOpenSpace(r.space_id)}
+                    aria-label={`Show feedback events for ${r.title || r.space_id}`}
+                    className={`cursor-pointer border-t border-default/50 focus:outline-none ${
+                      isActive
+                        ? 'bg-accent/10 border-l-2 border-l-accent'
+                        : 'hover:bg-elevated/50 focus:bg-elevated/50'
+                    }`}
+                    onClick={() => selectSpace(r.space_id)}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault()
-                        onOpenSpace(r.space_id)
+                        selectSpace(r.space_id)
                       }
                     }}
                   >
-                    <td className="px-4 py-2">
-                      <div className="text-sm font-medium">{r.title || '(untitled)'}</div>
-                      <div className="font-mono text-xs text-muted">{r.space_id}</div>
+                    <td className="max-w-[200px] px-4 py-2">
+                      <div className="truncate text-sm font-medium">{r.title || '(untitled)'}</div>
+                      <div className="truncate font-mono text-xs text-muted">{r.space_id}</div>
                     </td>
-                    <td className="px-4 py-2 text-muted">{r.owner_email || '—'}</td>
                     <td className="px-4 py-2 tabular-nums text-emerald-400">{formatInt(r.positive)}</td>
                     <td className="px-4 py-2 tabular-nums text-red-400">{formatInt(r.negative)}</td>
-                    <td className="px-4 py-2 tabular-nums">{formatInt(r.total)}</td>
                     <td className="px-4 py-2 tabular-nums">{r.neg_rate_pct.toFixed(1)}%</td>
                     <td className="px-4 py-2 text-muted">{formatDate(r.last_feedback_at)}</td>
+                    <td className="px-2 py-2 text-right">
+                      <button
+                        type="button"
+                        className="rounded p-1 text-muted hover:bg-elevated hover:text-fg"
+                        aria-label={`Open ${r.title || r.space_id} details`}
+                        title="Open space details"
+                        onClick={(e) => { e.stopPropagation(); onOpenSpace(r.space_id) }}
+                      >
+                        <ExternalLink size={14} />
+                      </button>
+                    </td>
                   </tr>
-                ))}
+                  )
+                })}
                 {sortedRollup && sortedRollup.length === 0 && (
                   <tr>
-                    <td colSpan={7} className="p-6 text-center text-muted">
+                    <td colSpan={6} className="p-6 text-center text-muted">
                       No spaces with feedback in this window.
                     </td>
                   </tr>
@@ -212,9 +289,26 @@ export function Feedback({ onOpenSpace }: Props) {
             </table>
           </Card>
 
+          <div ref={eventsRef}>
           <Card className="p-4">
             <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-              <h3 className="text-sm font-medium uppercase text-muted">Recent feedback</h3>
+              <div className="flex items-center gap-2">
+                <h3 className="text-sm font-medium uppercase text-muted">Recent feedback</h3>
+                {spaceFilter && (
+                  <button
+                    type="button"
+                    onClick={() => setSpaceFilter(null)}
+                    className="flex items-center gap-1 rounded border border-accent/40 bg-accent/10 px-2 py-0.5 text-xs text-accent hover:bg-accent/20"
+                    aria-label="Clear space filter"
+                    title="Clear space filter"
+                  >
+                    <span className="max-w-[140px] truncate">
+                      {data.per_space.find(s => s.space_id === spaceFilter)?.title || spaceFilter.slice(0, 12)}
+                    </span>
+                    <X size={12} />
+                  </button>
+                )}
+              </div>
               <div className="flex flex-wrap items-center gap-2">
                 <RatingButton current={ratingFilter} value="all" onClick={setRatingFilter}>
                   All
@@ -290,6 +384,13 @@ export function Feedback({ onOpenSpace }: Props) {
                     </button>
                     {expanded && (
                       <div className="border-t border-default px-3 py-2 text-xs">
+                        {e.space_id && e.conversation_id && e.message_id && (
+                          <EventComments
+                            spaceId={e.space_id}
+                            conversationId={e.conversation_id}
+                            messageId={e.message_id}
+                          />
+                        )}
                         <div className="grid gap-1 sm:grid-cols-2">
                           <div>
                             <span className="text-muted">message_id:</span>{' '}
@@ -320,9 +421,134 @@ export function Feedback({ onOpenSpace }: Props) {
               )}
             </ul>
           </Card>
+          </div>
+          </div>
         </>
       )}
     </div>
+  )
+}
+
+// Renders user-typed comments attached to a feedback event's Genie message.
+// Fetched lazily via the Genie API when an event card is expanded; results
+// are cached at module scope so re-expanding the same event is instant.
+function EventComments({
+  spaceId, conversationId, messageId,
+}: {
+  spaceId: string
+  conversationId: string
+  messageId: string
+}) {
+  const cacheKey = `feedback-comments:${spaceId}:${conversationId}:${messageId}`
+  const cached = getCached<FeedbackMessageComment[]>(cacheKey)
+  const [comments, setComments] = useState<FeedbackMessageComment[] | null>(cached ?? null)
+  const [loading, setLoading] = useState<boolean>(cached === undefined)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (cached !== undefined) return
+    let cancelled = false
+    api.getFeedbackComments(spaceId, conversationId, messageId)
+      .then(result => {
+        if (cancelled) return
+        putCached(cacheKey, result)
+        setComments(result)
+      })
+      .catch(e => {
+        if (cancelled) return
+        setError(e instanceof Error ? e.message : String(e))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cacheKey])
+
+  if (loading) {
+    return (
+      <p className="mb-2 flex items-center gap-1 text-xs text-muted">
+        <Loader2 size={12} className="animate-spin" /> Loading comment…
+      </p>
+    )
+  }
+  if (error) {
+    return <p className="mb-2 text-xs text-red-400">Failed to load comments: {error}</p>
+  }
+  if (!comments || comments.length === 0) return null
+  return (
+    <div className="mb-3 space-y-2">
+      {comments.map(c => (
+        <blockquote
+          key={c.message_comment_id}
+          className="rounded border-l-2 border-default bg-elevated/30 p-2 text-sm text-secondary"
+        >
+          <p className="whitespace-pre-wrap">{c.content}</p>
+          <footer className="mt-1 text-xs text-muted">{formatDate(c.created_at)}</footer>
+        </blockquote>
+      ))}
+    </div>
+  )
+}
+
+// Horizontal-bar chart card used twice on the page (Most positive / Most
+// negative). Bar length is value/max within the chart, so each chart is
+// internally normalized and reads the same regardless of absolute volume.
+function CountChartCard({
+  title, subtitle, rows, valueFn, barColor, labelColor,
+  activeId, onSelect, emptyText,
+}: {
+  title: string
+  subtitle: string
+  rows: FeedbackSpaceRow[]
+  valueFn: (s: FeedbackSpaceRow) => number
+  barColor: string
+  labelColor: string
+  activeId: string | null
+  onSelect: (spaceId: string) => void
+  emptyText: string
+}) {
+  const max = Math.max(1, ...rows.map(valueFn))
+  return (
+    <Card className="p-4">
+      <div className="mb-3">
+        <h3 className="text-sm font-medium uppercase text-muted">{title}</h3>
+        <p className="mt-0.5 text-xs text-muted">{subtitle}</p>
+      </div>
+      <div className="space-y-1.5">
+        {rows.length === 0 && (
+          <p className="text-xs text-muted">{emptyText}</p>
+        )}
+        {rows.map(s => {
+          const v = valueFn(s)
+          const isActive = activeId === s.space_id
+          return (
+            <button
+              type="button"
+              key={s.space_id}
+              onClick={() => onSelect(s.space_id)}
+              aria-label={`Filter to ${s.title || s.space_id}`}
+              className={`flex w-full items-center gap-3 rounded px-2 py-1.5 text-left text-xs transition-colors ${
+                isActive ? 'bg-accent/10' : 'hover:bg-elevated/50'
+              }`}
+            >
+              <span className="w-44 shrink-0 truncate" title={s.title || s.space_id}>
+                {s.title || s.space_id.slice(0, 16)}
+              </span>
+              <div className="relative h-3 flex-1 rounded bg-elevated">
+                <div
+                  className={`absolute inset-y-0 left-0 rounded ${barColor}`}
+                  style={{ width: `${(v / max) * 100}%` }}
+                />
+              </div>
+              <span className={`w-12 shrink-0 text-right tabular-nums ${labelColor}`}>
+                {v.toLocaleString()}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </Card>
   )
 }
 

--- a/frontend/src/watch/pages/SpaceDetail.tsx
+++ b/frontend/src/watch/pages/SpaceDetail.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { ArrowLeft, AlertCircle, ExternalLink, Info, RefreshCw } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -13,6 +12,9 @@ import type {
 import { formatDate, formatInt, formatMs, formatUsd, formatDay } from '@/watch/lib/format'
 import { useCachedFetch } from '@/watch/lib/cache'
 import { genieSpaceUrl } from '@/watch/lib/genie'
+import { Stat } from '@/watch/components/Stat'
+import { SimpleBars } from '@/watch/components/SimpleBars'
+import { LoadingCard } from '@/watch/components/LoadingCard'
 
 interface Props {
   spaceId: string
@@ -443,53 +445,5 @@ function EvalsTab({ spaceId, onOpenSettings }: { spaceId: string; onOpenSettings
   )
 }
 
-function LoadingCard() {
-  const [elapsed, setElapsed] = useState(0)
-  useEffect(() => {
-    const id = setInterval(() => setElapsed(e => e + 1), 1000)
-    return () => clearInterval(id)
-  }, [])
-  return (
-    <Card className="p-6 text-center">
-      <p className="font-medium">Loading… ({elapsed}s)</p>
-      <p className="mt-2 text-xs text-muted">
-        First load runs a fresh system-table query (typically 30–60s on a busy warehouse).
-        Subsequent visits within 5 min are cached and load instantly.
-      </p>
-    </Card>
-  )
-}
 
-function Stat({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <Card className="p-4">
-      <p className="text-xs uppercase text-muted">{label}</p>
-      <p className="mt-1 text-2xl font-semibold">{value}</p>
-    </Card>
-  )
-}
 
-function SimpleBars({
-  data, formatY,
-}: { data: { x: string; y: number }[]; formatY?: (v: number) => string }) {
-  const max = Math.max(1, ...data.map(d => d.y))
-  return (
-    <div className="space-y-1">
-      {data.map((d, i) => (
-        <div key={i} className="flex items-center gap-2 text-xs">
-          <span className="w-16 shrink-0 text-muted">{d.x}</span>
-          <div className="h-3 flex-1 rounded bg-elevated">
-            <div
-              className="h-3 rounded bg-blue-500"
-              style={{ width: `${(d.y / max) * 100}%` }}
-            />
-          </div>
-          <span className="w-16 shrink-0 text-right tabular-nums">
-            {formatY ? formatY(d.y) : d.y.toLocaleString()}
-          </span>
-        </div>
-      ))}
-      {!data.length && <p className="text-xs text-muted">No data.</p>}
-    </div>
-  )
-}

--- a/frontend/src/watch/types/api.ts
+++ b/frontend/src/watch/types/api.ts
@@ -221,3 +221,10 @@ export interface FeedbackTabResponse {
   per_space: FeedbackSpaceRow[]
   events: FeedbackEvent[]
 }
+
+export interface FeedbackMessageComment {
+  message_comment_id: string
+  content: string
+  created_at: string
+  user_id: number | null
+}

--- a/frontend/src/watch/types/api.ts
+++ b/frontend/src/watch/types/api.ts
@@ -65,6 +65,9 @@ export interface FeedbackEvent {
   comment: string | null
   message_id: string | null
   conversation_id: string | null
+  // Populated by the all-spaces feedback endpoint. Null for single-space callers.
+  space_id: string | null
+  space_title: string | null
 }
 
 export interface FeedbackSummary {
@@ -183,4 +186,38 @@ export interface HealthStatus {
   warehouse_id: string | null
   dashboard_cost_id: string | null
   workspace_host: string | null
+}
+
+// ── Feedback tab (workspace-wide aggregation) ───────────────────────────────
+
+export interface FeedbackTabSummary {
+  positive: number
+  negative: number
+  total: number
+  neg_rate_pct: number
+}
+
+export interface FeedbackTrendPoint {
+  day: string
+  positive: number
+  negative: number
+}
+
+export interface FeedbackSpaceRow {
+  space_id: string
+  title: string | null
+  owner_email: string | null
+  positive: number
+  negative: number
+  total: number
+  neg_rate_pct: number
+  last_feedback_at: string | null
+}
+
+export interface FeedbackTabResponse {
+  days: number
+  summary: FeedbackTabSummary
+  trend: FeedbackTrendPoint[]
+  per_space: FeedbackSpaceRow[]
+  events: FeedbackEvent[]
 }


### PR DESCRIPTION
## Summary
- Adds a new Feedback sub-tab to the Watch AdminDashboard (6th tab, between Cost and Resources), backed by a workspace-wide `/api/watch/feedback` endpoint that aggregates `system.access.audit` thumbs-up/down events for Genie spaces.
- Page shows: 7/30/90 day selector, KPI strip, twin top-10 charts (most positive / most negative), sortable per-space rollup with click-to-filter, and a recent-feedback list with inline-expandable cards.
- Inline-expanded cards lazy-fetch user-typed comments via a new `/api/watch/feedback/comments` endpoint that hits the Genie Conversation API (audit only stores IDs, not the comment text).
- Fixes a bug where the summary aggregation matched `'POSITIVE'`/`'NEGATIVE'` but audit actually stores `'THUMBS_UP'`/`'THUMBS_DOWN'`, so pos and neg counts were always 0. SQL now normalizes the audit values into a single canonical vocabulary.
- Extracts `Stat`, `SimpleBars`, and `LoadingCard` out of `SpaceDetail.tsx` into shared components under `frontend/src/watch/components/` so the new page can reuse them.

## Test plan
- [ ] Backend: hit `GET /api/watch/feedback?days=30` and confirm summary totals match `system.access.audit` directly (sanity-check `THUMBS_UP` / `THUMBS_DOWN` normalization)
- [ ] Backend: hit `GET /api/watch/feedback/comments?space_id=...&conversation_id=...&message_id=...` with a real message that has a typed comment; verify dedupe and oldest-first ordering
- [ ] Backend: confirm invalid hex IDs return 400, valid 32-char hex passes through
- [ ] Frontend: load the Feedback sub-tab on a workspace with feedback events — verify KPI counts match backend, charts render top 10, both pos and neg cases have data
- [ ] Frontend: click a row in the rollup → event feed filters to that space, chip appears with the title and X to clear
- [ ] Frontend: on a narrow viewport (<lg), confirm clicking a row smooth-scrolls the event feed into view; on lg+ confirm no scroll happens
- [ ] Frontend: expand an event card with a comment — confirm lazy fetch, loader spinner, then comment renders; re-expand the same card and verify it's instant (module-scope cache)
- [ ] Frontend: click the trailing ExternalLink button on a rollup row — verify it drills to `SpaceDetail` (does not filter)
- [ ] Frontend: empty state when a workspace has zero feedback events in the window
- [ ] Frontend: audit-lag warning banner renders

This pull request and its description were written by Isaac.