### PR TITLE
fix(install): handle Lakebase soft-deleted project name reservation

### DIFF
--- a/notebooks/install.py
+++ b/notebooks/install.py
@@ -13,7 +13,7 @@
 # MAGIC **Optional:** Lakebase Autoscaling is recommended for persistent app state. Set `lakebase_mode` to `skip` only when ephemeral in-memory state is acceptable.
 
 # COMMAND ----------
-# MAGIC %pip install databricks-sdk==0.102.0 pyyaml==6.0.3 "psycopg[binary]==3.3.3" hatchling==1.29.0 uv-dynamic-versioning==0.13.0
+# MAGIC %pip install databricks-sdk==0.117.0 pyyaml==6.0.3 "psycopg[binary]==3.3.3" hatchling==1.29.0 uv-dynamic-versioning==0.13.0
 
 # COMMAND ----------
 dbutils.library.restartPython()
@@ -21,6 +21,10 @@ dbutils.library.restartPython()
 # COMMAND ----------
 from pathlib import Path
 import sys
+
+# Workspace Git folders (wsfs) reject __pycache__ writes; skip bytecode caching
+# so importing scripts.deploy_lib does not log wsfs errors.
+sys.dont_write_bytecode = True
 
 
 def path_exists(path: Path) -> bool:

--- a/packages/genie-space-optimizer/pyproject.toml
+++ b/packages/genie-space-optimizer/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "fastapi==0.135.2",
     "pydantic-settings==2.13.1",
     "uvicorn==0.42.0",
-    "databricks-sdk==0.102.0",
+    "databricks-sdk==0.117.0",
     "mlflow[databricks]==3.11.1",
     "openai==2.30.0",
     "litellm==1.82.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Unified Databricks Genie Space management platform"
 requires-python = ">=3.11"
 dependencies = [
-    "databricks-sdk==0.102.0",
+    "databricks-sdk==0.117.0",
     "pydantic==2.12.5",
     "python-dotenv==1.2.2",
     "mlflow==3.11.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ cycler==0.12.1
     # via matplotlib
 databricks-agents==1.9.3
     # via mlflow
-databricks-sdk==0.102.0
+databricks-sdk==0.117.0
     # via
     #   databricks-agents
     #   genie-space-optimizer
@@ -529,6 +529,7 @@ urllib3==2.6.3
     # via
     #   botocore
     #   databricks-agents
+    #   databricks-sdk
     #   docker
     #   requests
 uuid-utils==0.14.1

--- a/scripts/deploy_lib/lakebase.py
+++ b/scripts/deploy_lib/lakebase.py
@@ -5,6 +5,39 @@ from __future__ import annotations
 from .config import InstallConfig, LakebaseInfo
 
 
+def find_soft_deleted_project(w, project_name: str):
+    """Return the soft-deleted project holding this name, if any.
+
+    Deleted Lakebase projects enter a 7-day soft-deleted state during which
+    their IDs stay reserved, so a same-name create fails with ALREADY_EXISTS
+    while get_project keeps returning NotFound.
+    """
+    resource_name = f"projects/{project_name}"
+    for project in w.postgres.list_projects(show_deleted=True):
+        if project.name == resource_name and project.delete_time:
+            return project
+    return None
+
+
+def purge_soft_deleted_project(w, project_name: str) -> None:
+    resource_name = f"projects/{project_name}"
+    print(
+        f"Lakebase project '{project_name}' is soft-deleted and its name is reserved. "
+        "Permanently deleting it (data is unrecoverable) before recreating..."
+    )
+    try:
+        w.postgres.delete_project(name=resource_name, purge=True).wait()
+    except Exception as exc:
+        raise RuntimeError(
+            f"Could not purge soft-deleted Lakebase project '{project_name}': {exc}. "
+            "Purge it manually with "
+            f"`databricks postgres delete-project projects/{project_name} --purge`, "
+            "restore it with "
+            f"`databricks postgres undelete-project projects/{project_name}`, "
+            "or set the lakebase_project_name widget to a different name."
+        ) from exc
+
+
 def ensure_project(w, project_name: str) -> str:
     from databricks.sdk.errors import AlreadyExists, NotFound
     from databricks.sdk.service.postgres import Project, ProjectSpec
@@ -16,17 +49,34 @@ def ensure_project(w, project_name: str) -> str:
     except NotFound:
         pass
 
+    if find_soft_deleted_project(w, project_name):
+        purge_soft_deleted_project(w, project_name)
+
     try:
         op = w.postgres.create_project(
             project=Project(spec=ProjectSpec()),
             project_id=project_name,
         )
         op.wait()
-    except AlreadyExists:
-        pass
     except Exception as exc:
-        if "ALREADY_EXISTS" not in str(exc) and "already exists" not in str(exc).lower():
+        is_already_exists = isinstance(exc, AlreadyExists) or (
+            "ALREADY_EXISTS" in str(exc) or "already exists" in str(exc).lower()
+        )
+        if not is_already_exists:
             raise
+        # ALREADY_EXISTS after a NotFound get means the name is reserved by a
+        # project we cannot see (e.g., soft-deleted under another owner).
+        try:
+            w.postgres.get_project(name=resource_name)
+        except NotFound:
+            raise RuntimeError(
+                f"Lakebase project name '{project_name}' is reserved but the project "
+                "is not accessible — most likely a soft-deleted project owned by "
+                "another user (deleted project IDs are reserved for 7 days). "
+                "Ask its owner to purge it with "
+                f"`databricks postgres delete-project projects/{project_name} --purge`, "
+                "or set the lakebase_project_name widget to a different name."
+            ) from exc
     return resource_name
 
 

--- a/scripts/deploy_lib/lakebase.py
+++ b/scripts/deploy_lib/lakebase.py
@@ -44,13 +44,16 @@ def ensure_project(w, project_name: str) -> str:
 
     resource_name = f"projects/{project_name}"
     try:
-        w.postgres.get_project(name=resource_name)
-        return resource_name
-    except NotFound:
-        pass
-
-    if find_soft_deleted_project(w, project_name):
+        project = w.postgres.get_project(name=resource_name)
+        # get_project returns soft-deleted projects as if live (delete_time
+        # set); only their sub-resources (branches, roles) 404. Treat them as
+        # absent so the name gets purged and recreated.
+        if not project.delete_time:
+            return resource_name
         purge_soft_deleted_project(w, project_name)
+    except NotFound:
+        if find_soft_deleted_project(w, project_name):
+            purge_soft_deleted_project(w, project_name)
 
     try:
         op = w.postgres.create_project(
@@ -85,13 +88,19 @@ def require_project(w, project_name: str) -> str:
 
     resource_name = f"projects/{project_name}"
     try:
-        w.postgres.get_project(name=resource_name)
+        project = w.postgres.get_project(name=resource_name)
     except NotFound as exc:
         raise RuntimeError(
             f"Lakebase project '{project_name}' does not exist. "
             "Choose lakebase_mode=create to create a new project, or fix the "
             "lakebase_project_name widget to an existing project name."
         ) from exc
+    if project.delete_time:
+        raise RuntimeError(
+            f"Lakebase project '{project_name}' is soft-deleted. Restore it with "
+            f"`databricks postgres undelete-project projects/{project_name}`, or "
+            "choose lakebase_mode=create to purge and recreate it."
+        )
     return resource_name
 
 

--- a/scripts/deploy_lib/lakebase.py
+++ b/scripts/deploy_lib/lakebase.py
@@ -62,8 +62,10 @@ def ensure_project(w, project_name: str) -> str:
         )
         op.wait()
     except Exception as exc:
-        is_already_exists = isinstance(exc, AlreadyExists) or (
-            "ALREADY_EXISTS" in str(exc) or "already exists" in str(exc).lower()
+        is_already_exists = (
+            isinstance(exc, AlreadyExists)
+            or "ALREADY_EXISTS" in str(exc)
+            or "already exists" in str(exc).lower()
         )
         if not is_already_exists:
             raise

--- a/scripts/setup_lakebase.py
+++ b/scripts/setup_lakebase.py
@@ -20,6 +20,43 @@ def _get_client(profile: str):
     return WorkspaceClient(profile=profile)
 
 
+def _purge_soft_deleted_project(w, project_name: str) -> bool:
+    """Purge a soft-deleted project that still reserves this name, if any.
+
+    Deleted Lakebase projects enter a 7-day soft-deleted state during which
+    their IDs stay reserved, so a same-name create fails with ALREADY_EXISTS
+    while get_project keeps returning NotFound.
+    """
+    resource_name = f"projects/{project_name}"
+    soft_deleted = next(
+        (
+            p
+            for p in w.postgres.list_projects(show_deleted=True)
+            if p.name == resource_name and p.delete_time
+        ),
+        None,
+    )
+    if not soft_deleted:
+        return False
+
+    print(
+        f"  Project '{project_name}' is soft-deleted and its name is reserved. "
+        "Permanently deleting it (data is unrecoverable) before recreating..."
+    )
+    try:
+        w.postgres.delete_project(name=resource_name, purge=True).wait()
+    except Exception as e:
+        raise RuntimeError(
+            f"Could not purge soft-deleted Lakebase project '{project_name}': {e}. "
+            "Purge it manually with "
+            f"`databricks postgres delete-project projects/{project_name} --purge`, "
+            "restore it with "
+            f"`databricks postgres undelete-project projects/{project_name}`, "
+            "or pass a different --project-name."
+        ) from e
+    return True
+
+
 def _ensure_project(w, project_name: str) -> str:
     """Create or get the Lakebase Autoscaling project. Returns the project resource name."""
     from databricks.sdk.errors import NotFound, AlreadyExists
@@ -33,6 +70,8 @@ def _ensure_project(w, project_name: str) -> str:
     except NotFound:
         pass
 
+    _purge_soft_deleted_project(w, project_name)
+
     print(f"  Creating Lakebase project '{project_name}' (this may take 1-2 minutes)...")
     try:
         op = w.postgres.create_project(
@@ -42,13 +81,24 @@ def _ensure_project(w, project_name: str) -> str:
         # wait() blocks until the long-running operation completes
         op.wait()
         print(f"  ✓ Lakebase project ready: {project_name}")
-    except AlreadyExists:
-        print(f"  ✓ Project already exists: {project_name}")
     except Exception as e:
-        if "ALREADY_EXISTS" in str(e):
-            print(f"  ✓ Project already exists: {project_name}")
-        else:
+        is_already_exists = isinstance(e, AlreadyExists) or "ALREADY_EXISTS" in str(e)
+        if not is_already_exists:
             raise
+        # ALREADY_EXISTS after a NotFound get means the name is reserved by a
+        # project we cannot see (e.g., soft-deleted under another owner).
+        try:
+            w.postgres.get_project(name=resource_name)
+            print(f"  ✓ Project already exists: {project_name}")
+        except NotFound:
+            raise RuntimeError(
+                f"Lakebase project name '{project_name}' is reserved but the project "
+                "is not accessible — most likely a soft-deleted project owned by "
+                "another user (deleted project IDs are reserved for 7 days). "
+                "Ask its owner to purge it with "
+                f"`databricks postgres delete-project projects/{project_name} --purge`, "
+                "or pass a different --project-name."
+            ) from e
 
     return resource_name
 

--- a/scripts/setup_lakebase.py
+++ b/scripts/setup_lakebase.py
@@ -64,13 +64,16 @@ def _ensure_project(w, project_name: str) -> str:
 
     resource_name = f"projects/{project_name}"
     try:
-        w.postgres.get_project(name=resource_name)
-        print(f"  ✓ Lakebase project exists: {project_name}")
-        return resource_name
+        project = w.postgres.get_project(name=resource_name)
+        # get_project returns soft-deleted projects as if live (delete_time
+        # set); only their sub-resources (branches, roles) 404. Treat them as
+        # absent so the name gets purged and recreated.
+        if not project.delete_time:
+            print(f"  ✓ Lakebase project exists: {project_name}")
+            return resource_name
+        _purge_soft_deleted_project(w, project_name)
     except NotFound:
-        pass
-
-    _purge_soft_deleted_project(w, project_name)
+        _purge_soft_deleted_project(w, project_name)
 
     print(f"  Creating Lakebase project '{project_name}' (this may take 1-2 minutes)...")
     try:

--- a/uv.lock
+++ b/uv.lock
@@ -756,16 +756,17 @@ wheels = [
 
 [[package]]
 name = "databricks-sdk"
-version = "0.102.0"
+version = "0.117.0"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
     { name = "requests" },
+    { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/b3/41ff1c3afe092df9085e084e0dc81c45bca5ed65f7b60dc59df0ade43c76/databricks_sdk-0.102.0.tar.gz", hash = "sha256:8fa5f82317ee27cc46323c6e2543d2cfefb4468653f92ba558271043c6f72fb9", size = 887450, upload-time = "2026-03-19T08:15:54.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/86/fe149c523a9181deb3a90ae4e83708f54a6ee80c40ca392cf66ffdf425df/databricks_sdk-0.117.0.tar.gz", hash = "sha256:30a6fc21a8f9c4a41830c43332ae63b38c3679a83ac1bda4734ce7ced114faf1", size = 989404, upload-time = "2026-06-11T18:19:29.034Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/8c/d082bd5f72d7613524d5b35dfe1f71732b2246be2704fad68cd0e3fdd020/databricks_sdk-0.102.0-py3-none-any.whl", hash = "sha256:75d1253276ee8f3dd5e7b00d62594b7051838435e618f74a8570a6dbd723ec12", size = 838533, upload-time = "2026-03-19T08:15:52.248Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4d/3e28a5a1ae9aa42237bd0f4e6b34867b554c046a0f3e7c2ef49fa74800f6/databricks_sdk-0.117.0-py3-none-any.whl", hash = "sha256:bafd588c067ee353c905e56cd2eb37c7eca7a56a4c1b57656621b77208c32f86", size = 936854, upload-time = "2026-06-11T18:19:27.395Z" },
 ]
 
 [package.optional-dependencies]
@@ -1117,7 +1118,7 @@ dev = [
 requires-dist = [
     { name = "databricks-connect", marker = "python_full_version >= '3.12' and extra == 'spark'", specifier = "==18.0.3" },
     { name = "databricks-connect", marker = "python_full_version < '3.12' and extra == 'spark'", specifier = "==16.1.7" },
-    { name = "databricks-sdk", specifier = "==0.102.0" },
+    { name = "databricks-sdk", specifier = "==0.117.0" },
     { name = "fastapi", specifier = "==0.135.2" },
     { name = "litellm", specifier = "==1.82.6" },
     { name = "mlflow", extras = ["databricks"], specifier = "==3.11.1" },
@@ -1166,7 +1167,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = "==0.31.0" },
-    { name = "databricks-sdk", specifier = "==0.102.0" },
+    { name = "databricks-sdk", specifier = "==0.117.0" },
     { name = "fastapi", specifier = "==0.135.2" },
     { name = "genie-space-optimizer", editable = "packages/genie-space-optimizer" },
     { name = "httpx", specifier = "==0.28.1" },
@@ -1362,6 +1363,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -1370,6 +1372,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -1378,6 +1381,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1386,6 +1390,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -1394,6 +1399,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },


### PR DESCRIPTION
## Problem

`notebooks/install.py` failed with an opaque error when provisioning Lakebase, even with `lakebase_mode=create`:

```
NotFound: Project with name 'projects/genie-workbench-lakebase' not found
```

## Root cause

A May 2026 Lakebase platform change introduced project soft-delete: deleted projects enter a 7-day soft-deleted state and their IDs stay reserved ([Manage projects](https://docs.databricks.com/aws/en/oltp/projects/manage-projects)). The tricky part: `get_project` returns soft-deleted projects **as if live** (with `delete_time` populated) — only their sub-resources (branches, roles, databases) return 404. So `ensure_project` saw the GET succeed, assumed the project was usable, and the installer then died on `create_role` with the NotFound above.

## Fix

- `ensure_project` (`scripts/deploy_lib/lakebase.py` + `scripts/setup_lakebase.py`): check `delete_time` on the successful GET; if set, purge the soft-deleted project (with a loud, explicit log line) and recreate it. A `list_projects(show_deleted=True)` probe backs up the NotFound path, and ALREADY_EXISTS from create is no longer blindly swallowed — it re-verifies visibility and raises an actionable error (e.g., name reserved by another user's soft-deleted project).
- `require_project` (`lakebase_mode=existing`): reject soft-deleted projects with a clear restore-or-recreate message instead of passing them through to the same downstream 404.
- Bump `databricks-sdk` 0.102.0 → 0.117.0 (all pin locations + `uv.lock` + regenerated `requirements.txt`) — the soft-delete API surface (`list_projects(show_deleted=)`, `delete_project(purge=)`, `Project.delete_time`) only exists from 0.106.0. All existing postgres/sql call sites verified compatible.
- `notebooks/install.py`: `sys.dont_write_bytecode = True` to silence wsfs `__pycache__` errors when importing `scripts.deploy_lib` from a workspace Git folder.

## Verification

- Reproduced and fixed against a real workspace with a soft-deleted `genie-workbench-lakebase`: the fixed `ensure_project` detected `delete_time`, purged, and recreated; the previously-404ing branches endpoint resolved afterwards.
- Full E2E via `notebooks/install.py` with a freshly soft-deleted project: installer logged the purge, recreated the project, resolved the database, and applied grants (`grants=True`).
- `uv lock --check` passes; stubbed unit-style checks cover reuse-live, purge-soft-deleted, reserved-name error, and fresh-create paths.

This pull request and its description were written by Isaac.