### PR TITLE
fix(gso): stop 9-judge eval SIGSEGV from concurrent Spark Connect

### DIFF
--- a/packages/genie-space-optimizer/src/genie_space_optimizer/common/spark_concurrency.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/common/spark_concurrency.py
@@ -1,0 +1,36 @@
+"""Process-wide serialization for shared Spark Connect access.
+
+The MLflow eval harness runs scorers across a thread pool (up to
+``scorer_workers`` threads). Spark Connect's client session and the
+underlying gRPC / pyarrow C extensions are not safe to drive from
+multiple threads concurrently — doing so can corrupt native state and
+crash the kernel with a SIGSEGV (exit code 139).
+
+Any code path that issues ``spark.sql(...)`` from within a thread-pooled
+scorer (or that could otherwise overlap with one) should wrap the call in
+``spark_serialized()`` so only one thread touches the shared session at a
+time. The lock is module-level (one per process), so it serializes across
+every caller that uses it.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from typing import Iterator
+
+# One lock per process. All callers share it, so Spark Connect is never
+# driven by two threads at once.
+_SPARK_LOCK = threading.Lock()
+
+
+@contextmanager
+def spark_serialized() -> Iterator[None]:
+    """Hold the global Spark lock for the duration of the block.
+
+    Wrap any ``spark.sql(...)`` / ``.toPandas()`` call that may run
+    concurrently with another Spark Connect call (e.g. inside a
+    thread-pooled scorer) to prevent native-extension crashes.
+    """
+    with _SPARK_LOCK:
+        yield

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
@@ -3644,7 +3644,11 @@ def _build_predict_and_scorers(
         _bl_instr_text = _bl_instr.get("text_instructions", "") if isinstance(_bl_instr, dict) else ""
     except Exception:
         _bl_instr_text = ""
-    scorers = make_all_scorers(w, spark, catalog, schema, instruction_context=_bl_instr_text)
+    scorers = make_all_scorers(
+        w, spark, catalog, schema,
+        instruction_context=_bl_instr_text,
+        warehouse_id=resolve_warehouse_id(""),
+    )
 
     _lines = [_section(banner_title, "-")]
     _lines.append(_kv("Space ID", space_id))
@@ -13313,7 +13317,11 @@ def _run_lever_loop(
     _parsed_space = config.get("_parsed_space", config)
     _instr_section = _parsed_space.get("instructions", {}) if isinstance(_parsed_space, dict) else {}
     _instr_text_for_scorers = _instr_section.get("text_instructions", "") if isinstance(_instr_section, dict) else ""
-    scorers = make_all_scorers(w, spark, catalog, schema, instruction_context=_instr_text_for_scorers)
+    scorers = make_all_scorers(
+        w, spark, catalog, schema,
+        instruction_context=_instr_text_for_scorers,
+        warehouse_id=resolve_warehouse_id(""),
+    )
     uc_schema = f"{catalog}.{schema}"
     metadata_snapshot = _parsed_space
     data_profile = (
@@ -23688,7 +23696,11 @@ def _run_finalize(
                     _ho_instr_text = _ho_instr.get("text_instructions", "") if isinstance(_ho_instr, dict) else ""
                 except Exception:
                     _ho_instr_text = ""
-                ho_scorers = make_all_scorers(w, spark, catalog, schema, instruction_context=_ho_instr_text)
+                ho_scorers = make_all_scorers(
+                    w, spark, catalog, schema,
+                    instruction_context=_ho_instr_text,
+                    warehouse_id=resolve_warehouse_id(""),
+                )
 
                 # Tier 4: v2 name — ``<run_short>/finalize/held_out``.
                 from genie_space_optimizer.common.mlflow_names import (

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/__init__.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/__init__.py
@@ -110,11 +110,15 @@ def make_all_scorers(
     schema: str,
     loaded_prompts: dict[str, str] | None = None,
     instruction_context: str = "",
+    warehouse_id: str = "",
 ) -> list:
     """Assemble all 9 scorers with bound runtime context.
 
     Returns an ordered list suitable for passing to
-    ``mlflow.genai.evaluate(scorers=...)``.
+    ``mlflow.genai.evaluate(scorers=...)``. When ``warehouse_id`` is set, the
+    syntax_validity scorer validates SQL via the thread-safe SQL Warehouse
+    Statement Execution API instead of the shared Spark Connect session,
+    avoiding native crashes under the scorer thread pool.
     """
     from .arbiter import _make_arbiter_scorer
     from .completeness import _make_completeness_judge
@@ -125,7 +129,7 @@ def make_all_scorers(
     from .syntax_validity import _make_syntax_validity_scorer
 
     scorers = [
-        _make_syntax_validity_scorer(spark, catalog, schema),
+        _make_syntax_validity_scorer(spark, catalog, schema, w=w, warehouse_id=warehouse_id),
         _make_schema_accuracy_judge(w, catalog, schema),
         _make_logical_accuracy_judge(w, catalog, schema),
         _make_semantic_equivalence_judge(w, catalog, schema),

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/syntax_validity.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/scorers/syntax_validity.py
@@ -19,8 +19,10 @@ from mlflow.genai.scorers import scorer
 
 from genie_space_optimizer.common.genie_client import sanitize_sql
 from genie_space_optimizer.common.logging_utils import quiet_grpc_logs
+from genie_space_optimizer.common.spark_concurrency import spark_serialized
 from genie_space_optimizer.optimization.evaluation import (
     CODE_SOURCE,
+    _execute_sql_via_warehouse,
     _extract_response_text,
     build_asi_metadata,
     format_asi_markdown,
@@ -30,6 +32,7 @@ from genie_space_optimizer.optimization.genie_eval_taxonomy import (
 )
 
 if TYPE_CHECKING:
+    from databricks.sdk import WorkspaceClient
     from pyspark.sql import SparkSession
 
 
@@ -70,8 +73,50 @@ def _parse_error_position(error_msg: str) -> tuple[int, int] | None:
         return None
 
 
-def _make_syntax_validity_scorer(spark: SparkSession, catalog: str, schema: str):
-    """Factory that binds ``spark`` into the scorer closure."""
+def _explain_sql(
+    sql: str,
+    spark: SparkSession,
+    catalog: str,
+    schema: str,
+    w: WorkspaceClient | None,
+    warehouse_id: str,
+) -> None:
+    """Run ``EXPLAIN sql`` to validate it, raising on any planning error.
+
+    Prefers the SQL Warehouse Statement Execution API (``w`` + ``warehouse_id``),
+    which is thread-safe because each call is an independent HTTP request with
+    no shared session. Falls back to Spark Connect under a process-wide lock so
+    concurrent scorer threads never drive the shared session at once (that
+    concurrency can crash the kernel with a native SIGSEGV).
+    """
+    if w is not None and warehouse_id:
+        explain_df = _execute_sql_via_warehouse(
+            w, warehouse_id, f"EXPLAIN {sql}", catalog=catalog, schema=schema
+        )
+        # The warehouse EXPLAIN returns a ``plan`` column instead of throwing
+        # on planning errors; surface those as a failure (mirrors the
+        # benchmark precheck in evaluation.py).
+        if not explain_df.empty and "plan" in explain_df.columns:
+            plan_text = "\n".join(str(v) for v in explain_df["plan"].tolist())
+            if "Error occurred during query planning" in plan_text:
+                raise RuntimeError(plan_text)
+        return
+
+    # No warehouse available: fall back to Spark Connect, serialized so two
+    # scorer threads can't drive the shared session concurrently.
+    with spark_serialized():
+        _set_sql_context(spark, catalog, schema)
+        spark.sql(f"EXPLAIN {sql}")
+
+
+def _make_syntax_validity_scorer(
+    spark: SparkSession,
+    catalog: str,
+    schema: str,
+    w: WorkspaceClient | None = None,
+    warehouse_id: str = "",
+):
+    """Factory that binds runtime context into the scorer closure."""
 
     @scorer
     def syntax_validity_scorer(inputs: dict, outputs: dict) -> Feedback:
@@ -145,10 +190,11 @@ def _make_syntax_validity_scorer(spark: SparkSession, catalog: str, schema: str)
         try:
             # Tier 3.7: wrap the EXPLAIN in ``quiet_grpc_logs`` so the
             # gRPC reattach retries don't print three copies of the same
-            # stack trace on every failing Genie SQL.
+            # stack trace on every failing Genie SQL. ``_explain_sql`` routes
+            # through the thread-safe warehouse API when available, falling
+            # back to a serialized Spark Connect call otherwise.
             with quiet_grpc_logs():
-                _set_sql_context(spark, catalog, schema)
-                spark.sql(f"EXPLAIN {sql}")
+                _explain_sql(sql, spark, catalog, schema, w, warehouse_id)
             pass_metadata = with_genie_equivalent_eval(
                 {},
                 judge_name="syntax_validity",


### PR DESCRIPTION
## Problem

GSO's `baseline_eval` task crashed the Python kernel with a fatal `SIGSEGV`
(exit code 139, "The Python kernel is unresponsive") during **Step 2b: Run
9-Judge Evaluation**. It was reproducible across serverless and dedicated
compute, and reducing `target_benchmark_count` did not help.

## Root cause

The 9-judge evaluation runs scorers across an 8-worker thread pool
(`scorer_workers=8`). Of the 9 judges, **only `syntax_validity` touches
Spark** — it called `spark.sql("USE CATALOG …")` / `spark.sql("EXPLAIN …")`
directly inside its scoring closure. Under the thread pool, up to 8 threads
drove the **shared Spark Connect session concurrently**, mutating session
state and issuing EXPLAINs over the same gRPC channel. Spark Connect's client
and the underlying gRPC / pyarrow C extensions are not safe under that
concurrency, producing a native segfault.

Evidence:
- **Preflight passes** (UC metadata + data profiling use Spark single-threaded);
  only Step 2b (8-way concurrent Spark) crashes.
- **Reproducible on any compute** — a code-level concurrency bug, not infra.
- **Reducing benchmark count doesn't help** — each row still fans out 8 scorers.
- The faulthandler dump shows the main thread merely parked in the watchdog
  `join`; the watchdog did not time out, so the crash came from inside the eval.

## Fix

1. **Route the scorer's EXPLAIN through the thread-safe SQL Warehouse Statement
   Execution API** (`_execute_sql_via_warehouse`) when a `warehouse_id` is
   available — each call is an independent HTTP request with no shared session.
   This mirrors the existing benchmark precheck, and surfaces planning errors
   from the returned `plan` column (the warehouse EXPLAIN returns a plan rather
   than throwing).
2. **Add a process-wide `spark_serialized()` lock** (`common/spark_concurrency.py`)
   as defense-in-depth for the no-warehouse fallback, so the shared Spark Connect
   session is never driven by two threads at once.

`EXPLAIN`'s full catalog-aware validation (unresolved columns/tables/functions,
not just syntax) is preserved — the warehouse path runs the same `EXPLAIN`.

### Changes
- `common/spark_concurrency.py` (new) — module-level lock + `spark_serialized()`.
- `scorers/syntax_validity.py` — new `_explain_sql()` helper (warehouse-first,
  serialized-Spark fallback); factory gains `w` + `warehouse_id`.
- `scorers/__init__.py` — `make_all_scorers(...)` gains `warehouse_id`, threaded
  into the syntax scorer.
- `harness.py` — all 3 `make_all_scorers` call sites pass
  `warehouse_id=resolve_warehouse_id("")`.

## Verification

No local dev server — verify by deploying (`./scripts/deploy.sh --update`) and
running an Auto-Optimize pass against a test Genie Space:
1. `baseline_eval` → **Step 2b** completes without the exit-139 SIGSEGV.
2. `syntax_validity` still emits yes/no verdicts — valid SQL → `yes`, SQL with a
   bad column/function → `no` with the right failure type (proves the
   warehouse-routed EXPLAIN does real catalog-aware validation).
3. Job log shows no concurrent Spark Connect EXPLAINs from the scorer pool.