### PR TITLE
Add "Export as bundle": parameterized DAB export for cross-workspace promotion

### DIFF
--- a/backend/routers/spaces.py
+++ b/backend/routers/spaces.py
@@ -1,17 +1,33 @@
 """Spaces router - org-wide Genie Space listing with IQ scoring."""
 
 import asyncio
+import io
 import logging
+import zipfile
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
-from fastapi.responses import StreamingResponse
+from fastapi.responses import StreamingResponse, Response
 import json
 
 from backend.routers._validators import SpaceId
 
-from backend.services.auth import get_workspace_client, get_service_principal_client
-from backend.services.genie_client import list_genie_spaces, is_scope_error
+from backend.services.auth import (
+    get_workspace_client,
+    get_service_principal_client,
+    get_databricks_host,
+)
+from backend.services.genie_client import (
+    list_genie_spaces,
+    is_scope_error,
+    get_genie_space,
+)
+from backend.services.bundle_exporter import (
+    export_space_as_bundle,
+    pick_source_prefix,
+    table_identifiers,
+    _slug,
+)
 from backend.services.lakebase import (
     get_latest_score,
     get_latest_scores_batch,
@@ -160,6 +176,99 @@ async def get_space_detail(space_id: SpaceId) -> dict:
     except Exception as e:
         logger.exception(f"Failed to get space detail: {e}")
         raise HTTPException(status_code=500, detail="Failed to get space detail")
+
+
+@router.get("/spaces/{space_id}/export-bundle")
+async def export_bundle(
+    space_id: SpaceId,
+    prod_host: Optional[str] = Query(None, description="Optional prod target workspace host"),
+    prod_catalog: Optional[str] = Query(None, description="Optional prod target catalog"),
+    prod_schema: Optional[str] = Query(None, description="Optional prod target schema"),
+    prod_warehouse_id: Optional[str] = Query(None, description="Optional prod target warehouse ID"),
+):
+    """Export a Genie Space as a downloadable, parameterized Databricks Asset Bundle.
+
+    Fetches the space's ``serialized_space`` (via the user's OBO identity, so the
+    user must be able to read the space), rewrites every ``catalog.schema``
+    reference to ``${var.catalog}.${var.schema}``, and returns a .zip containing
+    ``databricks.yml``, ``resources/<key>.genie_space.yml``, and a README.
+
+    The ``dev`` target points back at this workspace + the space's own catalog/
+    schema/warehouse. Supplying the ``prod_*`` query params adds a second
+    ``prod`` target for cross-workspace promotion.
+    """
+    try:
+        # Fetch raw space (title, description, warehouse_id, serialized_space).
+        # get_genie_space handles the OBO->SP scope fallback internally.
+        try:
+            raw = await asyncio.to_thread(get_genie_space, space_id)
+        except Exception as e:
+            if "403" in str(e) or "permission" in str(e).lower():
+                raise HTTPException(status_code=403, detail="You do not have access to this space")
+            raise
+
+        serialized = raw.get("serialized_space")
+        if not serialized:
+            raise HTTPException(status_code=422, detail="Space has no serialized_space to export")
+        space = json.loads(serialized)
+
+        title = raw.get("title") or space_id
+        description = raw.get("description") or ""
+
+        # Detect the source catalog.schema prefix to parameterize away.
+        prefix = pick_source_prefix(space)
+        if prefix is None:
+            raise HTTPException(
+                status_code=422,
+                detail="No three-part (catalog.schema.table) references found — nothing to parameterize",
+            )
+        source_catalog, source_schema = prefix
+
+        # Surface multi-prefix spaces as a header rather than failing: the
+        # dominant prefix is parameterized; others are left as-is (the general
+        # multi-catalog mapping case is a future enhancement).
+        from backend.services.bundle_exporter import detect_prefixes
+        distinct = list(detect_prefixes(space))
+        multi_prefix = len(distinct) > 1
+
+        dev_host = get_databricks_host()
+        dev_warehouse_id = str(raw.get("warehouse_id") or "")
+
+        files = export_space_as_bundle(
+            space,
+            title=title,
+            description=description,
+            source_catalog=source_catalog,
+            source_schema=source_schema,
+            dev_host=dev_host,
+            dev_warehouse_id=dev_warehouse_id,
+            prod_host=prod_host,
+            prod_catalog=prod_catalog,
+            prod_schema=prod_schema,
+            prod_warehouse_id=prod_warehouse_id,
+        )
+
+        # Build the zip in memory.
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for rel_path, contents in files.items():
+                zf.writestr(rel_path, contents)
+        buf.seek(0)
+
+        zip_name = f"{_slug(title, 'genie_space')}_bundle.zip"
+        headers = {
+            "Content-Disposition": f'attachment; filename="{zip_name}"',
+            "X-Export-Tables": str(len(table_identifiers(space))),
+            "X-Export-Source-Prefix": f"{source_catalog}.{source_schema}",
+            "X-Export-Multi-Prefix": "true" if multi_prefix else "false",
+        }
+        return Response(content=buf.getvalue(), media_type="application/zip", headers=headers)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Failed to export bundle for {space_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to export bundle")
 
 
 @router.post("/spaces/{space_id}/scan")

--- a/backend/services/bundle_exporter.py
+++ b/backend/services/bundle_exporter.py
@@ -1,0 +1,321 @@
+"""
+Genie Space -> Databricks Asset Bundle (DAB) exporter.
+
+Pure transform: given a fetched serialized_space (the dict returned by
+``get_serialized_space``) plus a little target metadata, produce the set of
+files that make up a deployable DAB whose data-source references are
+parameterized via ``${var.catalog}.${var.schema}``.
+
+The transform has no Databricks dependency — it takes a dict and returns
+``{relative_path: file_contents}``. The router layer is responsible for
+fetching the space and zipping the result.
+
+Why parameterize at all: Databricks Asset Bundles support Genie spaces
+(CLI v1.3.0+, ``engine: direct``). Variable interpolation (``${var.x}``)
+resolves inside an inlined ``serialized_space`` across every section — data
+sources, example SQL, join specs, and benchmarks — so the same space
+definition can deploy against a different catalog/schema in another
+workspace just by overriding the target's variables. That is what turns a
+hand-authored space into something promotable across environments.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import Counter
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_VAR_PREFIX = "${var.catalog}.${var.schema}"
+
+# Three-part dotted identifier, each part optionally backticked.
+_THREE_PART = re.compile(
+    r"`?([A-Za-z0-9_]+)`?\.`?([A-Za-z0-9_]+)`?\.`?([A-Za-z0-9_]+)`?"
+)
+
+
+# ── YAML emit ─────────────────────────────────────────────────────────────────
+# Emit a hand-authored-looking bundle: unquoted ${var.x} tokens, block-literal
+# style for multi-line SQL bodies. DABs interpolates the token regardless of
+# quoting, but unquoted reads cleanly and matches the proven artifact.
+
+
+class _BundleDumper(yaml.SafeDumper):
+    pass
+
+
+def _str_representer(dumper: yaml.Dumper, data: str):
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+_BundleDumper.add_representer(str, _str_representer)
+
+
+def _dump_yaml(obj: dict) -> str:
+    return yaml.dump(
+        obj,
+        Dumper=_BundleDumper,
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=True,
+        width=10_000,  # don't wrap long descriptions / SQL
+    )
+
+
+# ── Prefix detection ──────────────────────────────────────────────────────────
+
+
+def _walk_strings(obj):
+    """Yield every string leaf in a nested dict/list structure."""
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            yield from _walk_strings(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _walk_strings(item)
+
+
+def table_identifiers(space: dict) -> list[str]:
+    """Return all declared table / metric-view identifiers in the space."""
+    ds = space.get("data_sources", {}) or {}
+    out: list[str] = []
+    for key in ("tables", "metric_views"):
+        for t in ds.get(key, []) or []:
+            if isinstance(t, dict) and isinstance(t.get("identifier"), str):
+                out.append(t["identifier"])
+    return out
+
+
+def detect_prefixes(space: dict) -> Counter:
+    """Count ``(catalog, schema)`` prefixes across every three-part identifier
+    found anywhere in the space.
+
+    Detection is anchored on declared table identifiers first (authoritative),
+    then sweeps all string leaves to catch references buried in example SQL,
+    join specs, snippets, and benchmarks.
+    """
+    counts: Counter = Counter()
+    for ident in table_identifiers(space):
+        m = _THREE_PART.match(ident.strip())
+        if m:
+            counts[(m.group(1), m.group(2))] += 1
+    for s in _walk_strings(space):
+        for m in _THREE_PART.finditer(s):
+            counts[(m.group(1), m.group(2))] += 1
+    return counts
+
+
+def pick_source_prefix(space: dict) -> tuple[str, str] | None:
+    """Return the dominant ``(catalog, schema)`` prefix, or None if the space
+    has no three-part identifiers at all."""
+    counts = detect_prefixes(space)
+    if not counts:
+        return None
+    return counts.most_common(1)[0][0]
+
+
+# ── Parameterization ──────────────────────────────────────────────────────────
+
+
+def _parameterize_string(s: str, src_catalog: str, src_schema: str) -> str:
+    """Replace the source ``catalog.schema`` prefix with the var token, covering
+    both plain and per-part-backticked forms. Anchored on the known source
+    prefix so prose like ``a.b.c`` is never mangled."""
+    s = s.replace(f"{src_catalog}.{src_schema}.", f"{_VAR_PREFIX}.")
+    s = s.replace(f"`{src_catalog}`.`{src_schema}`.", f"{_VAR_PREFIX}.")
+    return s
+
+
+def _parameterize(obj, src_catalog: str, src_schema: str):
+    if isinstance(obj, str):
+        return _parameterize_string(obj, src_catalog, src_schema)
+    if isinstance(obj, dict):
+        return {k: _parameterize(v, src_catalog, src_schema) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_parameterize(v, src_catalog, src_schema) for v in obj]
+    return obj
+
+
+# ── Bundle assembly ────────────────────────────────────────────────────────────
+
+
+def _slug(text: str, fallback: str) -> str:
+    """Make a safe lowercase identifier for bundle/resource names."""
+    s = re.sub(r"[^a-z0-9_]+", "_", (text or "").lower()).strip("_")
+    return s or fallback
+
+
+def export_space_as_bundle(
+    serialized_space: dict,
+    *,
+    title: str,
+    description: str,
+    source_catalog: str,
+    source_schema: str,
+    dev_host: str,
+    dev_warehouse_id: str,
+    bundle_name: str | None = None,
+    resource_key: str | None = None,
+    prod_host: str | None = None,
+    prod_catalog: str | None = None,
+    prod_schema: str | None = None,
+    prod_warehouse_id: str | None = None,
+) -> dict[str, str]:
+    """Produce ``{relative_path: contents}`` for a parameterized Genie-space bundle.
+
+    The ``dev`` target points back at the source workspace/catalog/schema (the
+    dev-first assumption — you author in dev, then promote). A ``prod`` target
+    is emitted only when all ``prod_*`` arguments are supplied.
+
+    Args:
+        serialized_space: The space config dict (from ``get_serialized_space``).
+        title / description: Space metadata for the resource block.
+        source_catalog / source_schema: The prefix to parameterize away. Use
+            ``pick_source_prefix`` to detect this from the space.
+        dev_host / dev_warehouse_id: The source workspace + warehouse.
+        bundle_name / resource_key: Optional explicit names; derived from the
+            title when omitted.
+        prod_*: Optional second target for promotion.
+
+    Returns:
+        Mapping of bundle-relative path -> file contents (UTF-8 text).
+    """
+    bundle_name = bundle_name or _slug(title, "genie_space_bundle")
+    resource_key = resource_key or _slug(title, "genie_space")
+
+    parameterized = _parameterize(serialized_space, source_catalog, source_schema)
+
+    # ---- resources/<key>.genie_space.yml ----
+    resource_doc = {
+        "resources": {
+            "genie_spaces": {
+                resource_key: {
+                    "title": title,
+                    "description": description or "Exported by Genie Workbench",
+                    "warehouse_id": "${var.warehouse_id}",
+                    "serialized_space": parameterized,
+                }
+            }
+        }
+    }
+
+    # ---- databricks.yml ----
+    targets: dict = {
+        "dev": {
+            "default": True,
+            "mode": "development",
+            "workspace": {"host": dev_host},
+            "variables": {
+                "catalog": source_catalog,
+                "schema": source_schema,
+                "warehouse_id": str(dev_warehouse_id),
+            },
+        }
+    }
+    if prod_host and prod_catalog and prod_schema and prod_warehouse_id:
+        targets["prod"] = {
+            "mode": "production",
+            "workspace": {"host": prod_host},
+            "variables": {
+                "catalog": prod_catalog,
+                "schema": prod_schema,
+                "warehouse_id": str(prod_warehouse_id),
+            },
+        }
+
+    databricks_doc = {
+        "bundle": {
+            "name": bundle_name,
+            # Genie spaces require the direct deployment engine (CLI v1.3.0+).
+            "engine": "direct",
+        },
+        "include": ["resources/*.yml"],
+        "variables": {
+            "catalog": {"description": "Unity Catalog catalog holding the tables."},
+            "schema": {"description": "Schema (database) holding the tables."},
+            "warehouse_id": {
+                "description": "SQL warehouse Genie uses to run generated queries."
+            },
+        },
+        "targets": targets,
+    }
+
+    readme = _render_readme(
+        title=title,
+        has_prod=("prod" in targets),
+        n_tables=len(table_identifiers(serialized_space)),
+        source_catalog=source_catalog,
+        source_schema=source_schema,
+    )
+
+    return {
+        "databricks.yml": _dump_yaml(databricks_doc),
+        f"resources/{resource_key}.genie_space.yml": (
+            "# Generated by Genie Workbench — exported from a live Genie space.\n"
+            "# All catalog/schema references parameterized via "
+            "${var.catalog}.${var.schema}.\n"
+            + _dump_yaml(resource_doc)
+        ),
+        "README.md": readme,
+    }
+
+
+def _render_readme(
+    *,
+    title: str,
+    has_prod: bool,
+    n_tables: int,
+    source_catalog: str,
+    source_schema: str,
+) -> str:
+    prod_line = (
+        "databricks bundle deploy -t prod   # promote to the prod workspace\n"
+        if has_prod
+        else ""
+    )
+    prod_note = (
+        ""
+        if has_prod
+        else (
+            "\nThis export only defines a `dev` target (the source workspace). To "
+            "promote to another workspace, add a `prod` target block with that "
+            "workspace's `host`, `catalog`, `schema`, and `warehouse_id`.\n"
+        )
+    )
+    return f"""# {title} — Genie Space bundle
+
+Exported by **Genie Workbench**. This Databricks Asset Bundle deploys the Genie
+space **{title}** ({n_tables} source tables) and parameterizes every
+catalog/schema reference so the same definition can target different workspaces.
+
+The source space referenced `{source_catalog}.{source_schema}.*`; that prefix is
+now `${{var.catalog}}.${{var.schema}}.*`, overridden per target below.
+
+## Prerequisites
+- Databricks CLI **v1.3.0+** (`databricks --version`)
+- Auth configured for each target workspace (`databricks auth login`)
+
+## Deploy
+```bash
+databricks bundle validate -t dev
+databricks bundle deploy -t dev    # deploy to the source (dev) workspace
+{prod_line}```
+{prod_note}
+## How parameterization works
+`databricks.yml` declares `catalog`, `schema`, and `warehouse_id` variables.
+Each target overrides them, and DABs interpolates the tokens inside the inlined
+`serialized_space` — across data sources, example SQL, join specs, and
+benchmarks. Promoting to a new environment is just a new target block; the space
+definition itself never changes.
+
+> **Round-trip note:** edits made later in the Genie UI do **not** flow back into
+> this bundle. Re-export from Genie Workbench (or run `databricks bundle
+> generate`) to refresh it.
+"""

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -216,6 +216,50 @@ export async function scanSpace(spaceId: string): Promise<ScanResult> {
   )
 }
 
+/**
+ * Export a Genie Space as a parameterized Databricks Asset Bundle (.zip) and
+ * trigger a browser download. Returns lightweight metadata surfaced from the
+ * response headers (table count, detected source prefix, multi-prefix flag).
+ *
+ * Unlike the other helpers, this reads a binary blob rather than JSON, so it
+ * uses fetch directly instead of fetchWithTimeout.
+ */
+export async function exportSpaceBundle(spaceId: string): Promise<{
+  filename: string
+  tables: number
+  sourcePrefix: string
+  multiPrefix: boolean
+}> {
+  const response = await fetch(`${API_BASE}/spaces/${spaceId}/export-bundle`)
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: response.statusText }))
+    const message = extractDetailMessage(error.detail, "Failed to export bundle")
+    throw new ApiError(message, response.status)
+  }
+
+  // Derive the filename from Content-Disposition, fall back to a sane default.
+  const disposition = response.headers.get("Content-Disposition") || ""
+  const match = disposition.match(/filename="?([^"]+)"?/)
+  const filename = match ? match[1] : `${spaceId}_bundle.zip`
+
+  const tables = Number(response.headers.get("X-Export-Tables") || "0")
+  const sourcePrefix = response.headers.get("X-Export-Source-Prefix") || ""
+  const multiPrefix = response.headers.get("X-Export-Multi-Prefix") === "true"
+
+  // Trigger the download.
+  const blob = await response.blob()
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+
+  return { filename, tables, sourcePrefix, multiPrefix }
+}
+
 export async function getSpaceHistory(spaceId: string, days = 30): Promise<SpaceHistory> {
   return fetchWithTimeout<SpaceHistory>(
     `${API_BASE}/spaces/${spaceId}/history?days=${days}`,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -217,20 +217,47 @@ export async function scanSpace(spaceId: string): Promise<ScanResult> {
 }
 
 /**
+ * Optional prod-target details for {@link exportSpaceBundle}. When all four are
+ * supplied, the generated bundle gets a second `prod` target pointing at that
+ * workspace; when omitted, the bundle is dev-only (a code backup of the space).
+ */
+export interface ExportProdTarget {
+  prodHost?: string
+  prodCatalog?: string
+  prodSchema?: string
+  prodWarehouseId?: string
+}
+
+/**
  * Export a Genie Space as a parameterized Databricks Asset Bundle (.zip) and
  * trigger a browser download. Returns lightweight metadata surfaced from the
  * response headers (table count, detected source prefix, multi-prefix flag).
  *
+ * Pass `prod` details to bake a deployable `prod` target into the bundle's
+ * databricks.yml. The backend only emits the prod target when all four values
+ * are present, so partial input is treated as dev-only.
+ *
  * Unlike the other helpers, this reads a binary blob rather than JSON, so it
  * uses fetch directly instead of fetchWithTimeout.
  */
-export async function exportSpaceBundle(spaceId: string): Promise<{
+export async function exportSpaceBundle(
+  spaceId: string,
+  prod?: ExportProdTarget
+): Promise<{
   filename: string
   tables: number
   sourcePrefix: string
   multiPrefix: boolean
 }> {
-  const response = await fetch(`${API_BASE}/spaces/${spaceId}/export-bundle`)
+  const query = new URLSearchParams()
+  if (prod?.prodHost) query.set("prod_host", prod.prodHost)
+  if (prod?.prodCatalog) query.set("prod_catalog", prod.prodCatalog)
+  if (prod?.prodSchema) query.set("prod_schema", prod.prodSchema)
+  if (prod?.prodWarehouseId) query.set("prod_warehouse_id", prod.prodWarehouseId)
+  const qs = query.toString()
+  const response = await fetch(
+    `${API_BASE}/spaces/${spaceId}/export-bundle${qs ? `?${qs}` : ""}`
+  )
   if (!response.ok) {
     const error = await response.json().catch(() => ({ detail: response.statusText }))
     const message = extractDetailMessage(error.detail, "Failed to export bundle")

--- a/frontend/src/pages/SpaceDetail.tsx
+++ b/frontend/src/pages/SpaceDetail.tsx
@@ -12,6 +12,17 @@ import { HistoryTab } from "./HistoryTab"
 import { useAnalysis } from "@/hooks/useAnalysis"
 import { SpaceOverview } from "@/components/SpaceOverview"
 import { AutoOptimizeTab } from "@/components/auto-optimize/AutoOptimizeTab"
+import { Input } from "@/components/ui/input"
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog"
 
 type Tab = "score" | "optimize" | "history"
 const VALID_TABS: readonly string[] = ["score", "optimize", "history"]
@@ -40,6 +51,13 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
 
   const [isExporting, setIsExporting] = useState(false)
   const [exportMsg, setExportMsg] = useState<string | null>(null)
+  // Export-as-bundle dialog: collects the optional prod-target details that get
+  // baked into the bundle's databricks.yml. Leave them blank for a dev-only bundle.
+  const [exportDialogOpen, setExportDialogOpen] = useState(false)
+  const [prodHost, setProdHost] = useState("")
+  const [prodCatalog, setProdCatalog] = useState("")
+  const [prodSchema, setProdSchema] = useState("")
+  const [prodWarehouseId, setProdWarehouseId] = useState("")
 
   const { state, actions } = useAnalysis()
 
@@ -111,16 +129,39 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
     }
   }
 
+  // How many of the four prod fields are filled — used to enforce all-or-nothing.
+  const prodFilledCount = [prodHost, prodCatalog, prodSchema, prodWarehouseId].filter(
+    (v) => v.trim()
+  ).length
+
   const handleExportBundle = async () => {
+    // Prod target is all-or-nothing: either supply all four or none (dev-only).
+    if (prodFilledCount > 0 && prodFilledCount < 4) {
+      setExportMsg("Fill in all four prod fields, or leave them all blank for a dev-only bundle.")
+      return
+    }
     setIsExporting(true)
     setExportMsg(null)
     try {
-      const { tables, multiPrefix } = await exportSpaceBundle(spaceId)
+      const hasProd = prodFilledCount === 4
+      const { tables, multiPrefix } = await exportSpaceBundle(
+        spaceId,
+        hasProd
+          ? {
+              prodHost: prodHost.trim(),
+              prodCatalog: prodCatalog.trim(),
+              prodSchema: prodSchema.trim(),
+              prodWarehouseId: prodWarehouseId.trim(),
+            }
+          : undefined
+      )
+      const target = hasProd ? "dev + prod targets" : "dev target only"
       setExportMsg(
         multiPrefix
-          ? `Exported (${tables} tables). Note: multiple catalog.schema prefixes detected — only the dominant one was parameterized.`
-          : `Exported bundle (${tables} tables).`
+          ? `Exported ${tables} tables (${target}). Note: multiple catalog.schema prefixes detected — only the dominant one was parameterized.`
+          : `Exported ${tables} tables (${target}).`
       )
+      setExportDialogOpen(false)
     } catch (e) {
       console.error("Export failed:", e)
       setExportMsg(e instanceof Error ? `Export failed: ${e.message}` : "Export failed")
@@ -209,13 +250,12 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
               <Star className={`w-5 h-5 ${isStarred ? "fill-amber-400 text-amber-400" : "text-muted hover:text-amber-400"} transition-colors`} />
             </button>
             <button
-              onClick={handleExportBundle}
-              disabled={isExporting}
+              onClick={() => { setExportMsg(null); setExportDialogOpen(true) }}
               title="Export this space as a parameterized Databricks Asset Bundle (.zip)"
               className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-default text-sm font-medium text-secondary hover:bg-surface-secondary hover:text-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Package className="w-4 h-4" />
-              {isExporting ? "Exporting…" : "Export as bundle"}
+              Export as bundle
             </button>
           </div>
           {exportMsg && (
@@ -223,6 +263,82 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
               {exportMsg}
             </div>
           )}
+
+          <AlertDialog open={exportDialogOpen} onOpenChange={setExportDialogOpen}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Export as Databricks Asset Bundle</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Downloads a <code>.zip</code> bundle with every table reference
+                  parameterized as <code>${'{'}var.catalog{'}'}.${'{'}var.schema{'}'}</code>. The
+                  <strong> dev</strong> target points back at this workspace automatically.
+                  To make the bundle deployable to another workspace, fill in the
+                  <strong> prod</strong> target below — all four fields, or leave them all
+                  blank for a dev-only bundle.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+
+              <div className="mt-4 space-y-3 text-left">
+                <div>
+                  <label className="text-sm font-medium text-secondary">Prod workspace host</label>
+                  <Input
+                    value={prodHost}
+                    onChange={(e) => setProdHost(e.target.value)}
+                    placeholder="https://your-prod-workspace.cloud.databricks.com"
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="text-sm font-medium text-secondary">Prod catalog</label>
+                    <Input
+                      value={prodCatalog}
+                      onChange={(e) => setProdCatalog(e.target.value)}
+                      placeholder="prod_catalog"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium text-secondary">Prod schema</label>
+                    <Input
+                      value={prodSchema}
+                      onChange={(e) => setProdSchema(e.target.value)}
+                      placeholder="prod_schema"
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-secondary">Prod SQL warehouse ID</label>
+                  <Input
+                    value={prodWarehouseId}
+                    onChange={(e) => setProdWarehouseId(e.target.value)}
+                    placeholder="0123456789abcdef"
+                  />
+                </div>
+                <p className="text-xs text-muted">
+                  Genie Workbench runs in one workspace, so it can&apos;t deploy across a
+                  boundary itself. It generates the bundle; you deploy it to the prod
+                  workspace with <code>databricks bundle deploy -t prod</code> using your own
+                  prod credentials. The included README has the exact steps.
+                </p>
+              </div>
+
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={() => setExportDialogOpen(false)} disabled={isExporting}>
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleExportBundle}
+                  disabled={isExporting}
+                  className="disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isExporting
+                    ? "Exporting…"
+                    : prodFilledCount === 4
+                    ? "Export dev + prod bundle"
+                    : "Export dev-only bundle"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
           <div className="flex items-center gap-3 mt-2">
             {scanResult ? (
               <>

--- a/frontend/src/pages/SpaceDetail.tsx
+++ b/frontend/src/pages/SpaceDetail.tsx
@@ -3,8 +3,8 @@
  * Tabs: Score (default) | Optimize | History
  */
 import { useState, useEffect, useRef } from "react"
-import { ArrowLeft, Star, BarChart2, Clock, ExternalLink, Rocket, Play, ChevronDown, ChevronRight, Settings, RefreshCw } from "lucide-react"
-import { scanSpace, toggleStar, getSpaceHistory, getSpaceDetail, getActiveRunForSpace } from "@/lib/api"
+import { ArrowLeft, Star, BarChart2, Clock, ExternalLink, Rocket, Play, ChevronDown, ChevronRight, Settings, RefreshCw, Package } from "lucide-react"
+import { scanSpace, toggleStar, getSpaceHistory, getSpaceDetail, getActiveRunForSpace, exportSpaceBundle } from "@/lib/api"
 import { MATURITY_COLORS, getOptimizationLabel } from "@/lib/utils"
 import type { ScanResult, ScoreHistoryPoint, OptimizationEvent } from "@/types"
 import { IQScoreTab } from "./IQScoreTab"
@@ -37,6 +37,9 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
   const [isLoadingHistory, setIsLoadingHistory] = useState(false)
 
   const [configExpanded, setConfigExpanded] = useState(false)
+
+  const [isExporting, setIsExporting] = useState(false)
+  const [exportMsg, setExportMsg] = useState<string | null>(null)
 
   const { state, actions } = useAnalysis()
 
@@ -105,6 +108,25 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
       await toggleStar(spaceId, newStarred)
     } catch {
       setIsStarred(!newStarred)
+    }
+  }
+
+  const handleExportBundle = async () => {
+    setIsExporting(true)
+    setExportMsg(null)
+    try {
+      const { tables, multiPrefix } = await exportSpaceBundle(spaceId)
+      setExportMsg(
+        multiPrefix
+          ? `Exported (${tables} tables). Note: multiple catalog.schema prefixes detected — only the dominant one was parameterized.`
+          : `Exported bundle (${tables} tables).`
+      )
+    } catch (e) {
+      console.error("Export failed:", e)
+      setExportMsg(e instanceof Error ? `Export failed: ${e.message}` : "Export failed")
+    } finally {
+      setIsExporting(false)
+      setTimeout(() => setExportMsg(null), 8000)
     }
   }
 
@@ -186,7 +208,21 @@ export function SpaceDetail({ spaceId, displayName, spaceUrl, initialTab, autoSc
             <button onClick={handleToggleStar}>
               <Star className={`w-5 h-5 ${isStarred ? "fill-amber-400 text-amber-400" : "text-muted hover:text-amber-400"} transition-colors`} />
             </button>
+            <button
+              onClick={handleExportBundle}
+              disabled={isExporting}
+              title="Export this space as a parameterized Databricks Asset Bundle (.zip)"
+              className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-default text-sm font-medium text-secondary hover:bg-surface-secondary hover:text-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Package className="w-4 h-4" />
+              {isExporting ? "Exporting…" : "Export as bundle"}
+            </button>
           </div>
+          {exportMsg && (
+            <div className="mt-2 text-xs px-3 py-1.5 rounded-lg bg-surface-secondary text-secondary border border-default">
+              {exportMsg}
+            </div>
+          )}
           <div className="flex items-center gap-3 mt-2">
             {scanResult ? (
               <>


### PR DESCRIPTION
## Summary

Adds an **Export as bundle** action to the Space detail view that downloads a
Genie space as a parameterized **Databricks Asset Bundle** (`.zip`). Every table
reference is rewritten to `${var.catalog}.${var.schema}.<table>`, so the same
space definition can be deployed to another workspace by overriding the target's
variables.

This is the GitOps / cross-workspace promotion story for Genie spaces: author and
iterate in Workbench, then export a versionable, deployable bundle.

> **Opening as a draft to gather direction/feedback before investing further** —
> see "Open questions" below.

## What it does

Clicking **Export as bundle** opens a dialog:
- **Leave the prod fields blank** → a dev-only bundle (a code backup of the space,
  with a `dev` target pointing at the current workspace).
- **Fill in prod host / catalog / schema / warehouse** → the bundle also gets a
  `prod` target, making it deployable to that workspace with
  `databricks bundle deploy -t prod`.

The bundle contains `databricks.yml` (variables + dev/prod targets), an inlined
`resources/<key>.genie_space.yml` (the parameterized space), and a `README.md`
with deploy steps.

## Why inline `serialized_space` (the core technical choice)

`databricks bundle generate genie-space` emits the space to an external
`file_path:` JSON. **DAB variables (`${var.x}`) do not interpolate inside a
`file_path`-referenced JSON** — only inside config written directly in the YAML.
So this exporter inlines the definition under `serialized_space:` and tokenizes
the catalog/schema there, which is what makes parameterization actually resolve at
deploy time across all sections (data sources, example SQL, join specs, benchmarks).

## Changes (additive; +658 / −5 across 4 files)

| File | Change |
|---|---|
| `backend/services/bundle_exporter.py` | **New.** Pure transform (`serialized_space` dict → `{path: contents}`); prefix detection + recursive parameterization. No Databricks calls, no new deps (uses `yaml`). |
| `backend/routers/spaces.py` | **New endpoint** `GET /api/spaces/{id}/export-bundle` (OBO fetch → parameterize → stream zip). Optional `prod_*` query params. |
| `frontend/src/lib/api.ts` | `exportSpaceBundle()` helper (binary download + optional prod target). |
| `frontend/src/pages/SpaceDetail.tsx` | "Export as bundle" button + prod-target dialog (uses existing `AlertDialog`/`Input`). |

The 5 removed lines are import statements extended in place — all prior symbols
retained. No existing endpoint, function, dependency, or auth path is modified.

## Scope / boundary (by design)

Workbench runs in one workspace via OBO, which cannot cross workspace boundaries.
So this **generates** the bundle; the user **deploys** it to the target workspace
with their own credentials (`databricks auth login` + `bundle deploy -t prod`).
Cross-workspace deploy is intentionally out of the app.

## Testing

- Frontend `npm run build` (typecheck + Vite) passes.
- Deployed to a live Databricks App; exported a real space, deployed the resulting
  bundle to a second workspace, and confirmed the deployed space resolves 100% to
  the target catalog/schema and answers live Genie queries.

## Open questions for maintainers

1. **Prod-target capture** — is the in-dialog prompt the right UX, or should this
   integrate with a saved "environments" concept?
2. **Deploy facilitation** — should Workbench stop at the artifact (current), or
   grow a Git-commit / CI-trigger path (deploy via a CI service principal)?
3. **Target readiness** — the bundle parameterizes references but doesn't create
   target tables; worth a pre-deploy catalog/schema/table check?
4. **Multi-catalog spaces** — currently parameterizes the dominant prefix and warns
   on others; is full multi-prefix mapping in scope?

This pull request and its description were written by Isaac and tested end to end extensively by Arnav.
