### PR TITLE
Implement GSO V2 full-corpus counting

### DIFF
--- a/backend/routers/auto_optimize.py
+++ b/backend/routers/auto_optimize.py
@@ -449,11 +449,7 @@ def _build_step_summary(
     if step_name == "Finalization":
         score = f"{_finite(run_data.get('best_accuracy', 0)):.1f}" if run_data.get("best_accuracy") else "?"
         rep = f"{_finite(run_data.get('best_repeatability', 0)):.1f}" if run_data.get("best_repeatability") else "?"
-        summary = f"Final evaluation complete. Optimized score: {score}%. Repeatability: {rep}%"
-        ho_acc = _safe_float(detail.get("held_out_accuracy"))
-        if ho_acc is not None:
-            summary += f" Held-out: {ho_acc:.1f}%"
-        return summary
+        return f"Final evaluation complete. Optimized score: {score}%. Repeatability: {rep}%"
     if step_name == "Deploy":
         return f"Deployment {detail.get('status', 'pending')}"
     return None
@@ -631,7 +627,7 @@ def _build_step_io(
     if step_name == "Finalization":
         return (
             {"bestIteration": run_data.get("best_iteration")},
-            {"bestAccuracy": _safe_float(run_data.get("best_accuracy")), "repeatability": _safe_float(run_data.get("best_repeatability")), "convergenceReason": run_data.get("convergence_reason"), "ucModelName": detail.get("uc_model_name") or None, "ucModelVersion": detail.get("uc_model_version") or None, "ucChampionPromoted": detail.get("uc_champion_promoted", False), "heldOutAccuracy": _safe_float(detail.get("held_out_accuracy")), "heldOutCount": _safe_int(detail.get("held_out_count")), "trainAccuracy": _safe_float(detail.get("train_accuracy")), "heldOutDeltaPp": _safe_float(detail.get("delta_pp")), "stageEvents": timeline},
+            {"bestAccuracy": _safe_float(run_data.get("best_accuracy")), "repeatability": _safe_float(run_data.get("best_repeatability")), "convergenceReason": run_data.get("convergence_reason"), "ucModelName": detail.get("uc_model_name") or None, "ucModelVersion": detail.get("uc_model_version") or None, "ucChampionPromoted": detail.get("uc_champion_promoted", False), "stageEvents": timeline},
         )
 
     if step_name == "Deploy":
@@ -1072,7 +1068,7 @@ _STEP_DEFINITIONS = [
     {"stepNumber": 2, "name": "Baseline Evaluation",   "stage_prefixes": ["BASELINE_EVAL"]},
     {"stepNumber": 3, "name": "Proactive Enrichment",  "stage_prefixes": ["ENRICHMENT", "PROMPT_MATCH", "DESCRIPTION_ENRICHMENT", "JOIN_DISCOVERY", "SPACE_METADATA", "INSTRUCTION_SEED", "PROACTIVE_INSTRUCTION", "EXAMPLE_SQL", "POST_ENRICHMENT_EVAL"]},
     {"stepNumber": 4, "name": "Adaptive Optimization", "stage_prefixes": ["LEVER_", "AG_"]},
-    {"stepNumber": 5, "name": "Finalization",          "stage_prefixes": ["FINALIZE", "REPEATABILITY", "HELD_OUT", "COMPLETE"]},
+    {"stepNumber": 5, "name": "Finalization",          "stage_prefixes": ["FINALIZE", "REPEATABILITY", "COMPLETE"]},
     {"stepNumber": 6, "name": "Deploy",                "stage_prefixes": ["DEPLOY", "UC_OBO_WRITE"]},
 ]
 
@@ -1562,11 +1558,15 @@ async def list_iterations(run_id: RunId):
         num_correct = it["correct_count"]
         num_questions = it["total_questions"]
         evaluated = it.get("evaluated_count")
+        is_official = bool(it.get("eval_run_id") or it.get("eval_run_status"))
         it["num_correct"] = num_correct
         it["num_questions"] = num_questions
-        # num_done = questions actually evaluated (engine writes this as
-        # evaluated_count = result.num_done or num_questions).
-        it["num_done"] = evaluated if evaluated is not None else num_questions
+        # V2 official rows report progress against the full benchmark corpus.
+        # Legacy rows without eval-run metadata keep the older evaluated_count
+        # fallback for back-compat.
+        it["num_done"] = num_questions if is_official else (
+            evaluated if evaluated is not None else num_questions
+        )
         it["num_needs_review"] = (
             _safe_int(it.get("num_needs_review"))
             if it.get("num_needs_review") is not None else None
@@ -1578,7 +1578,6 @@ async def list_iterations(run_id: RunId):
         # legacy correct_count / evaluated_count denominator (which differs on
         # a partial run where num_done < num_questions). Legacy rows keep their
         # stored overall_accuracy untouched.
-        is_official = bool(it.get("eval_run_id") or it.get("eval_run_status"))
         if is_official and num_questions > 0:
             it["overall_accuracy"] = round(100.0 * num_correct / num_questions, 2)
 

--- a/backend/tests/test_auto_optimize_router.py
+++ b/backend/tests/test_auto_optimize_router.py
@@ -785,7 +785,7 @@ def test_baseline_step_summary_is_assessment_centric_no_judges() -> None:
 
 
 def test_iterations_official_accuracy_uses_num_questions_not_evaluated_count(monkeypatch) -> None:
-    """On a PARTIAL official run (num_done < num_questions), the headline
+    """On an official run with legacy evaluated_count < total_questions, the headline
     accuracy must be num_correct / num_questions — NOT correct / evaluated_count
     (which would inflate). Legacy rows keep their stored overall_accuracy."""
     monkeypatch.setenv("GSO_CATALOG", "main")
@@ -795,7 +795,8 @@ def test_iterations_official_accuracy_uses_num_questions_not_evaluated_count(mon
     from backend.routers import auto_optimize
 
     delta_rows = [
-        # Official, partial: 8 correct, only 8 done, but 10 total questions.
+        # Official V2: 8 correct and 10 total questions. A stale evaluated_count
+        # must not make the API/UI report an 8-question assessed subset.
         # Stored overall_accuracy is the stale 100.0; the endpoint must
         # recompute 8/10 = 80.0 from the official counts.
         {
@@ -833,6 +834,44 @@ def test_iterations_official_accuracy_uses_num_questions_not_evaluated_count(mon
     assert out[0]["overall_accuracy"] == 80.0
     assert out[0]["num_correct"] == 8
     assert out[0]["num_questions"] == 10
-    assert out[0]["num_done"] == 8
+    assert out[0]["num_done"] == 10
     # Legacy row: stored value preserved (no official recompute).
     assert out[1]["overall_accuracy"] == 88.0
+
+
+def test_iterations_official_v2_reports_full_30_question_corpus(monkeypatch) -> None:
+    """Regression guard for the removed split: a 30-question official row with
+    stale evaluated_count=25 must report 30 assessed questions."""
+    monkeypatch.setenv("GSO_CATALOG", "main")
+    monkeypatch.setenv("GSO_JOB_ID", "12345")
+    monkeypatch.setenv("GSO_WAREHOUSE_ID", "wh-test")
+
+    from backend.routers import auto_optimize
+
+    delta_rows = [
+        {
+            "iteration": 0, "eval_scope": "full", "overall_accuracy": 96.0,
+            "total_questions": 30, "correct_count": 24, "evaluated_count": 25,
+            "excluded_count": 0, "thresholds_met": True, "rolled_back": False,
+            "scores_json": "{}", "num_needs_review": 0, "lever": None,
+            "eval_run_id": "er-30", "eval_run_status": "DONE",
+        },
+    ]
+
+    async def fake_lakebase(_run_id):
+        return []
+
+    monkeypatch.setattr(auto_optimize.gso_lakebase, "load_gso_iterations", fake_lakebase)
+    monkeypatch.setattr(auto_optimize, "_select_iterations_delta", lambda _rid: [dict(r) for r in delta_rows])
+
+    app = FastAPI()
+    app.include_router(auto_optimize.router)
+    client = TestClient(app)
+
+    resp = client.get("/api/auto-optimize/runs/12345678-1234-1234-1234-1234567890ab/iterations")
+    assert resp.status_code == 200
+    row = resp.json()[0]
+
+    assert row["num_questions"] == 30
+    assert row["num_done"] == 30
+    assert row["overall_accuracy"] == 80.0

--- a/frontend/src/components/auto-optimize/AutoOptimizeTab.tsx
+++ b/frontend/src/components/auto-optimize/AutoOptimizeTab.tsx
@@ -130,7 +130,7 @@ export function AutoOptimizeTab({ spaceId, onRescan }: AutoOptimizeTabProps) {
           // Get total questions from the first iteration that has it
           const withTotal = iterations.find((it) => it.total_questions > 0)
           if (withTotal) setTotalQuestions(withTotal.total_questions)
-          // Filter to full-scope evaluations only (skip slice/p0/held_out)
+          // Filter to full-scope evaluations only (skip slice/p0 probes)
           const fullIters = iterations.filter((it) => it.eval_scope === "full")
           if (fullIters.length === 0) return
           const maxIter = Math.max(...fullIters.map((it) => it.iteration))

--- a/frontend/src/components/auto-optimize/StepDetailContent.tsx
+++ b/frontend/src/components/auto-optimize/StepDetailContent.tsx
@@ -153,20 +153,12 @@ function FinalizationContent({ outputs }: { outputs: Record<string, any> }) {
   const bNorm = bestAcc != null ? (bestAcc > 1 ? bestAcc : bestAcc * 100) : null
   const rep = outputs.repeatability != null ? Number(outputs.repeatability) : null
   const repNorm = rep != null ? (rep > 1 ? rep : rep * 100) : null
-  const hoAcc = outputs.heldOutAccuracy != null ? Number(outputs.heldOutAccuracy) : null
-  const hoNorm = hoAcc != null ? (hoAcc > 1 ? hoAcc : hoAcc * 100) : null
 
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap gap-1.5">
         <StatBadge label="Best accuracy" value={bNorm != null ? `${bNorm.toFixed(1)}%` : null} />
         <StatBadge label="Repeatability" value={repNorm != null ? `${repNorm.toFixed(1)}%` : null} />
-        {hoNorm != null && (
-          <StatBadge
-            label="Held-out"
-            value={`${hoNorm.toFixed(1)}% (${outputs.heldOutCount ?? "?"} Qs)${outputs.heldOutDeltaPp != null ? ` ${Number(outputs.heldOutDeltaPp).toFixed(1)}pp above train` : ""}`}
-          />
-        )}
         {outputs.convergenceReason && (
           <StatBadge label="Convergence" value={outputs.convergenceReason} />
         )}

--- a/frontend/src/lib/eval-counts.test.ts
+++ b/frontend/src/lib/eval-counts.test.ts
@@ -191,6 +191,26 @@ describe("evalCountsFromIteration", () => {
     expect(c.hasDrift).toBe(false)
   })
 
+  it("OFFICIAL: reports the full 30-question benchmark corpus even when legacy evaluated_count is 25", () => {
+    const c = evalCountsFromIteration(
+      iter({
+        overall_accuracy: 80.0,
+        total_questions: 30,
+        evaluated_count: 25,
+        correct_count: 24,
+        num_correct: 24,
+        num_questions: 30,
+        num_done: 25,
+        eval_run_status: "DONE",
+        eval_run_id: "er-30",
+      }),
+    )
+    expect(c.total).toBe(30)
+    expect(c.evaluated).toBe(30)
+    expect(c.correct).toBe(24)
+    expect(c.accuracyPct).toBeCloseTo(80, 4)
+  })
+
   it("OFFICIAL: needs-review rows stay in the num_questions denominator", () => {
     // 7 GOOD, 2 NEEDS_REVIEW, 1 BAD over 10 questions → 70% (GOOD / total).
     const c = evalCountsFromIteration(

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/backend/job_launcher.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/backend/job_launcher.py
@@ -495,4 +495,3 @@ def ensure_job_run_as(ws: WorkspaceClient, job_id: int, sp_client_id: str) -> No
             job_id,
             exc_info=True,
         )
-

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/backend/routes/runs.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/backend/routes/runs.py
@@ -282,7 +282,7 @@ _STEP_DEFINITIONS: list[_StepDefinition] = [
     {
         "stepNumber": 5,
         "name": "Finalization",
-        "stage_prefixes": ["FINALIZE", "REPEATABILITY", "HELD_OUT"],
+        "stage_prefixes": ["FINALIZE", "REPEATABILITY"],
         "summary_template": "Final evaluation complete. Optimized score: {score}%. Repeatability: {repeatability}%",
     },
     {
@@ -751,10 +751,6 @@ def _build_step_io(
                 "ucModelName": detail.get("uc_model_name") or None,
                 "ucModelVersion": detail.get("uc_model_version") or None,
                 "ucChampionPromoted": detail.get("uc_champion_promoted", False),
-                "heldOutAccuracy": _safe_float(detail.get("held_out_accuracy")),
-                "heldOutCount": _safe_int(detail.get("held_out_count")),
-                "trainAccuracy": _safe_float(detail.get("train_accuracy")),
-                "heldOutDeltaPp": _safe_float(detail.get("delta_pp")),
                 "stageEvents": timeline,
             },
         )
@@ -903,11 +899,7 @@ def _build_step_summary(
     if step_name == "Finalization":
         score = f"{_finite(run_data.get('best_accuracy', 0)):.1f}" if run_data.get("best_accuracy") else "?"
         rep = f"{_finite(run_data.get('best_repeatability', 0)):.1f}" if run_data.get("best_repeatability") else "?"
-        summary = defn["summary_template"].format(score=score, repeatability=rep)
-        ho_acc = _safe_float(detail.get("held_out_accuracy"))
-        if ho_acc is not None:
-            summary += f" Held-out: {ho_acc:.1f}%"
-        return summary
+        return defn["summary_template"].format(score=score, repeatability=rep)
     if step_name == "Deploy":
         status = detail.get("status", "pending")
         return defn["summary_template"].format(status=status)
@@ -1217,14 +1209,14 @@ def _build_lever_iterations(
 def _resolve_eval_counts(iter_row: dict | None) -> dict[str, int]:
     """Return canonical {total, evaluated, correct, excluded, quarantined} counts.
 
-    This is the single source of truth for Bug #2's denominator contract on
-    the API side. All endpoints that emit per-iteration counts must go
-    through this helper so that the values sent to the UI stay aligned with
-    the ones used to compute overall_accuracy by
-    _compute_arbiter_adjusted_accuracy.
+    This is the single source of truth for the API side count contract. Native
+    EvalRunner rows are V2 full-corpus rows, so their evaluated count is the
+    full ``total_questions`` value even when a legacy ``evaluated_count`` field
+    is present. Older rows without eval-run metadata keep the Bug #2 fallback.
 
     Back-compat rules:
-      * evaluated_count is preferred; if missing (old rows written before
+      * official EvalRunner rows use total_questions.
+      * legacy rows prefer evaluated_count; if missing (old rows written before
         Bug #2), fall back to total_questions - excluded_count (clamped ≥ 0),
         and then to total_questions when excluded is also missing.
       * excluded_count defaults to 0 (not None) so UI math is safe.
@@ -1250,8 +1242,9 @@ def _resolve_eval_counts(iter_row: dict | None) -> dict[str, int]:
     correct = _safe_int(iter_row.get("correct_count")) or 0
     excluded = _safe_int(iter_row.get("excluded_count")) or 0
 
+    is_official = bool(iter_row.get("eval_run_id") or iter_row.get("eval_run_status"))
     evaluated_raw = iter_row.get("evaluated_count")
-    evaluated = _safe_int(evaluated_raw)
+    evaluated = total if is_official and total > 0 else _safe_int(evaluated_raw)
     if evaluated is None:
         # Old rows: derive from (total - excluded), clamped at 0.
         # Preserves correctness when excluded_count was backfilled but

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/common/config.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/common/config.py
@@ -775,8 +775,7 @@ CURATED_SQL_GENERATION_MAX_RETRIES = 2
 question that originally lacked expected_sql."""
 
 HELD_OUT_RATIO = 0.15
-"""Fraction of non-curated benchmarks reserved for held-out generalization
-check in Finalize.  The optimizer never sees these during the lever loop."""
+"""Legacy split ratio retained for compatibility; inactive in the V2 flow."""
 
 PUBLISH_BENCHMARKS_TO_SPACE: bool = (
     os.environ.get("GSO_PUBLISH_BENCHMARKS_TO_SPACE", "true").lower()
@@ -794,7 +793,7 @@ out and keep the space's benchmark section untouched."""
 # All Bug-#4-era changes to these values are hidden behind GSO_NEW_SIZING so
 # rollback to previous behaviour is a one-env-var flip. The legacy values
 # were TARGET=24, MAX=29, HELD_OUT=0.15 (~20 train + ~4 held-out); the Phase
-# 4 plan specifies 30 total (~25 train + ~5 held-out), MAX=35 cap.
+# 4 plan later collapsed to the V2 30-question full-corpus contract.
 _GSO_NEW_SIZING = os.environ.get("GSO_NEW_SIZING", "true").lower() in {
     "1", "true", "yes", "on",
 }
@@ -807,9 +806,8 @@ else:
     MAX_BENCHMARK_COUNT = 29
 """Hard ceiling on benchmark count. No evaluation should ever run on more
 than this many questions, regardless of how many are generated or loaded.
-With the Phase 4 default the corpus is exactly 30 questions (~25 train + ~5
-held out via HELD_OUT_RATIO=0.15). Flip GSO_NEW_SIZING=0 to restore the
-legacy 24/29 values."""
+With the V2 default the assessed corpus is exactly 30 questions. Flip
+GSO_NEW_SIZING=0 to restore the legacy 24/29 values."""
 
 BENCHMARK_WINDOW_MIN = int(os.environ.get("GSO_BENCHMARK_WINDOW_MIN", "30") or "30")
 """GSO v2 (D8) — lower bound of the working benchmark window. At preflight,
@@ -823,10 +821,10 @@ a validated set ABOVE this count produces a RECOMMENDED prune set
 is a recommendation only — GSO never silently auto-deletes benchmark rows."""
 
 MIN_TRAIN_BENCHMARK_COUNT = 20
-"""Minimum desired train benchmark count after split assignment."""
+"""Legacy split minimum retained for compatibility; inactive in V2."""
 
 MIN_HELD_OUT_BENCHMARK_COUNT = 5
-"""Minimum desired held-out benchmark count when the corpus has enough rows."""
+"""Legacy split minimum retained for compatibility; inactive in V2."""
 
 # Phase 4 (Bug #4) — per-iteration / acceptance-gate defaults.
 # The optimizer re-evaluates the full training corpus each iteration and
@@ -856,8 +854,7 @@ iterations that fail. Set to False during debugging to disable rollback
 while keeping the metrics visible on the iteration row."""
 
 FINALIZE_REPEATABILITY_PASSES = 1
-"""Number of repeatability passes in Finalize.  Reduced from 2 to make room
-for a held-out generalization eval without increasing total Genie API calls."""
+"""Number of repeatability passes in Finalize."""
 
 COVERAGE_GAP_SOFT_CAP_FACTOR = 1.5
 
@@ -1623,7 +1620,7 @@ Regression policy awareness:
   collateral risk.
 
 Leakage boundary:
-- Do not copy held-out benchmark expected SQL into Genie-visible examples.
+- Do not copy benchmark expected SQL into Genie-visible examples.
 - Use failure evidence and generated SQL to understand behavior, but output
   reusable guidance, scoped metadata, SQL expressions, or safe example patterns.
 
@@ -1644,7 +1641,7 @@ This prompt creates one reusable Genie-visible example question/SQL pair.
 
 Rules:
 - Return exactly one single JSON object matching the requested schema.
-- Do not copy held-out benchmark expected SQL into Genie-visible examples.
+- Do not copy benchmark expected SQL into Genie-visible examples.
 - Use schema metadata and the supplied failure pattern to create a reusable
   example; remove benchmark-specific literals, aliases, row limits, and wording.
 - Keep the generated SQL narrow to the requested tables, joins, filters, and

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_baseline.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_baseline.py
@@ -188,7 +188,10 @@ from pyspark.sql import SparkSession
 
 from genie_space_optimizer.jobs._helpers import _banner as _banner_base
 from genie_space_optimizer.jobs._helpers import _log as _log_base
-from genie_space_optimizer.optimization.benchmarks import assert_benchmark_handoff_visible
+from genie_space_optimizer.optimization.benchmarks import (
+    assert_benchmark_handoff_visible,
+    benchmark_corpus_for_optimization,
+)
 from genie_space_optimizer.optimization.evaluation import load_benchmarks_from_dataset
 from genie_space_optimizer.optimization.harness import (
     baseline_setup_scorers,
@@ -283,17 +286,15 @@ assert_benchmark_handoff_visible(
     domain=domain,
     table_name=f"{uc_schema}.genie_benchmarks_{domain}",
 )
-benchmarks = [b for b in _all_benchmarks if b.get("split") != "held_out"]
-_held_out_n = len(_all_benchmarks) - len(benchmarks)
+benchmarks = benchmark_corpus_for_optimization(_all_benchmarks)
 _banner("Loaded Benchmarks")
 _log(
-    "Benchmark dataset (train/held-out split)",
+    "Benchmark corpus",
     uc_schema=uc_schema,
     domain=domain,
     total_loaded=len(_all_benchmarks),
-    train_count=len(benchmarks),
-    held_out_count=_held_out_n,
-    note="held-out reserved for Finalize generalization check",
+    assessed_count=len(benchmarks),
+    note="V2 uses the whole benchmark set; no train/held-out split",
 )
 if not benchmarks:
     raise RuntimeError(f"No benchmarks found in {uc_schema}.genie_benchmarks_{domain}")

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_deploy.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_deploy.py
@@ -48,7 +48,7 @@
 # MAGIC
 # MAGIC ## MLflow Integration
 # MAGIC
-# MAGIC > **📝 Note:** Deploy does **not** mint a new MLflow run name, and (GSO v2 Phase 5, D3/D7) does **not** create an MLflow LoggedModel or UC Model Registry version — tracking is Delta-only and the champion iteration is marked in `genie_opt_iterations`. The v2 run-naming scheme (`<run_short>/<stage>/<detail>`, see `common/mlflow_names.py`) governs the surviving tracing tasks — baseline, enrichment, strategy, slice/p0/full evals, finalize/held_out, finalize/repeat_pass_k — reachable via the same `genie.run_id` tag (Tier 4).
+# MAGIC > **📝 Note:** Deploy does **not** mint a new MLflow run name, and (GSO v2 Phase 5, D3/D7) does **not** create an MLflow LoggedModel or UC Model Registry version — tracking is Delta-only and the champion iteration is marked in `genie_opt_iterations`. The v2 run-naming scheme (`<run_short>/<stage>/<detail>`, see `common/mlflow_names.py`) governs the surviving tracing tasks — baseline, enrichment, strategy, slice/p0/full evals, finalize/repeat_pass_k — reachable via the same `genie.run_id` tag (Tier 4).
 # MAGIC
 # MAGIC ## ⚠️ What Happens If This Task Fails
 # MAGIC

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_enrichment.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_enrichment.py
@@ -69,6 +69,7 @@ from pyspark.sql import SparkSession
 
 from genie_space_optimizer.jobs._helpers import _banner as _banner_base
 from genie_space_optimizer.jobs._helpers import _log as _log_base
+from genie_space_optimizer.optimization.benchmarks import benchmark_corpus_for_optimization
 from genie_space_optimizer.optimization.evaluation import load_benchmarks_from_dataset
 from genie_space_optimizer.optimization.harness import _run_enrichment
 
@@ -148,17 +149,15 @@ _log(
 
 uc_schema = f"{catalog}.{schema}"
 _all_benchmarks = load_benchmarks_from_dataset(spark, uc_schema, domain)
-benchmarks = [b for b in _all_benchmarks if b.get("split") != "held_out"]
-_held_out_n = len(_all_benchmarks) - len(benchmarks)
+benchmarks = benchmark_corpus_for_optimization(_all_benchmarks)
 _banner("Loaded Benchmarks")
 _log(
-    "Benchmark dataset (train/held-out split)",
+    "Benchmark corpus",
     uc_schema=uc_schema,
     domain=domain,
     total_loaded=len(_all_benchmarks),
-    train_count=len(benchmarks),
-    held_out_count=_held_out_n,
-    note="held-out reserved for Finalize generalization check",
+    assessed_count=len(benchmarks),
+    note="V2 uses the whole benchmark set; no train/held-out split",
 )
 if not benchmarks:
     raise RuntimeError(f"No benchmarks found in {uc_schema}.genie_benchmarks_{domain}")

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
@@ -113,6 +113,7 @@ from pyspark.sql import SparkSession
 
 from genie_space_optimizer.jobs._helpers import _banner as _banner_base
 from genie_space_optimizer.jobs._helpers import _log as _log_base
+from genie_space_optimizer.optimization.benchmarks import benchmark_corpus_for_optimization
 from genie_space_optimizer.optimization.evaluation import load_benchmarks_from_dataset
 from genie_space_optimizer.optimization.harness import _run_finalize
 
@@ -277,15 +278,16 @@ _log(
 # COMMAND ----------
 
 uc_schema = f"{catalog}.{schema}"
-benchmarks = load_benchmarks_from_dataset(spark, uc_schema, domain)
-_held_out_n = sum(1 for b in benchmarks if b.get("split") == "held_out")
-_banner("Loaded Benchmarks for Repeatability + Held-Out Eval")
+_all_benchmarks = load_benchmarks_from_dataset(spark, uc_schema, domain)
+benchmarks = benchmark_corpus_for_optimization(_all_benchmarks)
+_banner("Loaded Benchmarks for Repeatability")
 _log(
-    "Benchmark dataset (train + held_out)",
+    "Benchmark corpus",
     uc_schema=uc_schema,
     domain=domain,
+    total_loaded=len(_all_benchmarks),
     benchmark_count=len(benchmarks),
-    held_out_count=_held_out_n,
+    note="V2 uses the whole benchmark set; no train/held-out split",
 )
 
 # COMMAND ----------
@@ -326,7 +328,6 @@ _log(
 # MAGIC
 # MAGIC | Stage | v2 run name |
 # MAGIC |---|---|
-# MAGIC | Held-out generalization eval | `<run_short>/finalize/held_out` |
 # MAGIC | Repeatability pass *k* | `<run_short>/finalize/repeat_pass_{k}` |
 # MAGIC | Pyfunc deploy snapshot | reuses the champion's source `run_id` (no new name) |
 # MAGIC

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_lever_loop.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_lever_loop.py
@@ -242,6 +242,7 @@ from pyspark.sql import SparkSession
 
 from genie_space_optimizer.jobs._helpers import _banner as _banner_base
 from genie_space_optimizer.jobs._helpers import _log as _log_base
+from genie_space_optimizer.optimization.benchmarks import benchmark_corpus_for_optimization
 from genie_space_optimizer.optimization.evaluation import load_benchmarks_from_dataset
 from genie_space_optimizer.optimization.harness import _run_lever_loop
 
@@ -464,17 +465,15 @@ if thresholds_met:
 
 uc_schema = f"{catalog}.{schema}"
 _all_benchmarks = load_benchmarks_from_dataset(spark, uc_schema, domain)
-benchmarks = [b for b in _all_benchmarks if b.get("split") != "held_out"]
-_held_out_n = len(_all_benchmarks) - len(benchmarks)
+benchmarks = benchmark_corpus_for_optimization(_all_benchmarks)
 _banner("Loaded Benchmarks")
 _log(
-    "Benchmark dataset (train/held-out split)",
+    "Benchmark corpus",
     uc_schema=uc_schema,
     domain=domain,
     total_loaded=len(_all_benchmarks),
-    train_count=len(benchmarks),
-    held_out_count=_held_out_n,
-    note="held-out reserved for Finalize generalization check",
+    assessed_count=len(benchmarks),
+    note="V2 uses the whole benchmark set; no train/held-out split",
 )
 if not benchmarks:
     raise RuntimeError(f"No benchmarks found in {uc_schema}.genie_benchmarks_{domain}")

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_preflight.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_preflight.py
@@ -112,7 +112,6 @@
 # COMMAND ----------
 
 import json
-import math
 import os
 import traceback
 from functools import partial
@@ -126,7 +125,6 @@ from databricks.sdk import WorkspaceClient
 from pyspark.sql import SparkSession
 
 from genie_space_optimizer.common.config import (
-    HELD_OUT_RATIO,
     MAX_BENCHMARK_COUNT,
     MAX_ITERATIONS,
     TARGET_BENCHMARK_COUNT,
@@ -212,11 +210,7 @@ if llm_model:
     os.environ["LLM_MODEL"] = llm_model
 
 effective_target = target_benchmark_count or TARGET_BENCHMARK_COUNT
-effective_max = (
-    math.ceil(effective_target / (1 - HELD_OUT_RATIO))
-    if target_benchmark_count
-    else MAX_BENCHMARK_COUNT
-)
+effective_max = effective_target if target_benchmark_count else MAX_BENCHMARK_COUNT
 
 _banner("Resolved Widget Inputs")
 _log(
@@ -600,15 +594,11 @@ preflight_out = {
 
 persisted_benchmark_count = int(ctx_exp.get("benchmark_count", len(_benchmarks)))
 
-_train_n = sum(1 for _b in _benchmarks if _b.get("split") != "held_out")
-_held_n = len(_benchmarks) - _train_n
 _log(
     "Preflight complete",
     benchmark_count=persisted_benchmark_count,
-    train_count=_train_n,
-    held_out_count=_held_n,
-    held_out_ratio=f"{HELD_OUT_RATIO:.0%}",
-    held_out_note="reserved for Finalize generalization check; baseline/lever_loop see train only",
+    assessed_count=len(_benchmarks),
+    note="V2 uses the whole benchmark set; no train/held-out split",
     model_creation="deferred to baseline eval",
     experiment_name=preflight_out["experiment_name"],
 )

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/__init__.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/__init__.py
@@ -10,7 +10,7 @@ Sub-modules:
   - ``state``: Delta-backed state machine for optimization runs
   - ``optimizer``: failure clustering, proposal generation, conflict detection
   - ``applier``: patch rendering, application, rollback
-  - ``benchmarks``: benchmark loading, validation, splitting, corrections
+  - ``benchmarks``: benchmark loading, validation, corpus normalization, corrections
   - ``harness``: 5 stage functions + ``optimize_genie_space()`` convenience fn
   - ``preflight``: extracted Stage 1 logic (config, metadata, benchmarks)
   - ``models``: MLflow LoggedModel management (create, promote, rollback)

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/benchmarks.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/benchmarks.py
@@ -1,5 +1,5 @@
 """
-Benchmark management — loading, validation, splitting, and corrections.
+Benchmark management — loading, validation, corpus normalization, and corrections.
 
 Benchmarks are stored as MLflow evaluation datasets in UC (no YAML files).
 """
@@ -9,12 +9,11 @@ from __future__ import annotations
 import hashlib
 import io
 import logging
-import random
 import re as _re
 from contextlib import contextmanager
 from typing import Any
 
-from genie_space_optimizer.common.config import HELD_OUT_RATIO, TEMPLATE_VARIABLES
+from genie_space_optimizer.common.config import TEMPLATE_VARIABLES
 from genie_space_optimizer.common.genie_client import detect_asset_type
 
 logger = logging.getLogger(__name__)
@@ -212,7 +211,7 @@ def load_benchmarks_from_dataset(
     table_name = f"{uc_schema}.genie_benchmarks_{domain}"
 
     if isinstance(spark_or_dataset, list):
-        return spark_or_dataset
+        return benchmark_corpus_for_optimization(spark_or_dataset)
 
     try:
         if hasattr(spark_or_dataset, "read"):
@@ -229,7 +228,7 @@ def load_benchmarks_from_dataset(
                     from genie_space_optimizer.common.config import MAX_BENCHMARK_COUNT
                     if len(benchmarks) > MAX_BENCHMARK_COUNT:
                         benchmarks = benchmarks[:MAX_BENCHMARK_COUNT]
-                    return benchmarks
+                    return benchmark_corpus_for_optimization(benchmarks)
                 except Exception as read_err:
                     err_msg = str(read_err)
                     if "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS" in err_msg and attempt < _max_retries - 1:
@@ -249,7 +248,7 @@ def load_benchmarks_from_dataset(
             from genie_space_optimizer.common.config import MAX_BENCHMARK_COUNT
             if len(benchmarks) > MAX_BENCHMARK_COUNT:
                 benchmarks = benchmarks[:MAX_BENCHMARK_COUNT]
-            return benchmarks
+            return benchmark_corpus_for_optimization(benchmarks)
     except Exception:
         logger.exception("Failed to load benchmarks from %s", table_name)
         return []
@@ -866,7 +865,7 @@ def validate_predicate_values(
         profile_lower[norm_key] = {"columns": cols_lower}
 
     results: list[dict] = []
-    for b in benchmarks:
+    for b in benchmark_corpus_for_optimization(benchmarks):
         sql = b.get("expected_sql", "")
         question = b.get("question", "")
         if not sql or not sql.strip():
@@ -1020,47 +1019,34 @@ def validate_gt_returns_results(
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# 3. Train/Held-Out Split
+# 3. Benchmark Corpus Normalization
 # ═══════════════════════════════════════════════════════════════════════
+
+
+def benchmark_corpus_for_optimization(benchmarks: list[dict] | None) -> list[dict]:
+    """Return the V2 optimization corpus: every validated benchmark question.
+
+    Legacy rows may still carry ``split=train`` / ``split=held_out`` from older
+    runs. V2 treats the whole benchmark set as held out by nature, so monitoring
+    and evaluation handoffs must ignore those labels.
+    """
+    corpus: list[dict] = []
+    for benchmark in benchmarks or []:
+        normalized = dict(benchmark)
+        normalized["split"] = "full"
+        corpus.append(normalized)
+    return corpus
 
 
 def assign_splits(
     benchmarks: list[dict],
-    train_ratio: float = 1.0 - HELD_OUT_RATIO,
+    train_ratio: float = 1.0,
     seed: int = 42,
 ) -> list[dict]:
-    """Assign ``split`` field using deterministic random sampling.
-
-    Split assignment is intentionally independent of benchmark provenance.
-    User-authored, sample-derived, synthetic, and gap-fill questions all
-    participate in the same random split so the held-out set is a real random
-    sample of the final validated corpus.
-    """
-    from genie_space_optimizer.common.config import (
-        MIN_HELD_OUT_BENCHMARK_COUNT,
-        MIN_TRAIN_BENCHMARK_COUNT,
-    )
-
-    n = len(benchmarks)
-    if n == 0:
-        return benchmarks
-    if n == 1:
-        benchmarks[0]["split"] = "train"
-        return benchmarks
-
-    if n >= MIN_TRAIN_BENCHMARK_COUNT + MIN_HELD_OUT_BENCHMARK_COUNT:
-        held_out_count = MIN_HELD_OUT_BENCHMARK_COUNT
-    else:
-        held_out_count = max(1, min(n - 1, int(round(n * (1.0 - train_ratio)))))
-
-    indices = list(range(n))
-    rng = random.Random(seed)
-    rng.shuffle(indices)
-    held_out_indices = set(indices[:held_out_count])
-
-    for i, benchmark in enumerate(benchmarks):
-        benchmark["split"] = "held_out" if i in held_out_indices else "train"
-
+    """Compatibility wrapper for the V2 no-split benchmark contract."""
+    _ = (train_ratio, seed)
+    for benchmark in benchmarks:
+        benchmark["split"] = "full"
     return benchmarks
 
 
@@ -1077,7 +1063,7 @@ def build_eval_records(benchmarks: list[dict]) -> list[dict]:
     """
     _VALID_ASSET_TYPES = frozenset({"MV", "TVF", "TABLE"})
     records: list[dict] = []
-    for b in benchmarks:
+    for b in benchmark_corpus_for_optimization(benchmarks):
         question = b.get("question", "")
         qid = b.get("question_id") or hashlib.md5(
             question.encode()
@@ -1104,7 +1090,7 @@ def build_eval_records(benchmarks: list[dict]) -> list[dict]:
                     "required_tables": b.get("required_tables", []),
                     "required_columns": b.get("required_columns", []),
                     "category": b.get("category", ""),
-                    "split": b.get("split", "train"),
+                    "split": b.get("split", "full"),
                 },
             }
         )

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/ddl.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/ddl.py
@@ -81,7 +81,7 @@ CREATE TABLE IF NOT EXISTS {catalog}.{schema}.genie_opt_runs (
     triggered_by        STRING                 COMMENT 'User email who initiated the run',
     warehouse_id        STRING                 COMMENT 'SQL warehouse ID resolved at preflight; used by lever_loop / finalize / deploy as a Delta-fallback for the preflight taskValue when Repair Run drops in-memory state',
     human_corrections_json STRING              COMMENT 'JSON array of carry-forward human corrections loaded by preflight; Delta-fallback for the preflight.human_corrections taskValue',
-    max_benchmark_count INT                    COMMENT 'Effective max benchmark count computed by preflight (target_benchmark_count adjusted for held-out ratio); Delta-fallback for the preflight.max_benchmark_count taskValue',
+    max_benchmark_count INT                    COMMENT 'Effective max benchmark count computed by preflight; Delta-fallback for the preflight.max_benchmark_count taskValue',
     updated_at          TIMESTAMP     NOT NULL COMMENT 'Last update timestamp'
 )
 USING DELTA
@@ -121,7 +121,7 @@ CREATE TABLE IF NOT EXISTS {catalog}.{schema}.genie_opt_iterations (
     run_id              STRING        NOT NULL COMMENT 'FK to genie_opt_runs.run_id',
     iteration           INT           NOT NULL COMMENT 'Evaluation iteration number (0 = baseline)',
     lever               INT                    COMMENT 'Which lever was applied before this eval (null for baseline)',
-    eval_scope          STRING        NOT NULL COMMENT 'full|slice|p0|held_out|enrichment',
+    eval_scope          STRING        NOT NULL COMMENT 'full|slice|p0|enrichment; legacy held_out rows may exist from older runs',
     timestamp           TIMESTAMP     NOT NULL COMMENT 'When this evaluation completed',
     overall_accuracy    DOUBLE        NOT NULL COMMENT 'Overall accuracy percentage (0-100)',
     total_questions     INT           NOT NULL COMMENT 'Number of benchmark questions evaluated',
@@ -285,7 +285,7 @@ CREATE TABLE IF NOT EXISTS {catalog}.{schema}.genie_opt_finalize_attestation_mat
     qid                 STRING        NOT NULL COMMENT 'Benchmark question_id',
     iteration_idx       STRING        NOT NULL COMMENT 'Canonical marker: "baseline" | "final" | integer iteration index',
     passed              BOOLEAN                COMMENT 'True if the question passed in this sweep (NULL = quarantined/excluded)',
-    is_heldout          BOOLEAN       NOT NULL COMMENT 'True if qid is in the held-out subset (evaluated only at baseline+finalize)',
+    is_heldout          BOOLEAN       NOT NULL COMMENT 'Legacy compatibility marker; V2 uses the full benchmark corpus',
     logged_at           TIMESTAMP     NOT NULL COMMENT 'When this row was written'
 )
 USING DELTA

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/evaluation.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/evaluation.py
@@ -4080,7 +4080,8 @@ def filter_benchmarks_by_scope(
     """Filter benchmarks based on evaluation scope.
 
     Scopes: "full" (all), "slice" (affected by patches),
-    "p0" (priority P0 only), "held_out" (held-out split).
+    "p0" (priority P0 only). The legacy "held_out" scope is a V2 alias for
+    "full"; the optimizer no longer maintains a train/held-out corpus split.
 
     For "slice" scope, benchmarks are included if:
     - Their required tables/columns overlap with *patched_objects*, OR
@@ -4145,7 +4146,7 @@ def filter_benchmarks_by_scope(
     if scope == "p0":
         return [b for b in benchmarks if b.get("priority", "P1") == "P0"]
     if scope == "held_out":
-        return [b for b in benchmarks if b.get("split") == "held_out"]
+        return benchmarks
     return benchmarks
 
 
@@ -6483,6 +6484,10 @@ def create_evaluation_dataset(
             )
         if len(benchmarks) > max_benchmark_count:
             benchmarks = _truncate_benchmarks(benchmarks, max_benchmark_count)
+        from genie_space_optimizer.optimization.benchmarks import (
+            benchmark_corpus_for_optimization,
+        )
+        benchmarks = benchmark_corpus_for_optimization(benchmarks)
         records = []
         for b in benchmarks:
             _expected_sql = b.get("expected_sql", "")
@@ -6504,7 +6509,7 @@ def create_evaluation_dataset(
                 "required_columns": b.get("required_columns", []),
                 "temporal_stale": b.get("temporal_stale", False),
                 "asset_fingerprint": b.get("asset_fingerprint", ""),
-                "split": b.get("split", "train"),
+                "split": b.get("split", "full"),
             }
             expectations = {k: v for k, v in expectations.items() if v is not None}
             records.append(
@@ -11694,14 +11699,9 @@ def _compute_synthetic_target(
 
 
 def _needs_benchmark_top_up(benchmarks: list[dict]) -> bool:
-    from genie_space_optimizer.common.config import (
-        MIN_HELD_OUT_BENCHMARK_COUNT,
-        MIN_TRAIN_BENCHMARK_COUNT,
-    )
+    from genie_space_optimizer.common.config import TARGET_BENCHMARK_COUNT
 
-    train_n = sum(1 for b in benchmarks if b.get("split") == "train")
-    held_out_n = sum(1 for b in benchmarks if b.get("split") == "held_out")
-    return train_n < MIN_TRAIN_BENCHMARK_COUNT or held_out_n < MIN_HELD_OUT_BENCHMARK_COUNT
+    return len(benchmarks) < TARGET_BENCHMARK_COUNT
 
 
 def _make_benchmark_id_allocator(existing_benchmarks: list[dict]) -> Callable[[str, int], str]:
@@ -12294,21 +12294,16 @@ def generate_benchmarks(
     if len(all_benchmarks) > max_benchmark_count:
         all_benchmarks = _truncate_benchmarks(all_benchmarks, max_benchmark_count)
     all_benchmarks = assign_splits(all_benchmarks)
-    _train_n = sum(1 for b in all_benchmarks if b.get("split") == "train")
-    _held_n = len(all_benchmarks) - _train_n
 
     logger.info(
         "Final benchmark set: %d total (%d curated from Genie space, "
-        "%d synthetic, %d gap-fill, %d discarded out of %d raw generated, "
-        "split: %d train / %d held_out)",
+        "%d synthetic, %d gap-fill, %d discarded out of %d raw generated)",
         len(all_benchmarks),
         len(curated),
         len(valid_benchmarks),
         len(gap_fill_benchmarks),
         len(invalid_benchmarks),
         len(raw_benchmarks),
-        _train_n,
-        _held_n,
     )
     return all_benchmarks
 
@@ -12406,7 +12401,7 @@ def load_benchmarks_from_dataset(
                     "validation_reason_code": expectations.get("validation_reason_code", ""),
                     "validation_error": expectations.get("validation_error"),
                     "correction_source": expectations.get("correction_source", ""),
-                    "split": expectations.get("split", "train"),
+                    "split": expectations.get("split", "full"),
                 }
             )
         pre_dedup = len(benchmarks)
@@ -12428,6 +12423,10 @@ def load_benchmarks_from_dataset(
         from genie_space_optimizer.common.config import MAX_BENCHMARK_COUNT
         if len(benchmarks) > MAX_BENCHMARK_COUNT:
             benchmarks = _truncate_benchmarks(benchmarks, MAX_BENCHMARK_COUNT)
+        from genie_space_optimizer.optimization.benchmarks import (
+            benchmark_corpus_for_optimization,
+        )
+        benchmarks = benchmark_corpus_for_optimization(benchmarks)
 
         logger.info("Loaded %d benchmarks from %s", len(benchmarks), table_name)
         return benchmarks

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
@@ -8140,7 +8140,6 @@ def _run_enrichment(
     baseline_model_id: str = "",
     optimization_run_id: str = "",
     *,
-    held_out_benchmarks: list[dict] | None = None,
     baseline_both_correct_rows: list[dict] | None = None,
 ) -> dict:
     """Stage 2.5: Config preparation + proactive enrichment + LoggedModel snapshot.
@@ -8169,10 +8168,15 @@ def _run_enrichment(
     )
 
     try:
+        from genie_space_optimizer.optimization.benchmarks import (
+            benchmark_corpus_for_optimization,
+        )
+        benchmark_corpus = benchmark_corpus_for_optimization(benchmarks)
+
         # ── 1. Load config (delegates to _prepare_lever_loop) ─────────────
         config = _prepare_lever_loop(
             w, spark, run_id, space_id, catalog, schema,
-            benchmarks=benchmarks,
+            benchmarks=benchmark_corpus,
         )
 
         uc_columns = config.get("_uc_columns", [])
@@ -8268,13 +8272,12 @@ def _run_enrichment(
             #
             # ``benchmarks`` here is used ONLY as the firewall corpus for
             # the prose miner's example_qsql target (it does not mine
-            # from benchmarks). Pass the full train+held_out corpus so
-            # the example-SQL firewall can catch held-out leakage.
+            # from benchmarks). V2 passes the whole benchmark corpus.
             _miner_out = _run_instruction_prose_mining(
                 w, spark, run_id, space_id, config, metadata_snapshot,
                 catalog, schema,
                 warehouse_id=resolve_warehouse_id(""),
-                benchmarks=list(benchmarks) + list(held_out_benchmarks or []),
+                benchmarks=benchmark_corpus,
             )
             if _miner_out["total_applied"] or _miner_out["keep_in_prose_count"]:
                 config, metadata_snapshot = _refresh_config_preserving_mv_state(
@@ -8314,11 +8317,9 @@ def _run_enrichment(
             #   to false to restore the pre-unification behaviour.
             #
             # Both paths share the same last-mile firewall at
-            # ``_apply_proactive_example_sqls``, which MUST see the full
-            # benchmark corpus (train + held_out) so the SQL fingerprint
-            # check catches held-out leakage. See
-            # ``docs/example-sql-isolation.md``.
-            _full_firewall_corpus = list(benchmarks) + list(held_out_benchmarks or [])
+            # ``_apply_proactive_example_sqls``, which MUST see the whole
+            # benchmark corpus. See ``docs/example-sql-isolation.md``.
+            _full_firewall_corpus = benchmark_corpus
             preflight_example_result: dict = {}
             unified_example_result: dict = {}
             if ENABLE_PREFLIGHT_EXAMPLE_SQL_SYNTHESIS:
@@ -23641,22 +23642,22 @@ def _run_finalize(
     terminal_reason = ""
     repeatability_pct = 0.0
     try:
-        # ── Phase 0: Split benchmarks ──
-        train_benchmarks = [b for b in (benchmarks or []) if b.get("split") != "held_out"]
-        held_out_benchmarks = [b for b in (benchmarks or []) if b.get("split") == "held_out"]
+        # ── Phase 0: Resolve V2 benchmark corpus ──
+        from genie_space_optimizer.optimization.benchmarks import (
+            benchmark_corpus_for_optimization,
+        )
+        benchmark_corpus = benchmark_corpus_for_optimization(benchmarks)
 
         # ── Phase 1: Repeatability Testing ──
         _lines = [_section("FINALIZE — REPEATABILITY TESTING", "-")]
         _lines.append(_kv("Run repeatability", run_repeatability))
-        _lines.append(_kv("Train benchmarks", len(train_benchmarks)))
-        _lines.append(_kv("Held-out benchmarks", len(held_out_benchmarks)))
+        _lines.append(_kv("Benchmark corpus", len(benchmark_corpus)))
         _lines.append(_bar("-"))
         print("\n".join(_lines))
 
         rep_results: list[dict] = []
-        held_out_accuracy: float | None = None
         _check_timeout("pre_repeatability")
-        if run_repeatability and train_benchmarks:
+        if run_repeatability and benchmark_corpus:
             write_stage(
                 spark, run_id, "REPEATABILITY_TEST", "STARTED",
                 task_key="finalize", catalog=catalog, schema=schema,
@@ -23664,7 +23665,7 @@ def _run_finalize(
             _emit_heartbeat(
                 "repeatability_test",
                 force=True,
-                detail={"benchmark_count": len(train_benchmarks), "runs": FINALIZE_REPEATABILITY_PASSES},
+                detail={"benchmark_count": len(benchmark_corpus), "runs": FINALIZE_REPEATABILITY_PASSES},
             )
 
             uc_schema = f"{catalog}.{schema}"
@@ -23684,9 +23685,9 @@ def _run_finalize(
                         reference_result_hashes = extract_reference_result_hashes(_rows_payload)
                     except (json.JSONDecodeError, TypeError):
                         pass
-            if not reference_sqls and train_benchmarks:
+            if not reference_sqls and benchmark_corpus:
                 logger.warning("No reference SQLs from iterations — extracting from benchmarks")
-                for b in train_benchmarks:
+                for b in benchmark_corpus:
                     qid = b.get("id", "")
                     sql = b.get("expected_sql", "")
                     if qid and sql:
@@ -23725,7 +23726,7 @@ def _run_finalize(
                         space_id=space_id,
                         experiment_name=exp_name,
                         iteration=iteration_counter,
-                        benchmarks=train_benchmarks,
+                        benchmarks=benchmark_corpus,
                         domain=domain,
                         reference_sqls=reference_sqls,
                         predict_fn=predict_fn,
@@ -23765,7 +23766,7 @@ def _run_finalize(
                     detail={
                         "average_pct": repeatability_pct,
                         "per_run_pcts": rep_pcts,
-                        "total_questions": len(train_benchmarks),
+                        "total_questions": len(benchmark_corpus),
                     },
                     catalog=catalog, schema=schema,
                 )
@@ -23804,130 +23805,13 @@ def _run_finalize(
         _rep_lines.append(_bar("-"))
         print("\n".join(_rep_lines))
 
-        # ── Phase 1b: Held-Out Generalization Check ──
-        if held_out_benchmarks:
-            try:
-                write_stage(
-                    spark, run_id, "HELD_OUT_EVAL", "STARTED",
-                    task_key="finalize", catalog=catalog, schema=schema,
-                )
-                _emit_heartbeat(
-                    "held_out_eval", force=True,
-                    detail={"held_out_count": len(held_out_benchmarks)},
-                )
-                _check_timeout("held_out_eval")
-
-                _ensure_sql_context(spark, catalog, schema)
-                ho_predict_fn = make_predict_fn(
-                    w, space_id, spark, catalog, schema,
-                    warehouse_id=resolve_warehouse_id(""),
-                )
-                _ho_parsed: dict | None = None
-                try:
-                    from genie_space_optimizer.common.genie_client import fetch_space_config as _ho_fetch
-                    _ho_cfg = _ho_fetch(w, space_id)
-                    _ho_parsed = _ho_cfg.get("_parsed_space", _ho_cfg)
-                    _ho_instr = _ho_parsed.get("instructions", {}) if isinstance(_ho_parsed, dict) else {}
-                    _ho_instr_text = _ho_instr.get("text_instructions", "") if isinstance(_ho_instr, dict) else ""
-                except Exception:
-                    _ho_instr_text = ""
-                ho_scorers = make_all_scorers(w, spark, catalog, schema, instruction_context=_ho_instr_text)
-
-                # Tier 4: v2 name — ``<run_short>/finalize/held_out``.
-                from genie_space_optimizer.common.mlflow_names import (
-                    default_tags as _v2_tags_ho,
-                    finalize_run_name as _finalize_run_name_ho,
-                )
-                held_out_result = run_evaluation(
-                    space_id, exp_name, iteration_counter, held_out_benchmarks,
-                    domain, prev_model_id, "held_out",
-                    ho_predict_fn, ho_scorers,
-                    spark=spark, w=w, catalog=catalog, gold_schema=schema,
-                    uc_schema=f"{catalog}.{schema}",
-                    run_name=_finalize_run_name_ho(
-                        run_id, detail="held_out", iteration=iteration_counter,
-                    ),
-                    extra_tags=_v2_tags_ho(
-                        run_id, space_id=space_id, stage="finalize_held_out",
-                        iteration=iteration_counter,
-                    ),
-                )
-
-                write_iteration(
-                    spark, run_id, iteration_counter, held_out_result,
-                    catalog=catalog, schema=schema,
-                    eval_scope="held_out",
-                    # GSO v2 Phase 4 (D3): ``_ho_parsed`` is the live config
-                    # fetched just above for the held-out eval.
-                    config_snapshot=_ho_parsed if isinstance(_ho_parsed, dict) else None,
-                )
-
-                held_out_accuracy = held_out_result.get("overall_accuracy", 0.0)
-                train_accuracy = prev_scores.get(
-                    "genie_correct",
-                    prev_scores.get("overall_accuracy", 0.0),
-                )
-                delta = train_accuracy - held_out_accuracy
-                _ho_lines = [_section("FINALIZE — HELD-OUT GENERALIZATION CHECK", "-")]
-                _ho_lines.append(_kv("Train accuracy", f"{train_accuracy:.1f}%"))
-                _ho_lines.append(_kv("Held-out accuracy", f"{held_out_accuracy:.1f}%"))
-                _ho_lines.append(_kv("Delta", f"{delta:+.1f} pp"))
-                _ho_lines.append(_kv("Held-out questions", len(held_out_benchmarks)))
-                if delta > 15.0:
-                    _ho_lines.append(_kv("Warning", "Possible instruction overfitting (>15pp gap)"))
-                _ho_lines.append(_bar("-"))
-                print("\n".join(_ho_lines))
-
-                write_stage(
-                    spark, run_id, "HELD_OUT_EVAL", "COMPLETE",
-                    task_key="finalize",
-                    detail={
-                        "held_out_accuracy": held_out_accuracy,
-                        "train_accuracy": train_accuracy,
-                        "delta_pp": round(delta, 1),
-                        "held_out_count": len(held_out_benchmarks),
-                    },
-                    catalog=catalog, schema=schema,
-                )
-
-                _best_eval_run_id = (latest_iter or {}).get("mlflow_run_id", "")
-                if _best_eval_run_id:
-                    try:
-                        from mlflow.tracking import MlflowClient as _HoMlflowClient
-                        _ho_client = _HoMlflowClient()
-                        _ho_client.log_metric(_best_eval_run_id, "held_out_accuracy", held_out_accuracy)
-                        _ho_client.log_metric(_best_eval_run_id, "held_out_count", float(len(held_out_benchmarks)))
-                        logger.info(
-                            "Logged held-out metrics to eval run %s: accuracy=%.1f%%, count=%d",
-                            _best_eval_run_id, held_out_accuracy, len(held_out_benchmarks),
-                        )
-                    except Exception:
-                        logger.debug("Failed to log held-out metrics to eval run", exc_info=True)
-            except TimeoutError:
-                raise
-            except Exception:
-                logger.exception("Held-out evaluation failed — continuing")
-                write_stage(
-                    spark, run_id, "HELD_OUT_EVAL", "FAILED",
-                    task_key="finalize",
-                    error_message="Held-out evaluation exception",
-                    catalog=catalog, schema=schema,
-                )
-        else:
-            write_stage(
-                spark, run_id, "HELD_OUT_EVAL", "SKIPPED",
-                task_key="finalize",
-                detail={"reason": "no_held_out_benchmarks"},
-                catalog=catalog, schema=schema,
-            )
-
         _review_lines = [_section("FINALIZE — HUMAN REVIEW FLAGGING", "-")]
         print("\n".join(_review_lines))
 
         _check_timeout("human_review_session")
         _emit_heartbeat("human_review_session", force=True)
         try:
-            for _rr in (rep_results if run_repeatability and benchmarks else []):
+            for _rr in (rep_results if run_repeatability and benchmark_corpus else []):
                 _rr_tmap = _rr.get("trace_map", {})
                 for qid, tid in _rr_tmap.items():
                     question_trace_map.setdefault(qid, []).append(tid)
@@ -24171,8 +24055,6 @@ def _run_finalize(
             "benchmark_publish_count": benchmark_publish_count,
             "elapsed_seconds": round(_elapsed_seconds(), 1),
             "heartbeat_count": heartbeat_count,
-            "held_out_accuracy": held_out_accuracy,
-            "held_out_count": len(held_out_benchmarks) if held_out_benchmarks else 0,
         }
 
     except TimeoutError as exc:
@@ -24317,7 +24199,7 @@ def _run_deploy(
     catalog: str,
     schema: str,
 ) -> dict:
-    """Stage 5: Deploy via DABs, held-out evaluation (optional).
+    """Stage 5: Deploy via DABs.
 
     Wrapper that calls deploy_check() then deploy_execute() in sequence.
     """
@@ -24692,16 +24574,18 @@ def optimize_genie_space(
         result.experiment_name = exp_name
         result.experiment_id = str(preflight_out.get("experiment_id", ""))
 
-        train_benchmarks = [b for b in benchmarks if b.get("split") != "held_out"]
-        held_out_benchmarks = [b for b in benchmarks if b.get("split") == "held_out"]
+        from genie_space_optimizer.optimization.benchmarks import (
+            benchmark_corpus_for_optimization,
+        )
+        benchmark_corpus = benchmark_corpus_for_optimization(benchmarks)
         logger.info(
-            "Benchmark split: %d train, %d held_out",
-            len(train_benchmarks), len(held_out_benchmarks),
+            "Benchmark corpus: %d questions (V2 no train/held-out split)",
+            len(benchmark_corpus),
         )
 
         # Stage 2: Baseline
         baseline_out = _run_baseline(
-            w, spark, run_id_str, space_id, train_benchmarks, exp_name,
+            w, spark, run_id_str, space_id, benchmark_corpus, exp_name,
             model_id, catalog, schema, domain,
         )
         prev_scores = cast(dict[str, float], baseline_out["scores"])
@@ -24747,10 +24631,9 @@ def optimize_genie_space(
         _effective_model_id = model_id
         try:
             _enrichment_out = _run_enrichment(
-                w, spark, run_id_str, space_id, domain, train_benchmarks, exp_name,
+                w, spark, run_id_str, space_id, domain, benchmark_corpus, exp_name,
                 catalog, schema,
                 baseline_model_id=model_id,
-                held_out_benchmarks=held_out_benchmarks,
                 baseline_both_correct_rows=_baseline_both_correct,
             )
             if not _enrichment_out["enrichment_skipped"]:
@@ -24905,7 +24788,7 @@ def optimize_genie_space(
         else:
             # Stage 3: Lever Loop (enrichment already done)
             loop_out = _run_lever_loop(
-                w, spark, run_id_str, space_id, domain, train_benchmarks, exp_name,
+                w, spark, run_id_str, space_id, domain, benchmark_corpus, exp_name,
                 prev_scores, prev_accuracy, _effective_model_id,
                 _enrichment_out["config"] if _enrichment_out else {},
                 catalog, schema, levers, max_iterations, thresholds, apply_mode,
@@ -24938,7 +24821,7 @@ def optimize_genie_space(
             finalize_out = _run_finalize(
                 w, spark, run_id_str, space_id, domain, exp_name,
                 prev_scores, prev_model_id, int(loop_out["iteration_counter"]),
-                catalog, schema, run_repeat, benchmarks, thresholds,
+                catalog, schema, run_repeat, benchmark_corpus, thresholds,
                 question_trace_map=loop_out.get("question_trace_map"),
                 reflection_buffer=loop_out.get("reflection_buffer"),
                 all_eval_mlflow_run_ids=loop_out.get("all_eval_mlflow_run_ids"),

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/leakage.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/leakage.py
@@ -120,9 +120,8 @@ def _jaccard(a: set[str], b: set[str]) -> float:
 class BenchmarkCorpus:
     """Pre-computed view of the benchmark corpus for fast leakage checks.
 
-    Both train and held-out benchmarks must be passed in — held-out
-    leakage is equally disqualifying even though held-out questions are
-    never fed into any LLM prompt.
+    The V2 corpus is the whole assessed benchmark set. Expected SQL remains
+    protected from Genie-visible examples even without a train/held-out split.
     """
     questions: list[str] = field(default_factory=list)
     expected_sqls: list[str] = field(default_factory=list)

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/report.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/report.py
@@ -142,18 +142,6 @@ def _build_executive_summary(run_row: dict, iterations_df: pd.DataFrame) -> str:
             else:
                 rolled_back += 1
 
-    held_out_line = ""
-    if not iterations_df.empty:
-        ho_rows = iterations_df[iterations_df["eval_scope"] == "held_out"]
-        if not ho_rows.empty:
-            ho_acc = float(ho_rows.iloc[-1].get("overall_accuracy", 0.0))
-            ho_total = int(ho_rows.iloc[-1].get("total_questions", 0))
-            ho_delta = best_accuracy - ho_acc
-            held_out_line = (
-                f"- **Held-Out Accuracy:** {ho_acc:.1f}% "
-                f"({ho_total} questions) — {ho_delta:+.1f}pp vs train\n"
-            )
-
     return (
         f"## Executive Summary\n\n"
         f"- **Baseline Score:** {baseline_accuracy:.1f}%\n"
@@ -162,7 +150,6 @@ def _build_executive_summary(run_row: dict, iterations_df: pd.DataFrame) -> str:
         f"- **Total Iterations:** {total_iterations}\n"
         f"- **Levers Accepted:** {accepted}\n"
         f"- **Levers Rolled Back:** {rolled_back}\n"
-        + held_out_line
     )
 
 
@@ -374,34 +361,9 @@ def _build_repeatability_report(iterations_df: pd.DataFrame) -> str:
 
 
 def _build_generalization_section(iterations_df: pd.DataFrame) -> str:
-    """Render a held-out generalization check section when data is available."""
-    if iterations_df.empty:
-        return ""
-    ho_rows = iterations_df[iterations_df["eval_scope"] == "held_out"]
-    if ho_rows.empty:
-        return ""
-
-    ho_row = ho_rows.iloc[-1]
-    ho_acc = float(ho_row.get("overall_accuracy", 0.0))
-    ho_total = int(ho_row.get("total_questions", 0))
-
-    full_rows = iterations_df[iterations_df["eval_scope"] == "full"]
-    train_acc = float(full_rows.iloc[-1].get("overall_accuracy", 0.0)) if not full_rows.empty else 0.0
-    full_total = int(full_rows.iloc[-1].get("total_questions", 0)) if not full_rows.empty else 0
-    delta = train_acc - ho_acc
-
-    header = "## Generalization Check\n\n"
-    table = (
-        "| Metric | Train | Held-Out | Delta |\n"
-        "|--------|-------|----------|-------|\n"
-        f"| Accuracy | {train_acc:.1f}% ({full_total} Qs) | {ho_acc:.1f}% ({ho_total} Qs) | {delta:+.1f} pp |\n"
-    )
-    note = (
-        "\n> **Note:** Held-out questions were never seen by the optimizer. "
-        "A large delta may indicate instruction overfitting. "
-        f"With only {ho_total} held-out questions, this signal is directional.\n"
-    )
-    return header + table + note
+    """V2 has no train/held-out split; keep legacy reports quiet."""
+    _ = iterations_df
+    return ""
 
 
 def _build_mlflow_links(run_row: dict, iterations_df: pd.DataFrame) -> str:

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/components/how-it-works/data.ts
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/components/how-it-works/data.ts
@@ -1142,7 +1142,7 @@ export const BENCHMARK_MODEL_FIELDS = [
   { name: "required_tables", type: "string[]", example: '["sales_fact"]' },
   { name: "required_columns", type: "string[]", example: '["region", "revenue"]' },
   { name: "priority", type: "enum", example: '"P0" | "P1"' },
-  { name: "split", type: "enum", example: '"train" | "held_out"' },
+  { name: "split", type: "enum", example: '"full"' },
   { name: "provenance", type: "enum", example: '"curated" | "synthetic" | "coverage_gap_fill"' },
   { name: "validation_status", type: "enum", example: '"valid" | "invalid"' },
 ];

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/components/how-it-works/stages/BenchmarksStage.tsx
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/components/how-it-works/stages/BenchmarksStage.tsx
@@ -174,14 +174,12 @@ export function BenchmarksStage() {
           content: <AnimatedChecklist items={VALIDATION_PHASES} />,
         },
         {
-          id: "train-heldout",
-          title: "Train/Held-Out Split",
+          id: "benchmark-corpus",
+          title: "Benchmark Corpus",
           content: (
             <p className="text-sm">
-              15% of synthetic/gap-fill benchmarks are held out (deterministic
-              seed=42). Curated questions always remain in train. The optimizer
-              never sees held-out questions — they are evaluated once in Finalize
-              as a directional generalization check.
+              Optimize evaluates the full validated benchmark set. The V2 flow
+              does not split benchmark questions into train and held-out subsets.
             </p>
           ),
         },

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/components/how-it-works/stages/FinalizeDeployStage.tsx
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/components/how-it-works/stages/FinalizeDeployStage.tsx
@@ -22,8 +22,8 @@ const CARDS = [
     accent: "text-blue-700",
   },
   {
-    title: "Generalization",
-    subtitle: "Held-out questions tested",
+    title: "Corpus Check",
+    subtitle: "Full benchmark set reviewed",
     iconArea: (
       <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-purple-100">
         <ShieldCheck className="h-5 w-5 text-purple-600" />
@@ -85,7 +85,7 @@ export function FinalizeDeployStage() {
 
   const explanation = (
     <p>
-      The final stage validates that improvements are repeatable, runs a held-out generalization check on questions the optimizer never saw, promotes the best configuration to &quot;champion&quot; status, creates a human review session, and optionally deploys to a target workspace.
+      The final stage validates that improvements are repeatable across the full benchmark corpus, promotes the best configuration to &quot;champion&quot; status, creates a human review session, and optionally deploys to a target workspace.
     </p>
   );
 
@@ -95,16 +95,7 @@ export function FinalizeDeployStage() {
       title: "Repeatability Testing",
       content: (
         <div className="space-y-2 text-sm">
-          <p>Runs 1 pass on train benchmarks; compares SQL hashes per benchmark. REPEATABILITY_TARGET=90%.</p>
-        </div>
-      ),
-    },
-    {
-      id: "held-out-check",
-      title: "Held-Out Generalization Check",
-      content: (
-        <div className="space-y-2 text-sm">
-          <p>Evaluates ~3-4 benchmark questions the optimizer never saw during the lever loop. Compares held-out accuracy to train accuracy. A gap over 15pp may indicate instruction overfitting. This check is directional only and does not affect optimization decisions.</p>
+          <p>Runs 1 pass on the full benchmark corpus and compares SQL hashes per benchmark. REPEATABILITY_TARGET=90%.</p>
         </div>
       ),
     },

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/routes/runs/$runId.tsx
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/routes/runs/$runId.tsx
@@ -1006,32 +1006,12 @@ function StepInsights({
     const ucModelName = outputs.ucModelName as string | undefined;
     const ucModelVersion = outputs.ucModelVersion as string | undefined;
     const ucChampionPromoted = outputs.ucChampionPromoted as boolean | undefined;
-    const heldOutAccuracy = outputs.heldOutAccuracy as number | undefined;
-    const heldOutCount = outputs.heldOutCount as number | undefined;
-    const heldOutDeltaPp = outputs.heldOutDeltaPp as number | undefined;
 
     return (
       <div className="space-y-2 text-xs">
         <div className="flex flex-wrap gap-2">
           {bestAccuracy != null && <Badge variant="secondary">Best accuracy (arbiter-adjusted): {bestAccuracy.toFixed(1)}%</Badge>}
           {repeatability != null && <Badge variant="secondary">Repeatability: {repeatability.toFixed(1)}%</Badge>}
-          {heldOutAccuracy != null && (
-            <Badge
-              variant="secondary"
-              className={
-                heldOutDeltaPp != null && heldOutDeltaPp > 15
-                  ? "border-amber-200 bg-amber-50 text-amber-800"
-                  : ""
-              }
-            >
-              Held-out: {heldOutAccuracy.toFixed(1)}% ({heldOutCount ?? "?"} Qs)
-              {heldOutDeltaPp != null && (
-                <span className="ml-1 opacity-70">
-                  {heldOutDeltaPp > 0 ? `${heldOutDeltaPp.toFixed(1)}pp below train` : `${Math.abs(heldOutDeltaPp).toFixed(1)}pp above train`}
-                </span>
-              )}
-            </Badge>
-          )}
           {convergenceReason && <Badge variant="secondary">Convergence: {convergenceReason}</Badge>}
         </div>
         {ucModelName && ucModelVersion && (

--- a/packages/genie-space-optimizer/tests/unit/test_benchmark_budget_and_split.py
+++ b/packages/genie-space-optimizer/tests/unit/test_benchmark_budget_and_split.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from genie_space_optimizer.optimization.benchmarks import assign_splits
+from genie_space_optimizer.optimization.benchmarks import (
+    assign_splits,
+    benchmark_corpus_for_optimization,
+    build_eval_records,
+    load_benchmarks_from_dataset,
+)
 
 
 def _rows(n: int) -> list[dict]:
@@ -14,37 +19,67 @@ def _rows(n: int) -> list[dict]:
     ]
 
 
-def test_assign_splits_is_random_across_curated_and_synthetic_rows() -> None:
-    # Curated rows must no longer be pinned to train. With deterministic
-    # random sampling, a seed that yields a mixed held_out proves the gate
-    # is open to both provenances; pinning would always send the 10 curated
-    # rows to train regardless of seed.
+def test_assign_splits_marks_every_question_full_scope() -> None:
     rows = assign_splits(_rows(30), seed=0)
 
-    held_out = [row for row in rows if row["split"] == "held_out"]
-    train = [row for row in rows if row["split"] == "train"]
-
-    assert len(train) == 25
-    assert len(held_out) == 5
-    assert any(row["provenance"] == "curated" for row in held_out)
-    assert any(row["provenance"] == "synthetic" for row in held_out)
+    assert len(rows) == 30
+    assert {row["split"] for row in rows} == {"full"}
+    assert sum(1 for row in rows if row["provenance"] == "curated") == 10
+    assert sum(1 for row in rows if row["provenance"] == "synthetic") == 20
 
 
-def test_assign_splits_is_deterministic_for_same_seed() -> None:
-    first = assign_splits(_rows(30), seed=42)
-    second = assign_splits(_rows(30), seed=42)
+def test_benchmark_corpus_for_optimization_ignores_legacy_split_labels() -> None:
+    legacy_rows = _rows(30)
+    for i, row in enumerate(legacy_rows):
+        row["split"] = "held_out" if i < 5 else "train"
 
-    first_held_out = [row["id"] for row in first if row["split"] == "held_out"]
-    second_held_out = [row["id"] for row in second if row["split"] == "held_out"]
+    corpus = benchmark_corpus_for_optimization(legacy_rows)
 
-    assert first_held_out == second_held_out
+    assert len(corpus) == 30
+    assert {row["split"] for row in corpus} == {"full"}
+    assert [row["id"] for row in corpus] == [row["id"] for row in legacy_rows]
 
 
-def test_assign_splits_best_effort_for_small_corpus() -> None:
+def test_build_eval_records_normalizes_legacy_split_labels() -> None:
+    legacy_rows = _rows(30)
+    for i, row in enumerate(legacy_rows):
+        row["split"] = "held_out" if i < 5 else "train"
+
+    records = build_eval_records(legacy_rows)
+
+    assert len(records) == 30
+    assert {record["expectations"]["split"] for record in records} == {"full"}
+
+
+def test_list_backed_benchmark_loader_normalizes_legacy_split_labels() -> None:
+    legacy_rows = _rows(30)
+    for i, row in enumerate(legacy_rows):
+        row["split"] = "held_out" if i < 5 else "train"
+
+    loaded = load_benchmarks_from_dataset(legacy_rows, "cat.sch", "sales")
+
+    assert len(loaded) == 30
+    assert {row["split"] for row in loaded} == {"full"}
+
+
+def test_assign_splits_small_corpus_still_uses_full_scope() -> None:
     rows = assign_splits(_rows(10), seed=42)
 
-    assert sum(1 for row in rows if row["split"] == "held_out") >= 1
-    assert sum(1 for row in rows if row["split"] == "train") >= 1
+    assert len(rows) == 10
+    assert {row["split"] for row in rows} == {"full"}
+
+
+def test_legacy_held_out_scope_is_full_corpus_alias() -> None:
+    from genie_space_optimizer.optimization.evaluation import filter_benchmarks_by_scope
+
+    legacy_rows = _rows(30)
+    for i, row in enumerate(legacy_rows):
+        row["split"] = "held_out" if i < 5 else "train"
+
+    scoped = filter_benchmarks_by_scope(legacy_rows, "held_out")
+
+    assert len(scoped) == 30
+    assert [row["id"] for row in scoped] == [row["id"] for row in legacy_rows]
 
 
 def test_truncate_benchmarks_caps_to_thirty_and_prefers_user_rows() -> None:

--- a/packages/genie-space-optimizer/tests/unit/test_delta_retry_call_sites.py
+++ b/packages/genie-space-optimizer/tests/unit/test_delta_retry_call_sites.py
@@ -223,5 +223,6 @@ def test_create_evaluation_dataset_persists_30_unique_topup_records(monkeypatch:
 
     assert result["record_count"] == 30
     assert len(merged_records) == 30
+    assert {r["expectations"]["split"] for r in merged_records} == {"full"}
     assert len({r["inputs"]["question_id"] for r in merged_records}) == 30
     assert len({r["inputs"]["question"].lower().strip() for r in merged_records}) == 30

--- a/packages/genie-space-optimizer/tests/unit/test_iteration_api_contract.py
+++ b/packages/genie-space-optimizer/tests/unit/test_iteration_api_contract.py
@@ -102,6 +102,20 @@ def test_bug2_denominator_contract_12_correct_of_14_with_2_excluded() -> None:
     assert counts["correct"] / counts["evaluated"] == 1.0
 
 
+def test_official_evalrunner_row_uses_full_corpus_not_legacy_evaluated_count() -> None:
+    """V2 Optimize rows with native eval metadata report the full benchmark
+    corpus, even if a legacy evaluated_count field still says 25."""
+    row = _iter_row(total=30, correct=24, evaluated=25, excluded=0)
+    row["eval_run_id"] = "er-30"
+    row["eval_run_status"] = "DONE"
+
+    counts = _resolve_eval_counts(row)
+
+    assert counts["total"] == 30
+    assert counts["evaluated"] == 30
+    assert counts["correct"] == 24
+
+
 def test_back_compat_missing_evaluated_derives_from_total_minus_excluded() -> None:
     """Old rows written before Bug #2 didn't have evaluated_count. The helper
     must derive it so stored overall_accuracy keeps tying out."""


### PR DESCRIPTION
## Summary
- Normalize Optimize benchmarks to the V2 full-corpus contract (`split="full"`) at generation, loading, and eval-record handoff boundaries.
- Remove train/held-out filtering from baseline, enrichment, lever loop, finalize, job wrappers, step summaries, and UI finalization badges.
- Make official EvalRunner API/UI count adapters report the full benchmark corpus, including the 30 total / 25 legacy evaluated-count regression case.

## Tests
- `git diff --check`
- `uv run python -m py_compile backend/routers/auto_optimize.py packages/genie-space-optimizer/src/genie_space_optimizer/backend/routes/runs.py packages/genie-space-optimizer/src/genie_space_optimizer/common/config.py packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_baseline.py packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_deploy.py packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_enrichment.py packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_lever_loop.py packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_preflight.py packages/genie-space-optimizer/src/genie_space_optimizer/optimization/__init__.py packages/genie-space-optimizer/src/genie_space_optimizer/optimization/benchmarks.py packages/genie-space-optimizer/src/genie_space_optimizer/optimization/ddl.py packages/genie-space-optimizer/src/genie_space_optimizer/optimization/evaluation.py packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py packages/genie-space-optimizer/src/genie_space_optimizer/optimization/leakage.py packages/genie-space-optimizer/src/genie_space_optimizer/optimization/report.py`
- `uv run --all-extras python -m pytest packages/genie-space-optimizer/tests/unit/test_benchmark_budget_and_split.py packages/genie-space-optimizer/tests/unit/test_delta_retry_call_sites.py packages/genie-space-optimizer/tests/unit/test_iteration_api_contract.py backend/tests/test_auto_optimize_router.py`
- `cd frontend && npm run test -- src/lib/eval-counts.test.ts`
- `cd packages/genie-space-optimizer && npm run test -- src/genie_space_optimizer/ui/lib/exclusions.test.ts`
- `cd frontend && npm run build`

## Known issue
- `cd frontend && npm run lint` still fails on broad pre-existing lint debt unrelated to this change (no-explicit-any, react-hooks/set-state-in-effect, existing hook ordering issues).