### PR TITLE
Fix notebook installer crash on DASHBOARD_COST_ID placeholder

### DIFF
--- a/scripts/deploy_lib/install.py
+++ b/scripts/deploy_lib/install.py
@@ -87,6 +87,10 @@ def run_install(w, cfg: InstallConfig, status_fn=None) -> dict[str, Any]:
             "LAKEBASE_INSTANCE": cfg.lakebase_instance or "",
             "LLM_MODEL": cfg.llm_model,
             "MLFLOW_EXPERIMENT_ID": cfg.mlflow_experiment_id or "",
+            # Notebook install path does not deploy the bundle, so the
+            # GenieWatch Cost dashboard never exists. Empty = hide the embed,
+            # matching deploy.sh's fallback when no dashboard ID resolves.
+            "DASHBOARD_COST_ID": "",
         },
         workspace_client=w,
     )


### PR DESCRIPTION
## Summary

- The GenieWatch merge (bd39cb40) added `DASHBOARD_COST_ID` to `app.yaml` and updated `scripts/deploy.sh` to substitute it, but the notebook install path in `scripts/deploy_lib/install.py` was missed.
- `render_app_yaml`'s strict sweep (`scripts/deploy_lib/app_yaml.py:20-22`) raises `ValueError` on any unresolved `__FOO__` token, so every `notebooks/install.py` run now fails with: `Unresolved app.yaml placeholders: __DASHBOARD_COST_ID__`.
- This adds `DASHBOARD_COST_ID: ""` to the replacements dict, matching `deploy.sh:512`'s fallback when no dashboard ID is resolvable. The bundle-managed dashboard isn't deployed via the notebook path, so empty is the correct default — the backend already treats empty as "hide the embedded Cost dashboard" per `app.yaml:103`.

## Test plan

- [ ] Run `notebooks/install.py` end-to-end in a Databricks workspace and confirm app deploys without the placeholder error
- [ ] Confirm Admin > Cost sub-tab loads with the embedded dashboard hidden (no JS errors)
- [ ] `scripts/deploy.sh` behavior unchanged (still resolves the dashboard ID via `databricks bundle summary`)

This pull request and its description were written by Isaac.