### PR TITLE
Remove Quick Fix from the Genie Workbench UI

### DIFF
--- a/frontend/src/components/how-it-works/PermissionDiagram.tsx
+++ b/frontend/src/components/how-it-works/PermissionDiagram.tsx
@@ -12,7 +12,6 @@ const rows: PermRow[] = [
   { operation: "Query Genie Spaces", identity: "user", note: "Falls back to SP if scope missing" },
   { operation: "Create Genie Space", identity: "user" },
   { operation: "IQ Scan (Score)", identity: "user" },
-  { operation: "Fix Agent (Apply Patches)", identity: "user" },
   { operation: "Trigger Auto-Optimize", identity: "both", note: "User triggers, SP executes job" },
   { operation: "Run Optimization Job", identity: "service-principal" },
   { operation: "Read/Write Lakebase", identity: "service-principal" },
@@ -35,7 +34,7 @@ export function PermissionDiagram({ className }: { className?: string }) {
             </div>
           </div>
           <div className="space-y-2">
-            {["Browse catalogs & schemas", "List & query Genie Spaces", "Create new Genie Spaces", "Score spaces (IQ Scan)", "Apply fixes (Fix Agent)", "Trigger optimization"].map(
+            {["Browse catalogs & schemas", "List & query Genie Spaces", "Create new Genie Spaces", "Score spaces (IQ Scan)", "Trigger optimization"].map(
               (item) => (
                 <div key={item} className="flex items-center gap-2 text-sm text-secondary">
                   <div className="h-1.5 w-1.5 rounded-full bg-accent shrink-0" />

--- a/frontend/src/pages/HowItWorks.tsx
+++ b/frontend/src/pages/HowItWorks.tsx
@@ -3,7 +3,6 @@ import {
   Sparkles,
   MessageSquarePlus,
   ShieldCheck,
-  Wrench,
   Zap,
   Lock,
   Layers,
@@ -52,7 +51,6 @@ const stages: Stage[] = [
   { id: "overview", label: "Overview", icon: <Sparkles className="h-4 w-4" />, color: ACCENT },
   { id: "create", label: "Create Agent", icon: <MessageSquarePlus className="h-4 w-4" />, color: CYAN },
   { id: "score", label: "IQ Scanner", icon: <ShieldCheck className="h-4 w-4" />, color: SUCCESS },
-  { id: "fix", label: "Quick Fix", icon: <Wrench className="h-4 w-4" />, color: WARNING },
   { id: "optimize", label: "Auto-Optimize", icon: <Zap className="h-4 w-4" />, color: DANGER },
   { id: "permissions", label: "Permissions", icon: <Lock className="h-4 w-4" />, color: INFO },
   { id: "architecture", label: "Architecture", icon: <Layers className="h-4 w-4" />, color: ACCENT },
@@ -86,7 +84,7 @@ export function HowItWorks() {
             How <span className="text-gradient">Genie Workbench</span> Works
           </h1>
           <p className="text-secondary text-base max-w-2xl mx-auto leading-relaxed">
-            Create, score, fix, and optimize your Genie Spaces — all from one intelligent interface.
+            Create, score, and optimize your Genie Spaces — all from one intelligent interface.
             Explore each capability below.
           </p>
         </div>
@@ -121,10 +119,9 @@ export function HowItWorks() {
         {activeStage === 0 && <OverviewContent />}
         {activeStage === 1 && <CreateAgentContent />}
         {activeStage === 2 && <IQScannerContent />}
-        {activeStage === 3 && <FixAgentContent />}
-        {activeStage === 4 && <AutoOptimizeContent />}
-        {activeStage === 5 && <PermissionsContent />}
-        {activeStage === 6 && <ArchitectureContent />}
+        {activeStage === 3 && <AutoOptimizeContent />}
+        {activeStage === 4 && <PermissionsContent />}
+        {activeStage === 5 && <ArchitectureContent />}
       </div>
 
       {/* Prev / Next navigation */}
@@ -165,10 +162,10 @@ function OverviewContent() {
     <div className="space-y-6">
       <div className="text-center mb-2">
         <h2 className="text-xl font-display font-bold text-primary">Everything You Need for Genie Spaces</h2>
-        <p className="text-sm text-muted mt-1">Four powerful capabilities, one streamlined workflow</p>
+        <p className="text-sm text-muted mt-1">Three core capabilities, one streamlined workflow</p>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 animate-stagger">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 animate-stagger">
         <FeatureCard
           icon={<MessageSquarePlus className="h-6 w-6" />}
           title="Create"
@@ -184,16 +181,9 @@ function OverviewContent() {
           glowColor={`${SUCCESS}15`}
         />
         <FeatureCard
-          icon={<Wrench className="h-6 w-6" />}
-          title="Quick Fix"
-          description="Turn scan findings into config-level fixes. Generates JSON patches and applies them directly — for bulk descriptions, use AI Generate in Unity Catalog."
-          accentColor={WARNING}
-          glowColor={`${WARNING}15`}
-        />
-        <FeatureCard
           icon={<Zap className="h-6 w-6" />}
           title="Optimize"
-          description="Run a full benchmark-driven optimization pipeline. Tests real questions, evaluates with 9 judges, and applies improvements automatically."
+          description="Run a benchmark-driven pipeline for spaces that fail checks or need accuracy validation. Tests real questions and applies validated improvements."
           accentColor={DANGER}
           glowColor={`${DANGER}15`}
         />
@@ -205,7 +195,6 @@ function OverviewContent() {
           steps={[
             { icon: <MessageSquarePlus className="h-5 w-5" />, label: "Create", description: "AI builds your space", color: CYAN },
             { icon: <ShieldCheck className="h-5 w-5" />, label: "Score", description: "12-check quality scan", color: SUCCESS },
-            { icon: <Wrench className="h-5 w-5" />, label: "Quick Fix", description: "Auto-apply patches", color: WARNING },
             { icon: <Zap className="h-5 w-5" />, label: "Optimize", description: "Benchmark & refine", color: DANGER },
             { icon: <CheckCircle2 className="h-5 w-5" />, label: "Trusted", description: "Production-ready", color: SUCCESS },
           ]}
@@ -386,101 +375,7 @@ function IQScannerContent() {
 }
 
 /* ================================================================
-   STAGE 3 — Fix Agent
-   ================================================================ */
-function FixAgentContent() {
-  const fixSteps: PipelineStep[] = [
-    { icon: <ShieldCheck className="h-5 w-5" />, label: "Scan Results", description: "Findings from IQ Scanner", color: SUCCESS },
-    { icon: <Search className="h-5 w-5" />, label: "Analyze", description: "LLM reviews each finding", color: INFO },
-    { icon: <FileText className="h-5 w-5" />, label: "Generate Patches", description: "JSON patches per finding", color: WARNING },
-    { icon: <Target className="h-5 w-5" />, label: "Validate", description: "Check patch safety", color: ACCENT },
-    { icon: <CheckCircle2 className="h-5 w-5" />, label: "Apply", description: "Write to Genie API", color: SUCCESS },
-  ]
-
-  return (
-    <div className="space-y-6">
-      <div className="text-center mb-2">
-        <h2 className="text-xl font-display font-bold text-primary">Quick Fix</h2>
-        <p className="text-sm text-muted mt-1">Automatically generates and applies config-level fixes from IQ Scanner findings</p>
-      </div>
-
-      <StageCard title="Scan → Fix Pipeline" icon={<Wrench className="h-4 w-4" />}>
-        <PipelineDiagram steps={fixSteps} />
-      </StageCard>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <StageCard title="What Gets Fixed" icon={<Target className="h-4 w-4" />}>
-          <div className="space-y-3">
-            {[
-              { label: "Missing instructions", fix: "Generates contextual instructions from table metadata" },
-              { label: "Missing sample questions", fix: "Creates realistic questions users would actually ask" },
-              { label: "Empty table descriptions", fix: "Writes descriptions from column analysis" },
-              { label: "Missing column docs", fix: "Documents columns based on names, types, and samples" },
-              { label: "Weak naming", fix: "Suggests clearer display names" },
-            ].map((item) => (
-              <div key={item.label} className="flex items-start gap-3">
-                <div className="mt-1 h-5 w-5 rounded bg-warning/10 flex items-center justify-center shrink-0">
-                  <Wrench className="h-3 w-3 text-warning" />
-                </div>
-                <div>
-                  <span className="text-sm font-medium text-primary">{item.label}</span>
-                  <p className="text-xs text-muted">{item.fix}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </StageCard>
-
-        <StageCard title="Patch Format" subtitle="JSON Patch (RFC 6902)" icon={<FileText className="h-4 w-4" />}>
-          <div className="rounded-lg bg-sunken border border-default p-4 font-mono text-xs leading-relaxed">
-            <div className="text-muted">{"// Example: adding a table description"}</div>
-            <div className="mt-2">
-              <span className="text-accent">{"{"}</span><br />
-              <span className="ml-3 text-cyan">"op"</span>: <span className="text-success">"replace"</span>,<br />
-              <span className="ml-3 text-cyan">"path"</span>: <span className="text-success">"/tables/0/description"</span>,<br />
-              <span className="ml-3 text-cyan">"value"</span>: <span className="text-success">"Daily sales transactions..."</span><br />
-              <span className="text-accent">{"}"}</span>
-            </div>
-          </div>
-          <div className="mt-4 space-y-2 text-sm">
-            <div className="flex items-center gap-2 text-secondary">
-              <CheckCircle2 className="h-4 w-4 text-success shrink-0" />
-              Patches run in parallel for speed
-            </div>
-            <div className="flex items-center gap-2 text-secondary">
-              <CheckCircle2 className="h-4 w-4 text-success shrink-0" />
-              ID sanitization prevents targeting errors
-            </div>
-            <div className="flex items-center gap-2 text-secondary">
-              <CheckCircle2 className="h-4 w-4 text-success shrink-0" />
-              Applied via Genie Space API — no file editing
-            </div>
-          </div>
-        </StageCard>
-      </div>
-
-      <StageCard title="Limitations" subtitle="What Quick Fix cannot do" icon={<AlertTriangle className="h-4 w-4" />}>
-        <div className="space-y-2.5 text-sm">
-          {[
-            "Column descriptions are capped at 50 per run — use AI Generate in Unity Catalog for bulk coverage",
-            "No data access — descriptions are inferred from column names only, not actual values",
-            "Generated example SQLs are untested — verify them in the Genie Space after applying",
-            "Cannot add or remove tables — manage data sources upstream in Unity Catalog",
-            "Optimization checks (11–12) require running the Optimize pipeline",
-          ].map((item) => (
-            <div key={item} className="flex items-start gap-2.5">
-              <XCircle className="h-4 w-4 text-red-400 shrink-0 mt-0.5" />
-              <span className="text-secondary">{item}</span>
-            </div>
-          ))}
-        </div>
-      </StageCard>
-    </div>
-  )
-}
-
-/* ================================================================
-   STAGE 4 — Auto-Optimize (GSO)
+   STAGE 3 — Auto-Optimize (GSO)
    ================================================================ */
 function AutoOptimizeContent() {
   const pipelineSteps: PipelineStep[] = [
@@ -493,18 +388,19 @@ function AutoOptimizeContent() {
   ]
 
   const levers = [
-    { name: "Instructions", desc: "Rewrite or enhance space-level instructions", color: ACCENT },
-    { name: "Table Descriptions", desc: "Improve how tables are described to the model", color: CYAN },
-    { name: "Column Descriptions", desc: "Add or refine column-level documentation", color: SUCCESS },
-    { name: "Sample Questions", desc: "Generate better example queries", color: WARNING },
-    { name: "Certified Queries", desc: "Add verified SQL for common questions", color: DANGER },
+    { name: "Tables & Columns", desc: "Improve table descriptions, column descriptions, and synonyms", color: CYAN },
+    { name: "Metric Views", desc: "Tune metric view column descriptions", color: INFO },
+    { name: "SQL Queries & Functions", desc: "Add or update example SQLs and remove underperforming TVFs", color: DANGER },
+    { name: "Join Specifications", desc: "Add, update, or remove join relationships", color: SUCCESS },
+    { name: "Text Instructions", desc: "Rewrite global routing instructions", color: ACCENT },
+    { name: "SQL Expressions", desc: "Add reusable measures, filters, and dimensions", color: WARNING },
   ]
 
   return (
     <div className="space-y-6">
       <div className="text-center mb-2">
         <h2 className="text-xl font-display font-bold text-primary">Auto-Optimize (GSO)</h2>
-        <p className="text-sm text-muted mt-1">Benchmark-driven optimization — tests real questions, picks what actually works</p>
+        <p className="text-sm text-muted mt-1">Benchmark-driven optimization for failed checks and measured accuracy — tests real questions and keeps what works</p>
       </div>
 
       <StageCard title="6-Task Pipeline" icon={<Zap className="h-4 w-4" />}>
@@ -512,7 +408,7 @@ function AutoOptimizeContent() {
       </StageCard>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <StageCard title="5 Lever Categories" subtitle="What gets tuned" icon={<Settings className="h-4 w-4" />}>
+        <StageCard title="6 Lever Categories" subtitle="What gets tuned" icon={<Settings className="h-4 w-4" />}>
           <div className="space-y-3">
             {levers.map((l) => (
               <div key={l.name} className="flex items-center gap-3">
@@ -555,7 +451,7 @@ function AutoOptimizeContent() {
 }
 
 /* ================================================================
-   STAGE 5 — Permissions
+   STAGE 4 — Permissions
    ================================================================ */
 function PermissionsContent() {
   return (
@@ -570,7 +466,7 @@ function PermissionsContent() {
 }
 
 /* ================================================================
-   STAGE 6 — Architecture
+   STAGE 5 — Architecture
    ================================================================ */
 function ArchitectureContent() {
   const layers = [

--- a/frontend/src/pages/IQScoreTab.tsx
+++ b/frontend/src/pages/IQScoreTab.tsx
@@ -299,7 +299,7 @@ export function IQScoreTab({ scanResult, isLoading, onScan, isScanning, onAction
                 {actionLabel}
               </button>
               {actionDescription && (
-                <p className="text-xs text-muted leading-relaxed sm:pt-0.5 max-w-3xl">
+                <p className="min-w-0 flex-1 text-xs text-muted leading-relaxed sm:pt-0.5">
                   {actionDescription}
                 </p>
               )}

--- a/frontend/src/pages/IQScoreTab.tsx
+++ b/frontend/src/pages/IQScoreTab.tsx
@@ -17,10 +17,11 @@ interface IQScoreTabProps {
   onAction?: () => void
   actionLabel?: string
   actionIcon?: React.ReactNode
+  actionDescription?: React.ReactNode
   onNavigateToOptimize?: () => void
 }
 
-export function IQScoreTab({ scanResult, isLoading, onScan, isScanning, onAction, actionLabel, actionIcon, onNavigateToOptimize }: IQScoreTabProps) {
+export function IQScoreTab({ scanResult, isLoading, onScan, isScanning, onAction, actionLabel, actionIcon, actionDescription, onNavigateToOptimize }: IQScoreTabProps) {
   const [checksExpanded, setChecksExpanded] = useState(false)
 
   if (isLoading) {
@@ -289,7 +290,7 @@ export function IQScoreTab({ scanResult, isLoading, onScan, isScanning, onAction
 
           {/* Single contextual action */}
           {onAction && actionLabel && (
-            <div className="mt-4 pt-4 border-t border-default flex items-start gap-4">
+            <div className="mt-4 pt-4 border-t border-default flex flex-col sm:flex-row sm:items-start gap-3 sm:gap-4">
               <button
                 onClick={onAction}
                 className="flex items-center gap-2 text-sm font-medium px-4 py-2.5 rounded-lg bg-accent text-white hover:bg-accent/90 transition-colors shrink-0"
@@ -297,12 +298,9 @@ export function IQScoreTab({ scanResult, isLoading, onScan, isScanning, onAction
                 {actionIcon}
                 {actionLabel}
               </button>
-              {actionLabel === "Quick Fix" && (
-                <p className="text-xs text-muted leading-relaxed pt-0.5">
-                  Fixes most config issues automatically. Column descriptions are limited to 50 per
-                  run and inferred from names — use <strong className="text-secondary">AI Generate</strong> in
-                  Unity Catalog for bulk or higher-accuracy results. Adding tables and optimization
-                  require separate workflows.
+              {actionDescription && (
+                <p className="text-xs text-muted leading-relaxed sm:pt-0.5 max-w-3xl">
+                  {actionDescription}
                 </p>
               )}
             </div>

--- a/frontend/src/pages/SpaceDetail.tsx
+++ b/frontend/src/pages/SpaceDetail.tsx
@@ -1,10 +1,9 @@
 /**
  * SpaceDetail - 3-tab detail view for a Genie Space.
  * Tabs: Score (default) | Optimize | History
- * Score tab includes an inline FixAgentPanel that slides in from the right.
  */
 import { useState, useEffect, useRef } from "react"
-import { ArrowLeft, Star, BarChart2, Clock, ExternalLink, Rocket, Play, Zap, ChevronDown, ChevronRight, Settings, RefreshCw } from "lucide-react"
+import { ArrowLeft, Star, BarChart2, Clock, ExternalLink, Rocket, Play, ChevronDown, ChevronRight, Settings, RefreshCw } from "lucide-react"
 import { scanSpace, toggleStar, getSpaceHistory, getSpaceDetail, getActiveRunForSpace } from "@/lib/api"
 import { MATURITY_COLORS, getOptimizationLabel } from "@/lib/utils"
 import type { ScanResult, ScoreHistoryPoint, OptimizationEvent } from "@/types"
@@ -13,7 +12,6 @@ import { HistoryTab } from "./HistoryTab"
 import { useAnalysis } from "@/hooks/useAnalysis"
 import { SpaceOverview } from "@/components/SpaceOverview"
 import { AutoOptimizeTab } from "@/components/auto-optimize/AutoOptimizeTab"
-import { FixAgentPanel } from "@/components/FixAgentPanel"
 
 type Tab = "score" | "optimize" | "history"
 const VALID_TABS: readonly string[] = ["score", "optimize", "history"]
@@ -37,8 +35,6 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
   const [hasActiveOptRun, setHasActiveOptRun] = useState(false)
   const [isLoadingScan, setIsLoadingScan] = useState(true)
   const [isLoadingHistory, setIsLoadingHistory] = useState(false)
-  const [fixPanelOpen, setFixPanelOpen] = useState(false)
-  const [fixFindings, setFixFindings] = useState<string[]>([])
 
   const [configExpanded, setConfigExpanded] = useState(false)
 
@@ -112,33 +108,7 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
     }
   }
 
-  // Findings that can't or shouldn't be fixed via config patches
-  const isFixable = (f: string) => {
-    const lower = f.toLowerCase()
-    return (
-      !lower.includes("optimization workflow") &&
-      !lower.includes("optimization accuracy") &&
-      !lower.includes("exceeds 120/space limit")  // informational — Genie ignores excess automatically
-    )
-  }
-
-  const openFixPanel = (sr: ScanResult) => {
-    const items: string[] = [
-      ...sr.findings.filter(isFixable),
-      ...(sr.warnings ?? []).filter(isFixable),
-    ]
-    if (items.length === 0) return
-    setFixFindings(items)
-    setFixPanelOpen(true)
-  }
-
-  const handleFixComplete = () => {
-    setFixPanelOpen(false)
-    setFixFindings([])
-    handleScan()
-  }
-
-  // Auto-scan on mount when requested (e.g., returning from fix flow)
+  // Auto-scan on mount when requested (e.g., returning from create/update flows)
   useEffect(() => {
     if (autoScan && !isScanning) {
       handleScan()
@@ -165,24 +135,31 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
   ]
 
   // Determine contextual action(s) based on scan results
-  const hasFixableItems = scanResult && (
-    scanResult.findings.some(isFixable) || (scanResult.warnings ?? []).some(isFixable)
+  const hasRemediationItems = scanResult && scanResult.maturity !== "Trusted" && (
+    scanResult.findings.length > 0 || (scanResult.warnings ?? []).length > 0
   )
   const maturity = scanResult?.maturity
-  let actionProps: { onAction?: () => void; actionLabel?: string; actionIcon?: React.ReactNode } = {}
-  if (hasFixableItems && scanResult) {
-    // Show "Quick Fix" whenever there are findings or warnings to address
-    actionProps = {
-      onAction: () => openFixPanel(scanResult),
-      actionLabel: "Quick Fix",
-      actionIcon: <Zap className="w-4 h-4" />,
-    }
-  } else if (maturity === "Ready to Optimize") {
-    // No issues/warnings left — show optimization CTA
+  let actionProps: { onAction?: () => void; actionLabel?: string; actionIcon?: React.ReactNode; actionDescription?: React.ReactNode } = {}
+  if (maturity === "Ready to Optimize") {
+    // No failing config checks left — show optimization CTA.
     actionProps = {
       onAction: () => setActiveTab("optimize"),
       actionLabel: "Run Optimization",
       actionIcon: <Rocket className="w-4 h-4" />,
+    }
+  } else if (hasRemediationItems) {
+    actionProps = {
+      onAction: () => setActiveTab("optimize"),
+      actionLabel: "Open Optimize",
+      actionIcon: <Rocket className="w-4 h-4" />,
+      actionDescription: (
+        <>
+          Auto-Optimize is the recommended path for improving spaces that fail IQ checks.
+          It runs benchmarks and applies validated configuration changes. Some issues, such
+          as missing data sources, permissions, or bulk Unity Catalog metadata gaps, may
+          still require manual setup.
+        </>
+      ),
     }
   }
 
@@ -324,27 +301,6 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
         )}
       </div>
 
-      {/* Fix agent modal overlay */}
-      {fixPanelOpen && fixFindings.length > 0 && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-          {/* Backdrop */}
-          <div
-            className="absolute inset-0 bg-black/40 backdrop-blur-sm"
-            onClick={() => { setFixPanelOpen(false); setFixFindings([]) }}
-          />
-          {/* Panel */}
-          <div className="relative w-full max-w-xl mx-4">
-            <FixAgentPanel
-              spaceId={spaceId}
-              displayName={displayName}
-              findings={fixFindings}
-              spaceConfig={state.spaceData ?? {}}
-              onClose={() => { setFixPanelOpen(false); setFixFindings([]) }}
-              onComplete={handleFixComplete}
-            />
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/pages/SpaceDetail.tsx
+++ b/frontend/src/pages/SpaceDetail.tsx
@@ -146,6 +146,13 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
       onAction: () => setActiveTab("optimize"),
       actionLabel: "Run Optimization",
       actionIcon: <Rocket className="w-4 h-4" />,
+      actionDescription: (
+        <>
+          This space passed the configuration checks. Auto-Optimize will benchmark real
+          questions, tune the selected levers, and apply only changes that improve the
+          measured result.
+        </>
+      ),
     }
   } else if (hasRemediationItems) {
     actionProps = {


### PR DESCRIPTION
## Summary
- Remove Quick Fix as a user-facing concept from the Score tab and the How It Works guide.
- Replace the Score-tab remediation CTA with `Open Optimize` so failed IQ checks route users into Auto-Optimize instead.
- Update the permissions diagram and workflow copy to reflect the simplified Create -> Score -> Optimize flow.

## Testing
- `npm run build` in `frontend/` passed.
- Targeted ESLint on the changed frontend files passed with no errors.
- Full repo lint still reports pre-existing unrelated errors in other frontend files.