### PR TITLE
Use uv run python for grant_permissions.py

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -278,7 +278,7 @@ if [ -z "$SP_CLIENT_ID" ]; then
 fi
 echo "  ✓ SP client ID: $SP_CLIENT_ID"
 
-python3 "$SCRIPT_DIR/grant_permissions.py" \
+uv run python "$SCRIPT_DIR/grant_permissions.py" \
     --profile "$PROFILE" \
     --app-name "$APP_NAME" \
     --catalog "$CATALOG" \


### PR DESCRIPTION
## Summary

- `grant_permissions.py` imports `from genie_space_optimizer.optimization.ddl import _ALL_DDL`, which requires the project venv
- It was being called with bare `python3`, which uses system Python and doesn't have the venv deps — causing a missing-dependency failure at deploy time
- Changed to `uv run python`, matching the pattern already used for `setup_lakebase.py`

## Test plan

- [x] Run `./scripts/deploy.sh` or `./scripts/deploy.sh --update` on a workspace where the venv is not pre-activated — grants step should complete without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)