### PR TITLE
Make IQ Scanner check #6 (data source count) configurable with safe-composition warning band

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -97,6 +97,21 @@ env:
   - name: GSO_WAREHOUSE_ID
     valueFrom: sql-warehouse
 
+  # ---------------------------------------------------------------------------
+  # IQ Scanner — check #6 (Data source count) thresholds (issue #212)
+  #
+  # Defaults preserve the original binary-12 behaviour. Override per deploy
+  # when a customer's space-design philosophy needs a different cap, or to
+  # enable the warning band for over-cap spaces with safe composition.
+  # See docs/05-iq-scanner.md for the full behaviour table.
+  # ---------------------------------------------------------------------------
+  # - name: GSO_MAX_SAFE_DATA_SOURCES
+  #   value: "12"              # soft cap; over this becomes warning or fail
+  # - name: GSO_MAX_WIDE_TABLE_COLUMNS
+  #   value: "60"              # raw tables above this column count are "wide"
+  # - name: GSO_MIN_METRIC_VIEW_RATIO
+  #   value: "0.5"             # metric-view ratio that qualifies for warning band
+
 # ---------------------------------------------------------------------------
 # Resources
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_scanner.py
+++ b/backend/tests/test_scanner.py
@@ -321,26 +321,26 @@ class TestJoinSpecs:
 
 class TestTableCount:
     def test_0_tables_fails(self, empty_space_data):
-        check = _check_by_label(calculate_score(empty_space_data), "Data source count 1-12")
+        check = _check_by_label(calculate_score(empty_space_data), "Data source count")
         assert check["passed"] is False
 
     def test_1_table_passes(self):
         tables = [{"name": "t", "columns": []}]
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
-        check = _check_by_label(calculate_score(data), "Data source count 1-12")
+        check = _check_by_label(calculate_score(data), "Data source count")
         assert check["passed"] is True
 
     def test_12_tables_passes(self):
         tables = [{"name": f"t{i}", "columns": []} for i in range(12)]
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
-        check = _check_by_label(calculate_score(data), "Data source count 1-12")
+        check = _check_by_label(calculate_score(data), "Data source count")
         assert check["passed"] is True
 
     def test_9_tables_clean_pass(self):
         tables = [{"name": f"t{i}", "columns": []} for i in range(9)]
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
         result = calculate_score(data)
-        check = _check_by_label(result, "Data source count 1-12")
+        check = _check_by_label(result, "Data source count")
         assert check["passed"] is True
         assert check["severity"] == "pass"
         assert not any("focused rooms" in w for w in result["warnings"])
@@ -348,16 +348,109 @@ class TestTableCount:
     def test_13_tables_fails(self):
         tables = [{"name": f"t{i}", "columns": []} for i in range(13)]
         data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
-        check = _check_by_label(calculate_score(data), "Data source count 1-12")
+        check = _check_by_label(calculate_score(data), "Data source count")
         assert check["passed"] is False
 
     def test_metric_views_counted_toward_limit(self):
-        """10 tables + 5 metric views = 15 data sources → fails."""
+        """10 tables + 5 metric views = 15 data sources, MV ratio 33% < 50% default → fails."""
         tables = [{"name": f"t{i}", "columns": []} for i in range(10)]
         mvs = [{"identifier": f"cat.sch.mv{i}"} for i in range(5)]
         data = {"data_sources": {"tables": tables, "metric_views": mvs}, "instructions": {}, "benchmarks": {}}
-        check = _check_by_label(calculate_score(data), "Data source count 1-12")
+        check = _check_by_label(calculate_score(data), "Data source count")
         assert check["passed"] is False
+
+
+class TestDataSourceCountSoftCap:
+    """Issue #212 — soft cap with warning band for safe over-cap composition."""
+
+    def test_over_cap_safe_composition_passes_with_warning(self):
+        """16 sources, 10 MVs (62%), 0 wide tables → passed=True, severity=warning."""
+        tables = [{"name": f"t{i}", "columns": [{"name": "c"}]} for i in range(6)]
+        mvs = [{"identifier": f"cat.sch.mv{i}"} for i in range(10)]
+        data = {"data_sources": {"tables": tables, "metric_views": mvs},
+                "instructions": {}, "benchmarks": {}}
+        result = calculate_score(data)
+        check = _check_by_label(result, "Data source count")
+        assert check["passed"] is True
+        assert check["severity"] == "warning"
+        assert any("composition is safe" in w for w in result["warnings"])
+        # advisory only — should NOT be in findings (Quick Fix should stay quiet)
+        assert not any("data sources" in f for f in result["findings"])
+
+    def test_over_cap_with_wide_raw_table_fails(self):
+        """16 sources, 10 MVs but one raw table has 80 columns → fail."""
+        tables = [{"name": f"t{i}", "columns": [{"name": f"c{j}"} for j in range(2)]}
+                  for i in range(5)]
+        # one wide table
+        tables.append({"name": "wide", "columns": [{"name": f"c{j}"} for j in range(80)]})
+        mvs = [{"identifier": f"cat.sch.mv{i}"} for i in range(10)]
+        data = {"data_sources": {"tables": tables, "metric_views": mvs},
+                "instructions": {}, "benchmarks": {}}
+        result = calculate_score(data)
+        check = _check_by_label(result, "Data source count")
+        assert check["passed"] is False
+        assert check["severity"] == "fail"
+        assert any("data sources" in f for f in result["findings"])
+
+    def test_over_cap_with_low_metric_view_ratio_fails(self):
+        """16 sources, 3 MVs (19%), no wide tables → fail (MV ratio below default 0.5)."""
+        tables = [{"name": f"t{i}", "columns": [{"name": "c"}]} for i in range(13)]
+        mvs = [{"identifier": f"cat.sch.mv{i}"} for i in range(3)]
+        data = {"data_sources": {"tables": tables, "metric_views": mvs},
+                "instructions": {}, "benchmarks": {}}
+        result = calculate_score(data)
+        check = _check_by_label(result, "Data source count")
+        assert check["passed"] is False
+        assert check["severity"] == "fail"
+
+    def test_warning_band_unblocks_ready_to_optimize(self):
+        """Maturity gates on `passed`, not `severity` — verify directly.
+
+        Constructing a fixture that satisfies all 10 production checks is brittle;
+        the point of this test is that ``get_maturity_label`` treats
+        ``passed=True, severity="warning"`` the same as a clean pass.
+        """
+        checks = [{"passed": True, "severity": "pass"}] * 5 + \
+                 [{"passed": True, "severity": "warning"}] + \
+                 [{"passed": True, "severity": "pass"}] * 4 + \
+                 [{"passed": False}, {"passed": False}]
+        assert get_maturity_label(checks) == "Ready to Optimize"
+
+        # And if the over-cap check were fail instead of warning, it would NOT unblock.
+        checks_fail = checks.copy()
+        checks_fail[5] = {"passed": False, "severity": "fail"}
+        assert get_maturity_label(checks_fail) == "Not Ready"
+
+    def test_env_var_raises_cap(self, monkeypatch):
+        """Raising GSO_MAX_SAFE_DATA_SOURCES makes a former fail into a clean pass."""
+        monkeypatch.setenv("GSO_MAX_SAFE_DATA_SOURCES", "20")
+        tables = [{"name": f"t{i}", "columns": []} for i in range(18)]
+        data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
+        check = _check_by_label(calculate_score(data), "Data source count")
+        assert check["passed"] is True
+        assert check["severity"] == "pass"
+
+    def test_env_var_lowers_cap(self, monkeypatch):
+        """Lowering GSO_MAX_SAFE_DATA_SOURCES makes a former pass into a fail."""
+        monkeypatch.setenv("GSO_MAX_SAFE_DATA_SOURCES", "4")
+        tables = [{"name": f"t{i}", "columns": []} for i in range(8)]
+        data = {"data_sources": {"tables": tables}, "instructions": {}, "benchmarks": {}}
+        check = _check_by_label(calculate_score(data), "Data source count")
+        assert check["passed"] is False
+        assert check["severity"] == "fail"
+
+    def test_env_var_lowers_wide_table_threshold(self, monkeypatch):
+        """Tightening GSO_MAX_WIDE_TABLE_COLUMNS pulls safe spaces into fail."""
+        monkeypatch.setenv("GSO_MAX_WIDE_TABLE_COLUMNS", "1")
+        tables = [{"name": f"t{i}", "columns": [{"name": "c1"}, {"name": "c2"}]}
+                  for i in range(6)]  # every table now counts as wide (2 > 1)
+        mvs = [{"identifier": f"cat.sch.mv{i}"} for i in range(10)]
+        data = {"data_sources": {"tables": tables, "metric_views": mvs},
+                "instructions": {}, "benchmarks": {}}
+        check = _check_by_label(calculate_score(data), "Data source count")
+        # MV ratio is still 62% (≥ 50%) but every raw table is "wide" → fail.
+        assert check["passed"] is False
+        assert check["severity"] == "fail"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/05-iq-scanner.md
+++ b/docs/05-iq-scanner.md
@@ -35,7 +35,7 @@ The first 10 checks evaluate configuration quality. The last 2 checks evaluate o
 | 3 | **Column descriptions** | ≥50% of columns have descriptions | Finding + next step to add descriptions |
 | 4 | **Text instructions** | Present and >50 characters total | Finding to add business context instructions |
 | 5 | **Join specifications** | At least 1 join spec (for multi-source spaces) | Finding to add join specs |
-| 6 | **Data source count 1–12** | Between 1 and 12 tables + metric views | Finding to reduce data sources or use multi-room architecture |
+| 6 | **Data source count** | At or below `GSO_MAX_SAFE_DATA_SOURCES` (default 12) → pass. Above → see "Soft cap" below; either passes with `severity="warning"` or fails | Finding (fail branch) or advisory warning (warning branch) — see below |
 | 7 | **8+ example SQLs** | At least 8 example question-SQL pairs | Finding to add more examples |
 | 8 | **SQL snippets** | At least 1 function, expression, measure, or filter | Finding to add SQL snippets |
 | 9 | **Entity/format matching** | At least 1 column with entity matching or format assistance | Finding to enable on categorical/date/number columns |
@@ -47,6 +47,29 @@ The first 10 checks evaluate configuration quality. The last 2 checks evaluate o
 |---|-------|--------------|------------|
 | 11 | **Optimization workflow completed** | A terminal optimization run exists (`CONVERGED`, `STALLED`, or `MAX_ITERATIONS`) | "Space has not been through the optimization workflow" |
 | 12 | **Optimization accuracy ≥ 85%** | Best accuracy from optimization is ≥ 0.85 | "Optimization accuracy is X% — target ≥ 85%" |
+
+## Soft cap on check #6 (configurable, issue #212)
+
+Check #6 ("Data source count") was a hard binary fail at >12 sources. As of
+issue #212, it has three outcomes and three env-var-driven thresholds, with
+defaults that preserve the original behaviour.
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `GSO_MAX_SAFE_DATA_SOURCES` | `12` | Soft cap on `len(tables) + len(metric_views)`. |
+| `GSO_MAX_WIDE_TABLE_COLUMNS` | `60` | A raw table with more columns than this is "wide". |
+| `GSO_MIN_METRIC_VIEW_RATIO` | `0.5` | Minimum `metric_views / total_sources` for the warning band. |
+
+Decision logic:
+
+1. `total_sources <= GSO_MAX_SAFE_DATA_SOURCES` → **pass** (`severity="pass"`).
+2. `total_sources > GSO_MAX_SAFE_DATA_SOURCES` AND `metric_view_ratio >= GSO_MIN_METRIC_VIEW_RATIO` AND no wide raw tables → **passed=True, severity="warning"**. The space can reach Ready to Optimize / Trusted because `get_maturity_label` gates on `passed`, not `severity`. An advisory entry is appended to `warnings` and `warning_next_steps`; nothing is added to `findings`, so Quick Fix is not triggered.
+3. `total_sources > GSO_MAX_SAFE_DATA_SOURCES` AND (wide raw tables OR low metric-view ratio) → **passed=False, severity="fail"** (original behaviour).
+
+This is a tactical landing under Epic #199 (Configurable Maturity Scoring). The
+three env vars will be absorbed into the registry refactor planned by that
+epic; the default behaviour stays identical for any deploy that does not set
+them.
 
 ## Severity Levels
 

--- a/frontend/src/pages/HowItWorks.tsx
+++ b/frontend/src/pages/HowItWorks.tsx
@@ -302,7 +302,7 @@ function IQScannerContent() {
     { name: "Column descriptions (≥50%)", desc: "50%+ of columns are documented" },
     { name: "Text instructions (>50 chars)", desc: "Business context and terminology explained" },
     { name: "Join specifications", desc: "Join paths defined for multi-source spaces" },
-    { name: "Data source count 1–12", desc: "Optimal number of tables and metric views for accuracy" },
+    { name: "Data source count", desc: "Configurable soft cap (default 12). Over-cap spaces with mostly metric views and no wide raw tables pass with a warning instead of failing." },
     { name: "8+ example SQLs", desc: "Diverse query patterns for the model to learn" },
     { name: "SQL snippets", desc: "Functions, expressions, measures, or filters defined" },
     { name: "Entity/format matching", desc: "Categorical and date/number columns annotated" },

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/common/config.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/common/config.py
@@ -687,6 +687,65 @@ def apply_quality_instructions_is_on() -> bool:
     return get_apply_quality_instructions_mode() == "on"
 
 
+# ── 3b. IQ Scanner — Configurable thresholds for check #6 ──────────────
+#
+# Check #6 ("Data source count") was a hard binary fail at >12 sources.
+# These three env vars soften it: spaces over the cap can pass with a
+# warning severity when composition signals are favourable (high
+# metric-view ratio, no wide raw tables). See docs/05-iq-scanner.md.
+#
+# Evaluated on every call so tests can ``monkeypatch.setenv`` without
+# reloading the module — same pattern as ``get_scoring_v2_mode``.
+#
+# Sub-task of Epic #199 (Configurable Maturity Scoring); these env vars
+# will be absorbed into the registry refactor planned by that epic.
+
+
+def get_max_safe_data_sources() -> int:
+    """Soft cap for IQ Scanner check #6. Default 12.
+
+    A space with at-or-below this many sources passes check #6 with
+    ``severity="pass"`` (current behaviour). Above this, see
+    ``get_min_metric_view_ratio`` and ``get_max_wide_table_columns``.
+    """
+    try:
+        return max(1, int(os.environ.get("GSO_MAX_SAFE_DATA_SOURCES", "12")))
+    except ValueError:
+        return 12
+
+
+def get_max_wide_table_columns() -> int:
+    """Column-count threshold above which a raw table is "wide". Default 60.
+
+    Used by IQ Scanner check #6: when ``total_sources`` exceeds the
+    soft cap, any raw table with more columns than this disqualifies
+    the space from the warning band — the over-cap result downgrades
+    to ``severity="fail"``.
+    """
+    try:
+        return max(1, int(os.environ.get("GSO_MAX_WIDE_TABLE_COLUMNS", "60")))
+    except ValueError:
+        return 60
+
+
+def get_min_metric_view_ratio() -> float:
+    """Minimum ``metric_views / total_sources`` ratio that qualifies an
+    over-cap space for the IQ Scanner check #6 warning band. Default 0.5.
+
+    Below this ratio, an over-cap space is treated as fail (current
+    behaviour). At-or-above this ratio AND no wide raw tables, the
+    check downgrades from fail to warning so the space can still reach
+    "Ready to Optimize" / "Trusted" maturity tiers.
+
+    Clamped to ``[0.0, 1.0]``.
+    """
+    try:
+        raw = float(os.environ.get("GSO_MIN_METRIC_VIEW_RATIO", "0.5"))
+    except ValueError:
+        return 0.5
+    return max(0.0, min(1.0, raw))
+
+
 # ── 4. LLM Configuration ──────────────────────────────────────────────
 
 LLM_ENDPOINT = "databricks-claude-opus-4-6"

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/iq_scan/scoring.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/iq_scan/scoring.py
@@ -13,6 +13,11 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime
 
+# NOTE: ``common.config`` re-exports symbols from this module, so a
+# top-level import would create a circular dependency at module-load.
+# Check #6's three configurable thresholds are imported lazily inside
+# ``calculate_score`` instead.
+
 
 # First 10 checks are config checks; the last 2 are optimization checks.
 CONFIG_CHECK_COUNT = 10
@@ -341,18 +346,90 @@ def calculate_score(space_data: dict, optimization_run: dict | None = None) -> d
         findings.append("No join specifications for multi-source space")
         next_steps.append("Add join specifications to help Genie correctly join your data sources")
 
-    # 6. Data source count 1-12 (Gap 10: adjusted from 1-10)
-    passed = 1 <= total_sources <= 12
-    detail = f"{total_sources} data source(s)"
-    severity = "pass"
-    if not passed and total_sources > 12:
-        detail += " — consider multi-room architecture"
-        severity = "fail"
-    _check(checks, "Data source count 1-12", passed, detail=detail, severity=severity)
-    if not passed and (tables or metric_views):
-        if total_sources > 12:
-            findings.append(f"{total_sources} data sources — more than 12 reduces Genie accuracy")
-            next_steps.append("Consider multi-room architecture or reducing to the most relevant 5-12 data sources")
+    # 6. Data source count — configurable soft cap (default 12).
+    #
+    # Default behaviour (no env vars set) matches the original binary
+    # check: pass at 1-12, fail above 12. Above the cap, the check
+    # downgrades from fail to a non-blocking *warning* when both
+    # composition signals are favourable:
+    #
+    #   - metric_view_ratio >= GSO_MIN_METRIC_VIEW_RATIO (default 0.5), AND
+    #   - no raw table has more columns than GSO_MAX_WIDE_TABLE_COLUMNS
+    #     (default 60).
+    #
+    # In that case the space can still reach Ready to Optimize / Trusted
+    # tiers because ``get_maturity_label`` gates on ``passed``, not
+    # ``severity``. See issue #212 / Epic #199.
+    #
+    # Lazy import to avoid the circular dependency described at the top
+    # of this module.
+    from genie_space_optimizer.common.config import (
+        get_max_safe_data_sources,
+        get_max_wide_table_columns,
+        get_min_metric_view_ratio,
+    )
+    max_safe_sources = get_max_safe_data_sources()
+    wide_col_threshold = get_max_wide_table_columns()
+    min_mv_ratio = get_min_metric_view_ratio()
+
+    if total_sources == 0:
+        # Check #1 already covers "no data sources"; nothing more to do here.
+        passed = False
+        _check(checks, "Data source count", passed,
+               detail="No data sources configured", severity="fail")
+    elif total_sources <= max_safe_sources:
+        passed = True
+        _check(checks, "Data source count", passed,
+               detail=f"{total_sources} data source(s)", severity="pass")
+    else:
+        # Over the soft cap — decide warning vs fail by composition.
+        mv_count = len(metric_views)
+        mv_ratio = mv_count / total_sources if total_sources else 0.0
+        wide_table_count = sum(
+            1 for t in tables
+            if len(t.get("columns", []) or []) + len(t.get("column_configs", []) or [])
+               > wide_col_threshold
+        )
+        safe_composition = mv_ratio >= min_mv_ratio and wide_table_count == 0
+        if safe_composition:
+            passed = True
+            severity = "warning"
+            detail = (
+                f"{total_sources} data sources "
+                f"({mv_count} metric views, {wide_table_count} wide tables) — "
+                f"over recommended cap {max_safe_sources} but composition is safe"
+            )
+            warnings.append(
+                f"{total_sources} data sources exceeds the recommended cap of "
+                f"{max_safe_sources}, but composition is safe "
+                f"(metric-view ratio {mv_ratio:.0%} ≥ {min_mv_ratio:.0%}, no raw "
+                f"tables above {wide_col_threshold} columns). This is advisory."
+            )
+            warning_next_steps.append(
+                "Monitor accuracy and consider multi-room architecture or further "
+                "metric-view consolidation if Genie SQL quality degrades."
+            )
+        else:
+            passed = False
+            severity = "fail"
+            detail = (
+                f"{total_sources} data sources "
+                f"(wide_tables={wide_table_count}, "
+                f"metric_view_ratio={mv_ratio:.0%}) — exceeds cap {max_safe_sources}"
+            )
+            findings.append(
+                f"{total_sources} data sources — more than the recommended "
+                f"cap of {max_safe_sources} reduces Genie accuracy, especially "
+                f"with {wide_table_count} wide raw table(s) and a metric-view "
+                f"ratio of {mv_ratio:.0%}."
+            )
+            next_steps.append(
+                f"Consider multi-room architecture, reducing to the most relevant "
+                f"{max_safe_sources} data sources, or converting wide raw tables "
+                f"into metric views as a semantic layer."
+            )
+        _check(checks, "Data source count", passed,
+               detail=detail, severity=severity)
 
     # 7. 8+ example SQLs (Gap 4: tightened from 5; Gap 9: usage_guidance check)
     example_sqls = space_data.get("instructions", {}).get("example_question_sqls", [])


### PR DESCRIPTION
Resolves #212. Sub-task of Epic #199.

Replaces the hard binary "1-12" data-source gate in IQ Scanner check #6 with three env-var-driven thresholds:

- `GSO_MAX_SAFE_DATA_SOURCES` (default 12) — the soft cap
- `GSO_MAX_WIDE_TABLE_COLUMNS` (default 60) — what counts as a wide raw table
- `GSO_MIN_METRIC_VIEW_RATIO` (default 0.5) — qualifier for the warning band

Defaults reproduce the original behaviour exactly. Above the cap, a space qualifies for `severity="warning"` (`passed=True`) when its composition is safe (metric-view ratio at-or-above min, zero wide raw tables); otherwise it stays at `severity="fail"` (`passed=False`) as before.

`get_maturity_label()` gates on `passed`, not `severity`, so the warning band correctly unblocks Ready-to-Optimize / Trusted tiers without weakening the ranking. The advisory text lands in `warnings` / `warning_next_steps` (not `findings`), so Quick Fix stays quiet for safe over-cap spaces.

Same warning-band pattern is already used by check #9 (entity matching).

The check label is renamed from "Data source count 1-12" to "Data source count" since the range is now configurable; historical scans persist the original label string so the history view is unaffected.

## Testing
- 7 new unit-test cases in `TestDataSourceCountSoftCap` (warning-band pass, wide-table fail, low-ratio fail, env-var raise/lower of all three knobs, maturity-unblock proof via `get_maturity_label` directly)
- All 87 `backend/tests/test_scanner.py` tests pass
- All 6 `backend/tests/test_scanner_parity.py` tests pass
- 437 passes / 0 failures across all scan/scor/check_6/data_source tests
