### PR TITLE
Streamline notebook installer widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,8 @@ The recommended install path is the Databricks notebook installer.
    - `catalog`
    - `warehouse_id`
    - `llm_model`
-   - `mlflow_experiment_id`
    - `lakebase_mode`
-   - `lakebase_instance`
-   - `grant_genie_spaces`
+   - `lakebase_project_name`
 4. Run the notebook from the top.
 
 The notebook uses notebook-native `WorkspaceClient()` auth, creates a generated deployment source folder under `/Workspace/Users/<you>/.genie-workbench-deploy/<app-name>/app`, patches `app.yaml` there, provisions UC/Lakebase/GSO resources, and deploys the Databricks App from that generated source. The Git folder remains unchanged.

--- a/backend/tests/test_deploy_lib.py
+++ b/backend/tests/test_deploy_lib.py
@@ -133,6 +133,16 @@ def test_config_validation_normalizes_lakebase_defaults():
     assert cfg.gso_job_name == "genie-workbench-gso-optimization-job"
     cfg.validate()
 
+    explicit_cfg = InstallConfig(
+        app_name="genie-workbench",
+        catalog="main",
+        warehouse_id="abc",
+        repo_root="/Workspace/Repos/me/repo",
+        lakebase_mode="create",
+        lakebase_instance="custom-lakebase",
+    ).normalized()
+    assert explicit_cfg.lakebase_instance == "custom-lakebase"
+
     with pytest.raises(ValueError, match="app_name"):
         InstallConfig(app_name="Bad Name", catalog="main", warehouse_id="abc", repo_root="/tmp").validate()
 
@@ -144,6 +154,24 @@ def test_config_validation_normalizes_lakebase_defaults():
             repo_root="/tmp",
             lakebase_mode="existing",
         ).validate()
+
+
+def test_notebook_installer_uses_streamlined_widgets_and_defaults():
+    notebook_source = Path("notebooks/install.py").read_text()
+
+    assert 'dbutils.widgets.text("lakebase_project_name", "")' in notebook_source
+    assert 'dbutils.widgets.get("lakebase_project_name").strip()' in notebook_source
+    assert 'lakebase_instance = f"{app_name}-lakebase"' in notebook_source
+    assert 'dbutils.widgets.text("lakebase_instance"' not in notebook_source
+    assert 'dbutils.widgets.get("lakebase_instance")' not in notebook_source
+
+    assert 'dbutils.widgets.text("mlflow_experiment_id"' not in notebook_source
+    assert 'dbutils.widgets.get("mlflow_experiment_id")' not in notebook_source
+    assert "mlflow_experiment_id=None" in notebook_source
+
+    assert 'dbutils.widgets.dropdown("grant_genie_spaces"' not in notebook_source
+    assert 'dbutils.widgets.get("grant_genie_spaces")' not in notebook_source
+    assert "grant_genie_spaces=True" in notebook_source
 
 
 def test_workspace_source_inclusion_rules(tmp_path):

--- a/docs/03-authentication-and-permissions.md
+++ b/docs/03-authentication-and-permissions.md
@@ -154,7 +154,7 @@ If the workspace or user's OAuth consent doesn't grant all scopes, the app degra
 |-----------|---------|
 | `CAN_MANAGE` | API fallback when user token lacks Genie scope; applying optimization patches during the GSO pipeline |
 
-Grant via the Genie Space sharing UI or through an installer. `scripts/install.sh` handles this for the local terminal path, and `notebooks/install.py` can optionally grant visible Genie Spaces for the Databricks notebook path.
+Grant via the Genie Space sharing UI or through an installer. `scripts/install.sh` handles this for the local terminal path, and `notebooks/install.py` grants visible Genie Spaces for the Databricks notebook path.
 
 ### Per referenced data schema
 
@@ -222,12 +222,12 @@ This is distinct from the runtime identities documented above: installer permiss
 | Create the Lakebase Autoscaling project | `scripts/setup_lakebase.py`, `scripts/deploy_lib/lakebase.py` `ensure_project()` | Lakebase project creation entitlement |
 | Create Postgres role for the app SP | `scripts/deploy_lib/lakebase.py` `ensure_role()` | Lakebase project ownership |
 | `GRANT CONNECT, CREATE ON DATABASE databricks_postgres` to the app SP | `scripts/deploy_lib/lakebase.py` `grant_database_permissions()` | Role with `GRANT` on the Lakebase database (effectively project owner / superuser) |
-| Create or look up MLflow experiment for tracing (optional) | `scripts/install.sh` step 6, `notebooks/install.py` `mlflow_experiment_id` widget | Workspace files write at the experiment path |
+| Create or look up MLflow experiment for tracing (optional) | `scripts/install.sh` step 6; dormant in the notebook installer | Workspace files write at the experiment path |
 | Probe / require MLflow Prompt Registry for Auto-Optimize | `backend/routers/auto_optimize.py` (Prompt Registry probe) | Workspace admin to enable Prompt Registry on the workspace if it is not already on |
 | Build and deploy the GSO optimization job | `databricks bundle deploy -t app` (local), `scripts/deploy_lib/gso_job.py` (notebook) | Jobs create entitlement; write on the bundle workspace directory |
 | Set GSO job ACL (owner=installer, SP=`CAN_MANAGE`, users=`CAN_VIEW`) | `scripts/deploy.sh` step 6 (`PUT /api/2.0/permissions/jobs/<id>`) | `CAN_MANAGE` on the job |
 | Grant SP `CAN_MANAGE` on the bundle workspace directory | `scripts/deploy.sh` step 6, `scripts/deploy_lib/gso_job.py` `grant_directory_permissions()` | `CAN_MANAGE` on the directory |
-| Grant SP `CAN_MANAGE` on existing Genie Spaces (optional) | `scripts/install.sh` step 12, `scripts/deploy_lib/genie_spaces.py` `grant_can_manage_on_space()` | `CAN_MANAGE` on each selected space |
+| Grant SP `CAN_MANAGE` on existing Genie Spaces (automatic in notebook, prompted in local installer) | `scripts/install.sh` step 12, `scripts/deploy_lib/genie_spaces.py` `grant_can_manage_on_space()` | `CAN_MANAGE` on each selected space |
 
 ### Pre-flight checks today
 

--- a/docs/08-deployment-guide.md
+++ b/docs/08-deployment-guide.md
@@ -99,12 +99,10 @@ Use this path when you are already working inside Databricks and do not want a l
 | `catalog` | Yes | Unity Catalog for GSO tables and artifacts |
 | `warehouse_id` | Yes | SQL Warehouse ID used by the app and GSO |
 | `llm_model` | No | Model serving endpoint name |
-| `mlflow_experiment_id` | No | MLflow experiment ID for tracing |
 | `lakebase_mode` | Yes | `create`, `existing`, or `skip` |
-| `lakebase_instance` | Conditional | Lakebase project name for `create` or `existing` |
-| `grant_genie_spaces` | No | Whether to grant visible Genie Spaces to the app SP |
+| `lakebase_project_name` | Conditional | Lakebase project name for `create` or `existing`; defaults to `<app-name>-lakebase` for `create` |
 
-The notebook user must hold the same permissions listed in [Authentication & Permissions — Installer Permissions](03-authentication-and-permissions.md#installer-permissions). In particular, granting Genie Spaces requires `CAN_MANAGE` on each selected space.
+The notebook user must hold the same permissions listed in [Authentication & Permissions — Installer Permissions](03-authentication-and-permissions.md#installer-permissions). The notebook installer automatically grants visible Genie Spaces to the app service principal, so the notebook user needs `CAN_MANAGE` on each visible space they want the app to manage.
 
 4. Run the notebook from the top.
 
@@ -121,7 +119,7 @@ The notebook:
 9. Renders a patched `app.yaml` into the generated source folder
 10. Patches app OAuth scopes and resources
 11. Deploys the app from the generated source folder
-12. Optionally grants the app SP access to visible Genie Spaces
+12. Grants the app SP access to visible Genie Spaces
 
 The Git folder remains unchanged. The generated workspace folder is deployment output; do not edit it by hand. To update a notebook-installed app, pull the latest repo changes in Databricks Git and re-run `notebooks/install.py` from the top.
 
@@ -147,7 +145,7 @@ The local terminal installer writes the project name as `GENIE_LAKEBASE_INSTANCE
 `.env.deploy`. The notebook installer reads the Lakebase project from widgets.
 If you skip Lakebase during install, set `GENIE_LAKEBASE_INSTANCE` later and
 run `./scripts/deploy.sh --update` for the local path, or set the notebook
-`lakebase_mode`/`lakebase_instance` widgets and rerun `notebooks/install.py`.
+`lakebase_mode`/`lakebase_project_name` widgets and rerun `notebooks/install.py`.
 Attaching an existing Lakebase project is an advanced path that requires
 explicit confirmation because cross-app reuse can fail on object ownership.
 

--- a/docs/09-operations-guide.md
+++ b/docs/09-operations-guide.md
@@ -69,7 +69,7 @@ Auto-Optimize requires MLflow Prompt Registry for versioned judge prompts. If Pr
   value: "<your-experiment-id>"
 ```
 
-The experiment ID is workspace-specific. The local terminal installer can create one during setup; the notebook installer accepts an existing experiment ID in the `mlflow_experiment_id` widget. You can also create one manually and redeploy with the updated value.
+The experiment ID is workspace-specific. The local terminal installer can create one during setup. The notebook installer leaves Create Agent tracing dormant and deploys with no app-level experiment ID. You can still enable tracing manually by setting `MLFLOW_EXPERIMENT_ID` in `app.yaml` before deploying.
 
 ## Monitoring
 

--- a/notebooks/install.py
+++ b/notebooks/install.py
@@ -60,10 +60,8 @@ dbutils.widgets.text("app_name", "genie-workbench")
 dbutils.widgets.text("catalog", "")
 dbutils.widgets.text("warehouse_id", "")
 dbutils.widgets.text("llm_model", "databricks-claude-sonnet-4-6")
-dbutils.widgets.text("mlflow_experiment_id", "")
 dbutils.widgets.dropdown("lakebase_mode", "create", ["create", "existing", "skip"])
-dbutils.widgets.text("lakebase_instance", "")
-dbutils.widgets.dropdown("grant_genie_spaces", "false", ["false", "true"])
+dbutils.widgets.text("lakebase_project_name", "")
 
 # COMMAND ----------
 # MAGIC %md
@@ -119,7 +117,7 @@ def notebook_status(message: str) -> None:
 
 app_name = dbutils.widgets.get("app_name").strip()
 lakebase_mode = dbutils.widgets.get("lakebase_mode").strip()
-explicit_lakebase = dbutils.widgets.get("lakebase_instance").strip()
+explicit_lakebase = dbutils.widgets.get("lakebase_project_name").strip()
 
 if lakebase_mode == "skip":
     lakebase_instance = None
@@ -133,11 +131,11 @@ cfg = InstallConfig(
     catalog=dbutils.widgets.get("catalog").strip(),
     warehouse_id=dbutils.widgets.get("warehouse_id").strip(),
     llm_model=dbutils.widgets.get("llm_model").strip(),
-    mlflow_experiment_id=dbutils.widgets.get("mlflow_experiment_id").strip() or None,
+    mlflow_experiment_id=None,
     lakebase_mode=lakebase_mode,
     lakebase_instance=lakebase_instance,
     repo_root=str(repo_root),
-    grant_genie_spaces=dbutils.widgets.get("grant_genie_spaces").strip().lower() == "true",
+    grant_genie_spaces=True,
 )
 
 w = WorkspaceClient()

--- a/scripts/deploy_lib/lakebase.py
+++ b/scripts/deploy_lib/lakebase.py
@@ -40,7 +40,7 @@ def require_project(w, project_name: str) -> str:
         raise RuntimeError(
             f"Lakebase project '{project_name}' does not exist. "
             "Choose lakebase_mode=create to create a new project, or fix the "
-            "lakebase_instance widget to an existing project name."
+            "lakebase_project_name widget to an existing project name."
         ) from exc
     return resource_name
 


### PR DESCRIPTION
## Summary
- Drop the rarely-used `mlflow_experiment_id` and `grant_genie_spaces` widgets from `notebooks/install.py` — Genie Space permission grants are now always on, and MLflow experiment wiring stays at its default (post-install configurable).
- Rename the `lakebase_instance` widget to `lakebase_project_name` to match the Lakebase Autoscaling terminology used elsewhere in the codebase, and update the error message in `scripts/deploy_lib/lakebase.py` to reference the new widget.
- Refresh docs (`docs/03`, `docs/08`, `docs/09`) and add a small regression test (`backend/tests/test_deploy_lib.py`) covering the new widget naming.

## Test plan
- [ ] Run `notebooks/install.py` end-to-end against a workspace with `lakebase_mode=create` and confirm the GSO job + app deploy succeed.
- [ ] Re-run with `lakebase_mode=existing` and a known `lakebase_project_name` to verify the rename path.
- [ ] `uv run pytest backend/tests/test_deploy_lib.py`

This pull request and its description were drafted with assistance from Claude Code.