### PR TITLE
Propagate app LLM model into GSO jobs

### DIFF
--- a/backend/routers/auto_optimize.py
+++ b/backend/routers/auto_optimize.py
@@ -248,6 +248,7 @@ def _build_gso_config() -> IntegrationConfig:
         schema_name=os.environ.get("GSO_SCHEMA", "genie_space_optimizer"),
         warehouse_id=os.environ.get("GSO_WAREHOUSE_ID") or os.environ.get("SQL_WAREHOUSE_ID", ""),
         job_id=int(os.environ["GSO_JOB_ID"]) if os.environ.get("GSO_JOB_ID", "").isdigit() else None,
+        llm_model=os.environ.get("LLM_MODEL", "databricks-claude-sonnet-4-6"),
     )
 
 

--- a/backend/tests/test_auto_optimize_router.py
+++ b/backend/tests/test_auto_optimize_router.py
@@ -320,6 +320,7 @@ def test_trigger_proceeds_when_prompt_registry_available(
         auto_optimize, "get_service_principal_client", lambda: mock_sp_ws
     )
     monkeypatch.setattr(auto_optimize, "get_workspace_client", lambda: mock_user_ws)
+    monkeypatch.setenv("LLM_MODEL", "custom-trigger-model")
 
     ok_probe = ProbeResult(
         available=True, reason_code="ok", actionable_by="customer"
@@ -352,6 +353,8 @@ def test_trigger_proceeds_when_prompt_registry_available(
         "status": "QUEUED",
     }
     trigger_mock.assert_called_once()
+    config = trigger_mock.call_args.kwargs["config"]
+    assert config.llm_model == "custom-trigger-model"
 
 
 def test_trigger_blocks_on_probe_error_fail_closed(

--- a/backend/tests/test_deploy_lib.py
+++ b/backend/tests/test_deploy_lib.py
@@ -338,6 +338,7 @@ def test_gso_job_settings_match_persistent_dag_shape():
         app_name="genie-workbench",
         catalog="main",
         warehouse_id="wh",
+        llm_model="custom-gso-model",
         repo_root="/tmp",
     )
     settings = build_job_settings(
@@ -351,8 +352,12 @@ def test_gso_job_settings_match_persistent_dag_shape():
     assert settings["tags"]["app"] == "genie-workbench"
     assert settings["tags"]["managed-by"] == "notebook-installer"
     assert settings["environments"][0]["spec"]["environment_version"] == "4"
+    params = {p["name"]: p["default"] for p in settings["parameters"]}
+    assert params["llm_model"] == "custom-gso-model"
     task_keys = [task["task_key"] for task in settings["tasks"]]
     assert task_keys == ["preflight", "baseline_eval", "enrichment", "lever_loop", "finalize", "deploy"]
+    assert settings["tasks"][0]["notebook_task"]["base_parameters"]["llm_model"] == "{{job.parameters.llm_model}}"
+    assert settings["tasks"][1]["notebook_task"]["base_parameters"]["llm_model"] == "{{job.parameters.llm_model}}"
     assert settings["tasks"][1]["depends_on"] == [{"task_key": "preflight"}]
     assert settings["tasks"][-1]["condition_task"]["right"] == "disabled"
 

--- a/databricks.yml
+++ b/databricks.yml
@@ -85,6 +85,8 @@ resources:
           default: ""
         - name: warehouse_id
           default: ""
+        - name: llm_model
+          default: ${var.llm_model}
       tasks:
         - task_key: preflight
           notebook_task:
@@ -101,6 +103,7 @@ resources:
               experiment_name: "{{job.parameters.experiment_name}}"
               deploy_target: "{{job.parameters.deploy_target}}"
               warehouse_id: "{{job.parameters.warehouse_id}}"
+              llm_model: "{{job.parameters.llm_model}}"
           environment_key: default
           timeout_seconds: 7200
           max_retries: 0
@@ -109,6 +112,8 @@ resources:
             - task_key: preflight
           notebook_task:
             notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_baseline.py
+            base_parameters:
+              llm_model: "{{job.parameters.llm_model}}"
           environment_key: default
           timeout_seconds: 7200
           max_retries: 0
@@ -117,6 +122,8 @@ resources:
             - task_key: baseline_eval
           notebook_task:
             notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_enrichment.py
+            base_parameters:
+              llm_model: "{{job.parameters.llm_model}}"
           environment_key: default
           timeout_seconds: 7200
           max_retries: 0
@@ -125,6 +132,8 @@ resources:
             - task_key: enrichment
           notebook_task:
             notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_lever_loop.py
+            base_parameters:
+              llm_model: "{{job.parameters.llm_model}}"
           environment_key: default
           timeout_seconds: 7200
           max_retries: 0
@@ -133,6 +142,8 @@ resources:
             - task_key: lever_loop
           notebook_task:
             notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
+            base_parameters:
+              llm_model: "{{job.parameters.llm_model}}"
           environment_key: default
           timeout_seconds: 7200
           max_retries: 0

--- a/docs/appendices/C-environment-variables.md
+++ b/docs/appendices/C-environment-variables.md
@@ -16,7 +16,8 @@ These variables are defined in `app.yaml` and injected into the app runtime. Pla
 
 | Variable | Value | Description |
 |----------|-------|-------------|
-| `LLM_MODEL` | `__LLM_MODEL__` | Databricks model serving endpoint for analysis, fix agent, create agent. Default: `databricks-claude-sonnet-4-6` |
+| `LLM_MODEL` | `__LLM_MODEL__` | Databricks model serving endpoint for analysis, fix agent, create agent, and GSO. Default: `databricks-claude-sonnet-4-6` |
+| `GSO_LLM_ENDPOINT` | unset | Optional GSO-only override for emergency/debug use. If unset, GSO uses `LLM_MODEL` |
 
 ### SQL Warehouse
 
@@ -66,7 +67,7 @@ The Databricks notebook path does not write `.env.deploy`; it collects equivalen
 | `GENIE_CATALOG` | Yes | — | Unity Catalog name (you need CREATE SCHEMA permission) |
 | `GENIE_APP_NAME` | No | `genie-workbench` | Databricks App name (must be unique in your workspace) |
 | `GENIE_DEPLOY_PROFILE` | No | `DEFAULT` | Databricks CLI profile name |
-| `GENIE_LLM_MODEL` | No | `databricks-claude-sonnet-4-6` | LLM serving endpoint for analysis |
+| `GENIE_LLM_MODEL` | No | `databricks-claude-sonnet-4-6` | LLM serving endpoint for the app and GSO optimization job |
 | `GENIE_LAKEBASE_INSTANCE` | No | empty | Lakebase Autoscaling project to use or create; installer defaults new installs to `<app-name>-lakebase`; keep stable for the same app, use a fresh project for a new app instance |
 
 ## How Variables Flow

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/backend/job_launcher.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/backend/job_launcher.py
@@ -365,6 +365,7 @@ def submit_optimization(
     deploy_target: str = "",
     warehouse_id: str = "",
     target_benchmark_count: str = "",
+    llm_model: str = "",
 ) -> tuple[str, int]:
     """Trigger a run on the bundle-managed optimization job.
 
@@ -395,6 +396,7 @@ def submit_optimization(
                 "deploy_target": deploy_target,
                 "warehouse_id": warehouse_id,
                 "target_benchmark_count": target_benchmark_count,
+                "llm_model": llm_model or os.getenv("LLM_MODEL", ""),
             },
         )
 

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/common/config.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/common/config.py
@@ -689,7 +689,23 @@ def apply_quality_instructions_is_on() -> bool:
 
 # ── 4. LLM Configuration ──────────────────────────────────────────────
 
-LLM_ENDPOINT = "databricks-claude-opus-4-6"
+DEFAULT_LLM_ENDPOINT = "databricks-claude-sonnet-4-6"
+
+
+def get_llm_endpoint() -> str:
+    """Return the Databricks model serving endpoint used by GSO LLM calls.
+
+    ``LLM_MODEL`` is the app-wide source of truth. ``GSO_LLM_ENDPOINT`` is an
+    explicit GSO-only override for emergency/debug use.
+    """
+    return (
+        os.environ.get("GSO_LLM_ENDPOINT")
+        or os.environ.get("LLM_MODEL")
+        or DEFAULT_LLM_ENDPOINT
+    ).strip() or DEFAULT_LLM_ENDPOINT
+
+
+LLM_ENDPOINT = DEFAULT_LLM_ENDPOINT
 LLM_TEMPERATURE = 0
 LLM_MAX_RETRIES = 3
 
@@ -3764,9 +3780,11 @@ MAX_INSTRUCTION_TEXT_CHARS = 2000
 MAX_HOLISTIC_INSTRUCTION_CHARS = 8000
 
 PROMPT_TOKEN_BUDGET = 70_000
-"""Token budget for LLM prompts.  Claude Opus 4.6 supports 200k tokens;
-we target ~70k to stay in the quality sweet-spot while leaving headroom
-for the response."""
+"""Token budget for LLM prompts.
+
+The default endpoint supports large contexts; keep prompts around 70k tokens to
+leave response headroom and remain inside the quality sweet spot.
+"""
 
 RISK_LEVEL_SCORE = {
     "low": 1,

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/integration/config.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/integration/config.py
@@ -18,3 +18,4 @@ class IntegrationConfig:
     schema_name: str
     warehouse_id: str
     job_id: int | None = None
+    llm_model: str = ""

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/integration/trigger.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/integration/trigger.py
@@ -228,6 +228,7 @@ def trigger_optimization(
             experiment_name=experiment_name or "",
             deploy_target=deploy_target or "",
             warehouse_id=config.warehouse_id or "",
+            llm_model=config.llm_model or "",
         )
 
         sql_warehouse_execute(

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_baseline.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_baseline.py
@@ -225,6 +225,13 @@ domain = dbutils.jobs.taskValues.get(taskKey="preflight", key="domain")
 catalog = dbutils.jobs.taskValues.get(taskKey="preflight", key="catalog")
 schema = dbutils.jobs.taskValues.get(taskKey="preflight", key="schema")
 exp_name = dbutils.jobs.taskValues.get(taskKey="preflight", key="experiment_name")
+dbutils.widgets.text("llm_model", "")
+llm_model = (
+    dbutils.widgets.get("llm_model").strip()
+    or dbutils.jobs.taskValues.get(taskKey="preflight", key="llm_model", default="").strip()
+)
+if llm_model:
+    os.environ["LLM_MODEL"] = llm_model
 
 import os as _os
 _warehouse_id = dbutils.jobs.taskValues.get(taskKey="preflight", key="warehouse_id", default="")
@@ -254,6 +261,7 @@ _log(
     catalog=catalog,
     schema=schema,
     experiment_name=exp_name,
+    llm_model=llm_model or "(default)",
 )
 
 # COMMAND ----------

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_enrichment.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_enrichment.py
@@ -95,6 +95,15 @@ domain = dbutils.jobs.taskValues.get(taskKey="preflight", key="domain")
 catalog = dbutils.jobs.taskValues.get(taskKey="preflight", key="catalog")
 schema = dbutils.jobs.taskValues.get(taskKey="preflight", key="schema")
 exp_name = dbutils.jobs.taskValues.get(taskKey="preflight", key="experiment_name")
+dbutils.widgets.text("llm_model", "")
+llm_model = (
+    dbutils.widgets.get("llm_model").strip()
+    or dbutils.jobs.taskValues.get(taskKey="preflight", key="llm_model", default="").strip()
+)
+if llm_model:
+    import os
+
+    os.environ["LLM_MODEL"] = llm_model
 
 from genie_space_optimizer.common.warehouse import (
     export_warehouse_id,
@@ -127,6 +136,7 @@ _log(
     baseline_model_id=baseline_model_id,
     thresholds_met=thresholds_met,
     warehouse_id=_warehouse_id or "(not set — detection will run without warehouse)",
+    llm_model=llm_model or "(default)",
 )
 
 # COMMAND ----------

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
@@ -166,9 +166,11 @@ configure_mlflow_connection_pool(CONNECTION_POOL_SIZE)
 dbutils.widgets.text("run_id", "")
 dbutils.widgets.text("catalog", "")
 dbutils.widgets.text("schema", "")
+dbutils.widgets.text("llm_model", "")
 _widget_run_id = dbutils.widgets.get("run_id").strip()
 _widget_catalog = dbutils.widgets.get("catalog").strip()
 _widget_schema = dbutils.widgets.get("schema").strip()
+_widget_llm_model = dbutils.widgets.get("llm_model").strip()
 
 from genie_space_optimizer.jobs._handoff import (
     get_baseline_eval_state,
@@ -199,6 +201,12 @@ deploy_target = (
 )
 
 import os as _os
+llm_model = (
+    _widget_llm_model
+    or dbutils.jobs.taskValues.get(taskKey="preflight", key="llm_model", default="").strip()
+)
+if llm_model:
+    _os.environ["LLM_MODEL"] = llm_model
 _warehouse_id = ctx["warehouse_id"].value or ""
 if _warehouse_id:
     _os.environ["GENIE_SPACE_OPTIMIZER_WAREHOUSE_ID"] = _warehouse_id
@@ -248,6 +256,7 @@ _log(
     lever_skipped=bool(lever_skipped),
     prev_model_id=prev_model_id,
     iteration_counter=iteration_counter,
+    llm_model=llm_model or "(default)",
     score_keys=sorted(list(prev_scores.keys())) if isinstance(prev_scores, dict) else [],
 )
 _log(

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_lever_loop.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_lever_loop.py
@@ -282,9 +282,11 @@ spark = SparkSession.builder.getOrCreate()
 dbutils.widgets.text("run_id", "")
 dbutils.widgets.text("catalog", "")
 dbutils.widgets.text("schema", "")
+dbutils.widgets.text("llm_model", "")
 _widget_run_id = dbutils.widgets.get("run_id").strip()
 _widget_catalog = dbutils.widgets.get("catalog").strip()
 _widget_schema = dbutils.widgets.get("schema").strip()
+_widget_llm_model = dbutils.widgets.get("llm_model").strip()
 
 from genie_space_optimizer.jobs._handoff import (
     HandoffSource,
@@ -316,6 +318,12 @@ human_corrections = ctx["human_corrections"].value or []
 max_benchmark_count = ctx["max_benchmark_count"].value
 
 import os as _os
+llm_model = (
+    _widget_llm_model
+    or dbutils.jobs.taskValues.get(taskKey="preflight", key="llm_model", default="").strip()
+)
+if llm_model:
+    _os.environ["LLM_MODEL"] = llm_model
 _warehouse_id = ctx["warehouse_id"].value or ""
 if _warehouse_id:
     _os.environ["GENIE_SPACE_OPTIMIZER_WAREHOUSE_ID"] = _warehouse_id
@@ -395,6 +403,7 @@ _log(
     enrichment_model_id=enrichment_model_id,
     enrichment_skipped=enrichment_skipped,
     triggered_by=triggered_by,
+    llm_model=llm_model or "(default)",
 )
 _log(
     "Handoff sources (TASK_VALUES = healthy, DELTA_FALLBACK = repaired)",

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_preflight.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_preflight.py
@@ -192,6 +192,7 @@ dbutils.widgets.text("deploy_target", "")
 dbutils.widgets.text("warehouse_id", "")
 dbutils.widgets.text("triggered_by", "")
 dbutils.widgets.text("target_benchmark_count", "")
+dbutils.widgets.text("llm_model", "")
 
 run_id = dbutils.widgets.get("run_id")
 space_id = dbutils.widgets.get("space_id")
@@ -206,6 +207,9 @@ deploy_target = dbutils.widgets.get("deploy_target") or None
 triggered_by = dbutils.widgets.get("triggered_by") or ""
 _target_benchmark_count_raw = dbutils.widgets.get("target_benchmark_count").strip()
 target_benchmark_count = int(_target_benchmark_count_raw) if _target_benchmark_count_raw else None
+llm_model = dbutils.widgets.get("llm_model").strip()
+if llm_model:
+    os.environ["LLM_MODEL"] = llm_model
 
 effective_target = target_benchmark_count or TARGET_BENCHMARK_COUNT
 effective_max = (
@@ -229,6 +233,7 @@ _log(
     deploy_target=deploy_target,
     triggered_by=triggered_by,
     target_benchmark_count=target_benchmark_count,
+    llm_model=llm_model or "(default)",
 )
 
 # COMMAND ----------
@@ -629,6 +634,7 @@ dbutils.jobs.taskValues.set(key="levers", value=json.dumps(levers))
 dbutils.jobs.taskValues.set(key="apply_mode", value=apply_mode)
 dbutils.jobs.taskValues.set(key="deploy_target", value=deploy_target or "")
 dbutils.jobs.taskValues.set(key="warehouse_id", value=warehouse_id)
+dbutils.jobs.taskValues.set(key="llm_model", value=llm_model)
 dbutils.jobs.taskValues.set(key="triggered_by", value=triggered_by)
 dbutils.jobs.taskValues.set(key="human_corrections", value=json.dumps(preflight_out.get("human_corrections", []), default=str))
 dbutils.jobs.taskValues.set(key="max_benchmark_count", value=effective_max)

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/benchmarks.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/benchmarks.py
@@ -687,7 +687,6 @@ def validate_question_sql_alignment(
 
     from genie_space_optimizer.common.config import (
         BENCHMARK_ALIGNMENT_CHECK_PROMPT,
-        LLM_ENDPOINT,
         format_mlflow_template,
     )
 

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/evaluation.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/evaluation.py
@@ -55,7 +55,6 @@ from genie_space_optimizer.common.config import (
     INSTRUCTION_PROMPT_NAME_TEMPLATE,
     JUDGE_PROMPTS,
     LEVER_PROMPTS,
-    LLM_ENDPOINT,
     LLM_MAX_RETRIES,
     LLM_SOURCE_ID_TEMPLATE,
     LLM_TEMPERATURE,
@@ -70,6 +69,7 @@ from genie_space_optimizer.common.config import (
     TARGET_BENCHMARK_COUNT,
     TEMPLATE_VARIABLES,
     format_mlflow_template,
+    get_llm_endpoint,
     scoring_v2_is_legacy,
     scoring_v2_is_on,
     scoring_v2_is_shadow,
@@ -106,8 +106,20 @@ logger = logging.getLogger(__name__)
 CODE_SOURCE = AssessmentSource(source_type="CODE", source_id=CODE_SOURCE_ID)
 LLM_SOURCE = AssessmentSource(
     source_type="LLM_JUDGE",
-    source_id=format_mlflow_template(LLM_SOURCE_ID_TEMPLATE, endpoint=LLM_ENDPOINT),
+    source_id=format_mlflow_template(
+        LLM_SOURCE_ID_TEMPLATE, endpoint=get_llm_endpoint(),
+    ),
 )
+
+
+def get_llm_source() -> AssessmentSource:
+    """Return LLM judge metadata using the currently configured endpoint."""
+    return AssessmentSource(
+        source_type="LLM_JUDGE",
+        source_id=format_mlflow_template(
+            LLM_SOURCE_ID_TEMPLATE, endpoint=get_llm_endpoint(),
+        ),
+    )
 
 
 # ── Judge-failure predicates ──────────────────────────────────────────

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/llm_client.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/llm_client.py
@@ -17,9 +17,9 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from genie_space_optimizer.common.config import (
-    LLM_ENDPOINT,
     LLM_MAX_RETRIES,
     LLM_TEMPERATURE,
+    get_llm_endpoint,
 )
 
 if TYPE_CHECKING:
@@ -124,9 +124,10 @@ def call_llm(
     JSON parsing, prompt linking, span wrapping, etc.
     """
     client = get_openai_client(w)
+    model = get_llm_endpoint()
 
     call_kwargs: dict[str, Any] = {
-        "model": LLM_ENDPOINT,
+        "model": model,
         "messages": messages,
         "temperature": temperature,
         "timeout": eval_llm_timeout_seconds(),

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/optimizer.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/optimizer.py
@@ -2,8 +2,8 @@
 Metadata Optimizer — failure analysis, proposal generation, conflict detection.
 
 Analyzes evaluation failures (ASI) + current metadata snapshot to produce
-targeted metadata change proposals grouped by lever.  LLM calls use
-Databricks Claude Opus 4.6 via the Foundation Model API.
+targeted metadata change proposals grouped by lever. LLM calls use the
+configured Databricks model serving endpoint via the Foundation Model API.
 """
 
 from __future__ import annotations
@@ -51,7 +51,6 @@ from genie_space_optimizer.common.config import (
     LEVER_5_INSTRUCTION_PROMPT,
     LEVER_6_SQL_EXPRESSION_PROMPT,
     LEVER_NAMES,
-    LLM_ENDPOINT,
     LLM_MAX_RETRIES,
     LLM_TEMPERATURE,
     LOW_RISK_PATCHES,
@@ -72,6 +71,7 @@ from genie_space_optimizer.common.config import (
     STRATEGIST_TRIAGE_PROMPT,
     _LEVER_TO_PATCH_TYPE,
     format_mlflow_template,
+    get_llm_endpoint,
 )
 from genie_space_optimizer.common.genie_schema import ensure_join_spec_fields
 
@@ -225,8 +225,9 @@ def _traced_llm_call(
     from mlflow.entities import SpanEvent, SpanType
 
     with mlflow.start_span(name=span_name, span_type=SpanType.CHAIN) as span:
+        model = get_llm_endpoint()
         span.set_inputs({
-            "model": LLM_ENDPOINT,
+            "model": model,
             "temperature": temperature,
             "prompt_chars": len(prompt),
         })
@@ -248,7 +249,7 @@ def _traced_llm_call(
                     messages.append({"role": "system", "content": system_msg})
                 messages.append({"role": "user", "content": prompt})
                 call_kwargs: dict[str, Any] = {
-                    "model": LLM_ENDPOINT,
+                    "model": model,
                     "messages": messages,
                     "temperature": temperature,
                 }
@@ -8034,7 +8035,7 @@ def _call_llm_for_proposal(
     lever: int,
     w: WorkspaceClient | None = None,
 ) -> dict:
-    """Call Databricks Claude Opus 4.6 to generate proposal text.
+    """Call the configured Databricks LLM endpoint to generate proposal text.
 
     Returns ``{"proposed_value": str, "rationale": str}``.
     For lever 5 the response may also contain ``instruction_type``,

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/arbiter.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/arbiter.py
@@ -13,11 +13,11 @@ from typing import TYPE_CHECKING
 from mlflow.entities import Feedback
 from mlflow.genai.scorers import scorer
 
-from genie_space_optimizer.common.config import JUDGE_PROMPTS, LLM_ENDPOINT
+from genie_space_optimizer.common.config import JUDGE_PROMPTS, get_llm_endpoint
 from genie_space_optimizer.common.genie_client import resolve_sql, sanitize_sql
 from genie_space_optimizer.optimization.evaluation import (
     CODE_SOURCE,
-    LLM_SOURCE,
+    get_llm_source,
     build_temporal_note,
     slim_comparison,
     _call_llm_for_scoring,
@@ -403,7 +403,7 @@ def _make_arbiter_scorer(
                     extra={"llm_response": result, "comparison": slim_comparison(cmp)},
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
                 metadata=_meta,
             )
         except Exception as e:
@@ -415,7 +415,7 @@ def _make_arbiter_scorer(
                 "│ Prompt len:  %d chars\n"
                 "│ LLM endpoint: %s\n"
                 "└─────────────────────────────────────────────────────────────────────────",
-                question[:80], str(e)[:300], len(prompt), LLM_ENDPOINT,
+                question[:80], str(e)[:300], len(prompt), get_llm_endpoint(),
             )
             metadata = build_asi_metadata(
                 failure_type="other",
@@ -439,7 +439,7 @@ def _make_arbiter_scorer(
                     extra={"comparison": slim_comparison(cmp)},
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
                 metadata=metadata,
             )
 

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/completeness.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/completeness.py
@@ -12,11 +12,11 @@ from typing import TYPE_CHECKING
 from mlflow.entities import Feedback
 from mlflow.genai.scorers import scorer
 
-from genie_space_optimizer.common.config import LLM_ENDPOINT, scoring_v2_is_legacy
+from genie_space_optimizer.common.config import get_llm_endpoint, scoring_v2_is_legacy
 from genie_space_optimizer.common.genie_client import resolve_sql, sanitize_sql
 from genie_space_optimizer.optimization.evaluation import (
     CODE_SOURCE,
-    LLM_SOURCE,
+    get_llm_source,
     _call_llm_for_scoring,
     _extract_response_text,
     build_asi_metadata,
@@ -124,7 +124,7 @@ def _make_completeness_judge(w: WorkspaceClient, catalog: str, schema: str):
                 "│ Prompt len:  %d chars\n"
                 "│ LLM endpoint: %s\n"
                 "└─────────────────────────────────────────────────────────────────────────",
-                question[:80], str(e)[:300], len(prompt), LLM_ENDPOINT,
+                question[:80], str(e)[:300], len(prompt), get_llm_endpoint(),
             )
             metadata = build_asi_metadata(
                 failure_type="other",
@@ -147,7 +147,7 @@ def _make_completeness_judge(w: WorkspaceClient, catalog: str, schema: str):
                     metadata=metadata,
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
                 metadata=metadata,
             )
 
@@ -196,7 +196,7 @@ def _make_completeness_judge(w: WorkspaceClient, catalog: str, schema: str):
                     extra={"llm_response": result, "override_reason": "result_match"},
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
             )
 
         if result.get("complete", False):
@@ -210,7 +210,7 @@ def _make_completeness_judge(w: WorkspaceClient, catalog: str, schema: str):
                     extra={"llm_response": result},
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
             )
 
         base_confidence = 0.95
@@ -249,7 +249,7 @@ def _make_completeness_judge(w: WorkspaceClient, catalog: str, schema: str):
                 extra={"llm_response": result},
                 question_id=question_id,
             ),
-            source=LLM_SOURCE,
+            source=get_llm_source(),
             metadata=metadata,
         )
 

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/logical_accuracy.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/logical_accuracy.py
@@ -12,10 +12,10 @@ from typing import TYPE_CHECKING
 from mlflow.entities import Feedback
 from mlflow.genai.scorers import scorer
 
-from genie_space_optimizer.common.config import LLM_ENDPOINT
+from genie_space_optimizer.common.config import get_llm_endpoint
 from genie_space_optimizer.common.genie_client import resolve_sql, sanitize_sql
 from genie_space_optimizer.optimization.evaluation import (
-    LLM_SOURCE,
+    get_llm_source,
     _call_llm_for_scoring,
     _extract_response_text,
     build_asi_metadata,
@@ -103,7 +103,7 @@ def _make_logical_accuracy_judge(w: WorkspaceClient, catalog: str, schema: str):
                 "│ Prompt len:  %d chars\n"
                 "│ LLM endpoint: %s\n"
                 "└─────────────────────────────────────────────────────────────────────────",
-                question[:80], str(e)[:300], len(prompt), LLM_ENDPOINT,
+                question[:80], str(e)[:300], len(prompt), get_llm_endpoint(),
             )
             metadata = build_asi_metadata(
                 failure_type="other",
@@ -126,7 +126,7 @@ def _make_logical_accuracy_judge(w: WorkspaceClient, catalog: str, schema: str):
                     metadata=metadata,
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
                 metadata=metadata,
             )
 
@@ -165,7 +165,7 @@ def _make_logical_accuracy_judge(w: WorkspaceClient, catalog: str, schema: str):
                     extra={"llm_response": result, "override_reason": "result_match"},
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
             )
 
         if result.get("correct", False):
@@ -179,7 +179,7 @@ def _make_logical_accuracy_judge(w: WorkspaceClient, catalog: str, schema: str):
                     extra={"llm_response": result},
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
             )
 
         base_confidence = 0.95
@@ -224,7 +224,7 @@ def _make_logical_accuracy_judge(w: WorkspaceClient, catalog: str, schema: str):
                 extra={"llm_response": result},
                 question_id=question_id,
             ),
-            source=LLM_SOURCE,
+            source=get_llm_source(),
             metadata=metadata,
         )
 

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/response_quality.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/response_quality.py
@@ -16,10 +16,10 @@ from typing import TYPE_CHECKING
 from mlflow.entities import Feedback
 from mlflow.genai.scorers import scorer
 
-from genie_space_optimizer.common.config import LLM_ENDPOINT
+from genie_space_optimizer.common.config import get_llm_endpoint
 from genie_space_optimizer.common.genie_client import resolve_sql, sanitize_sql
 from genie_space_optimizer.optimization.evaluation import (
-    LLM_SOURCE,
+    get_llm_source,
     _call_llm_for_scoring,
     _extract_response_text,
     build_asi_metadata,
@@ -59,7 +59,7 @@ def _make_response_quality_judge(w: WorkspaceClient, catalog: str, schema: str):
                     rationale="No analysis text available from Genie.",
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
             )
 
         genie_sql = sanitize_sql(_extract_response_text(outputs))
@@ -114,7 +114,7 @@ def _make_response_quality_judge(w: WorkspaceClient, catalog: str, schema: str):
                 "│ Prompt len:  %d chars\n"
                 "│ LLM endpoint: %s\n"
                 "└─────────────────────────────────────────────────────────────────────────",
-                question[:80], str(e)[:300], len(prompt), LLM_ENDPOINT,
+                question[:80], str(e)[:300], len(prompt), get_llm_endpoint(),
             )
             metadata = build_asi_metadata(
                 failure_type="other",
@@ -137,7 +137,7 @@ def _make_response_quality_judge(w: WorkspaceClient, catalog: str, schema: str):
                     metadata=metadata,
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
                 metadata=metadata,
             )
 
@@ -166,7 +166,7 @@ def _make_response_quality_judge(w: WorkspaceClient, catalog: str, schema: str):
                     extra={"llm_response": result},
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
             )
 
         metadata = build_asi_metadata(
@@ -194,7 +194,7 @@ def _make_response_quality_judge(w: WorkspaceClient, catalog: str, schema: str):
                 extra={"llm_response": result},
                 question_id=question_id,
             ),
-            source=LLM_SOURCE,
+            source=get_llm_source(),
             metadata=metadata,
         )
 

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/schema_accuracy.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/schema_accuracy.py
@@ -12,10 +12,10 @@ from typing import TYPE_CHECKING
 from mlflow.entities import Feedback
 from mlflow.genai.scorers import scorer
 
-from genie_space_optimizer.common.config import LLM_ENDPOINT
+from genie_space_optimizer.common.config import get_llm_endpoint
 from genie_space_optimizer.common.genie_client import resolve_sql, sanitize_sql
 from genie_space_optimizer.optimization.evaluation import (
-    LLM_SOURCE,
+    get_llm_source,
     _call_llm_for_scoring,
     _extract_response_text,
     build_asi_metadata,
@@ -117,7 +117,7 @@ def _make_schema_accuracy_judge(w: WorkspaceClient, catalog: str, schema: str):
                 "│ Prompt len:  %d chars\n"
                 "│ LLM endpoint: %s\n"
                 "└─────────────────────────────────────────────────────────────────────────",
-                question[:80], str(e)[:300], len(prompt), LLM_ENDPOINT,
+                question[:80], str(e)[:300], len(prompt), get_llm_endpoint(),
             )
             metadata = build_asi_metadata(
                 failure_type="other",
@@ -140,7 +140,7 @@ def _make_schema_accuracy_judge(w: WorkspaceClient, catalog: str, schema: str):
                     metadata=metadata,
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
                 metadata=metadata,
             )
 
@@ -179,7 +179,7 @@ def _make_schema_accuracy_judge(w: WorkspaceClient, catalog: str, schema: str):
                     extra={"llm_response": result, "override_reason": "result_match"},
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
             )
 
         if result.get("correct", False):
@@ -193,7 +193,7 @@ def _make_schema_accuracy_judge(w: WorkspaceClient, catalog: str, schema: str):
                     extra={"llm_response": result},
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
             )
 
         base_confidence = 0.95
@@ -243,7 +243,7 @@ def _make_schema_accuracy_judge(w: WorkspaceClient, catalog: str, schema: str):
                 extra={"llm_response": result},
                 question_id=question_id,
             ),
-            source=LLM_SOURCE,
+            source=get_llm_source(),
             metadata=metadata,
         )
 

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/semantic_equivalence.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/semantic_equivalence.py
@@ -12,10 +12,10 @@ from typing import TYPE_CHECKING
 from mlflow.entities import Feedback
 from mlflow.genai.scorers import scorer
 
-from genie_space_optimizer.common.config import LLM_ENDPOINT
+from genie_space_optimizer.common.config import get_llm_endpoint
 from genie_space_optimizer.common.genie_client import resolve_sql, sanitize_sql
 from genie_space_optimizer.optimization.evaluation import (
-    LLM_SOURCE,
+    get_llm_source,
     _call_llm_for_scoring,
     _extract_response_text,
     build_asi_metadata,
@@ -100,7 +100,7 @@ def _make_semantic_equivalence_judge(w: WorkspaceClient, catalog: str, schema: s
                 "│ Prompt len:  %d chars\n"
                 "│ LLM endpoint: %s\n"
                 "└─────────────────────────────────────────────────────────────────────────",
-                question[:80], str(e)[:300], len(prompt), LLM_ENDPOINT,
+                question[:80], str(e)[:300], len(prompt), get_llm_endpoint(),
             )
             metadata = build_asi_metadata(
                 failure_type="other",
@@ -123,7 +123,7 @@ def _make_semantic_equivalence_judge(w: WorkspaceClient, catalog: str, schema: s
                     metadata=metadata,
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
                 metadata=metadata,
             )
 
@@ -172,7 +172,7 @@ def _make_semantic_equivalence_judge(w: WorkspaceClient, catalog: str, schema: s
                     extra={"llm_response": result, "override_reason": "result_match"},
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
             )
 
         if result.get("equivalent", False):
@@ -186,7 +186,7 @@ def _make_semantic_equivalence_judge(w: WorkspaceClient, catalog: str, schema: s
                     extra={"llm_response": result},
                     question_id=question_id,
                 ),
-                source=LLM_SOURCE,
+                source=get_llm_source(),
             )
 
         base_confidence = 0.95
@@ -225,7 +225,7 @@ def _make_semantic_equivalence_judge(w: WorkspaceClient, catalog: str, schema: s
                 extra={"llm_response": result},
                 question_id=question_id,
             ),
-            source=LLM_SOURCE,
+            source=get_llm_source(),
             metadata=metadata,
         )
 

--- a/packages/genie-space-optimizer/tests/unit/test_config_flags.py
+++ b/packages/genie-space-optimizer/tests/unit/test_config_flags.py
@@ -2,6 +2,30 @@
 from __future__ import annotations
 
 
+def test_llm_endpoint_default_is_sonnet(monkeypatch):
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    monkeypatch.delenv("GSO_LLM_ENDPOINT", raising=False)
+    from genie_space_optimizer.common.config import get_llm_endpoint
+
+    assert get_llm_endpoint() == "databricks-claude-sonnet-4-6"
+
+
+def test_llm_endpoint_uses_app_model(monkeypatch):
+    monkeypatch.delenv("GSO_LLM_ENDPOINT", raising=False)
+    monkeypatch.setenv("LLM_MODEL", "custom-model")
+    from genie_space_optimizer.common.config import get_llm_endpoint
+
+    assert get_llm_endpoint() == "custom-model"
+
+
+def test_llm_endpoint_gso_override_wins(monkeypatch):
+    monkeypatch.setenv("LLM_MODEL", "app-model")
+    monkeypatch.setenv("GSO_LLM_ENDPOINT", "gso-override")
+    from genie_space_optimizer.common.config import get_llm_endpoint
+
+    assert get_llm_endpoint() == "gso-override"
+
+
 def test_rca_ungrounded_records_enabled_default_on(monkeypatch):
     monkeypatch.delenv("GSO_RCA_UNGROUNDED_RECORDS_ENABLED", raising=False)
     from genie_space_optimizer.common.config import (

--- a/packages/genie-space-optimizer/tests/unit/test_llm_client.py
+++ b/packages/genie-space-optimizer/tests/unit/test_llm_client.py
@@ -135,9 +135,10 @@ class TestGetOpenaiClientShared:
 
 class TestCallLlm:
     @patch("genie_space_optimizer.optimization.llm_client.get_openai_client")
-    def test_returns_text_and_response(self, mock_get_client):
+    def test_returns_text_and_response(self, mock_get_client, monkeypatch):
         from genie_space_optimizer.optimization.llm_client import call_llm
 
+        monkeypatch.setenv("LLM_MODEL", "custom-endpoint")
         mock_client = MagicMock()
         mock_client.chat.completions.create.return_value = _make_openai_response('{"ok": true}')
         mock_get_client.return_value = mock_client
@@ -145,6 +146,7 @@ class TestCallLlm:
         text, resp = call_llm(None, messages=[{"role": "user", "content": "hi"}])
         assert text == '{"ok": true}'
         assert resp.usage.prompt_tokens == 100
+        assert mock_client.chat.completions.create.call_args.kwargs["model"] == "custom-endpoint"
 
     @patch("genie_space_optimizer.optimization.llm_client.get_openai_client")
     def test_retries_on_failure(self, mock_get_client):

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -122,6 +122,7 @@ for j in (jobs if isinstance(jobs, list) else jobs.get('jobs', [])):
     if (cd "$PROJECT_DIR" && databricks bundle destroy -t app \
         --var="catalog=${CATALOG}" \
         --var="warehouse_id=${WAREHOUSE_ID:-placeholder}" \
+        --var="llm_model=${LLM_MODEL}" \
         --profile "$PROFILE" --auto-approve 2>&1 | sed 's/^/  /'); then
         echo "  ✓ Bundle resources destroyed"
     else
@@ -320,6 +321,7 @@ set +e
 BUNDLE_OUTPUT=$(cd "$PROJECT_DIR" && databricks bundle deploy -t app \
     --var="catalog=$CATALOG" \
     --var="warehouse_id=$WAREHOUSE_ID" \
+    --var="llm_model=$LLM_MODEL" \
     --profile "$PROFILE" 2>&1)
 BUNDLE_EXIT=$?
 set -e
@@ -369,6 +371,7 @@ echo "  ✓ Job notebooks verified on workspace"
 JOB_ID=$(cd "$PROJECT_DIR" && databricks bundle summary -t app \
     --var="catalog=$CATALOG" \
     --var="warehouse_id=$WAREHOUSE_ID" \
+    --var="llm_model=$LLM_MODEL" \
     --profile "$PROFILE" -o json 2>/dev/null \
     | python3 -c "
 import sys, json
@@ -380,7 +383,7 @@ if [ -z "$JOB_ID" ]; then
     echo "  ✗ Bundle deployed but could not resolve job ID from Terraform state."
     echo ""
     echo "  Remediation:"
-    echo "    1. Run: databricks bundle summary -t app --profile $PROFILE -o json"
+    echo "    1. Run: databricks bundle summary -t app --var=\"catalog=$CATALOG\" --var=\"warehouse_id=$WAREHOUSE_ID\" --var=\"llm_model=$LLM_MODEL\" --profile $PROFILE -o json"
     echo "    2. Check if resources.jobs.gso-optimization-runner.id exists"
     echo "    3. Re-run: ./scripts/deploy.sh --update"
     exit 1

--- a/scripts/deploy_lib/gso_job.py
+++ b/scripts/deploy_lib/gso_job.py
@@ -41,6 +41,7 @@ JOB_PARAMETERS = {
     "experiment_name": "",
     "deploy_target": "",
     "warehouse_id": "",
+    "llm_model": "",
 }
 
 
@@ -127,6 +128,9 @@ def _task_payload(task_key: str, notebook_stem: str, depends_on: str | None, not
         "notebook_task": {
             "notebook_path": f"{notebooks_path}/{notebook_stem}",
             "source": "WORKSPACE",
+            "base_parameters": {
+                "llm_model": "{{job.parameters.llm_model}}",
+            },
         },
         "environment_key": "default",
         "timeout_seconds": 7200,
@@ -135,7 +139,7 @@ def _task_payload(task_key: str, notebook_stem: str, depends_on: str | None, not
     if depends_on:
         task["depends_on"] = [{"task_key": depends_on}]
     if task_key == "preflight":
-        task["notebook_task"]["base_parameters"] = {
+        task["notebook_task"]["base_parameters"].update({
             "run_id": "{{job.parameters.run_id}}",
             "space_id": "{{job.parameters.space_id}}",
             "domain": "{{job.parameters.domain}}",
@@ -147,7 +151,8 @@ def _task_payload(task_key: str, notebook_stem: str, depends_on: str | None, not
             "experiment_name": "{{job.parameters.experiment_name}}",
             "deploy_target": "{{job.parameters.deploy_target}}",
             "warehouse_id": "{{job.parameters.warehouse_id}}",
-        }
+            "llm_model": "{{job.parameters.llm_model}}",
+        })
     return task
 
 
@@ -174,7 +179,13 @@ def build_job_settings(cfg: InstallConfig, notebooks_path: str, wheel_path: str)
             "managed-by": "notebook-installer",
             "pattern": "persistent-dag",
         },
-        "parameters": [{"name": name, "default": default} for name, default in JOB_PARAMETERS.items()],
+        "parameters": [
+            {
+                "name": name,
+                "default": cfg.llm_model if name == "llm_model" else default,
+            }
+            for name, default in JOB_PARAMETERS.items()
+        ],
         "tasks": tasks,
         "environments": [
             {


### PR DESCRIPTION
Currently the app defaults to Claude Sonnet 4.6 during app deployment. However, GSO's model of choice is currently hardcoded to Claude Opus 4.6. This PR is to align both to the default model choice during installation. I hesitate to default the entire app to Opus 4.6 just yet. We should do a separate PR on model default choice. 