### PR TITLE
[gso] Surface native benchmark review signals

### DIFF
--- a/packages/genie-space-optimizer/src/genie_space_optimizer/backend/models.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/backend/models.py
@@ -447,6 +447,7 @@ class IterationSummary(SafeModel):
     correctCount: int
     excludedCount: int = 0
     quarantinedCount: int = 0
+    needsReviewCount: int = 0
     repeatabilityPct: float | None = None
     thresholdsMet: bool
     judgeScores: dict[str, float | None] = {}
@@ -515,6 +516,12 @@ class QuestionResult(SafeModel):
     matchType: str | None = None
     expectedSql: str | None = None
     generatedSql: str | None = None
+    # Native Genie Benchmark assessment signal. ``resultCorrectness`` remains
+    # the accuracy input; these fields preserve the third state for review UI.
+    assessment: str | None = None
+    manualAssessment: bool = False
+    assessmentReasons: list[str] = []
+    needsReview: bool = False
     # Bug #3 — when a row was excluded from the arbiter-adjusted denominator,
     # these fields explain why. The UI renders these in the iteration
     # drill-down so items no longer silently disappear. reasonCode is the
@@ -573,6 +580,7 @@ class IterationDetail(SafeModel):
     correctCount: int = 0
     excludedCount: int = 0
     quarantinedCount: int = 0
+    needsReviewCount: int = 0
     mlflowRunId: str | None = None
     modelId: str | None = None
     gates: list[GateResult] = []

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/backend/routes/runs.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/backend/routes/runs.py
@@ -1448,7 +1448,6 @@ def _question_result_from_row(row: dict[str, Any]) -> QuestionResult:
     needs_review = (
         _is_truthy(row.get("needs_review"))
         or assessment == "NEEDS_REVIEW"
-        or manual_assessment
     )
 
     return QuestionResult(

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/backend/routes/runs.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/backend/routes/runs.py
@@ -1350,6 +1350,126 @@ def _iteration_scores(iter_row: dict | None) -> dict[str, float | None]:
     return {str(k): _safe_float(v) for k, v in scores.items()}
 
 
+def _list_of_str(raw: Any) -> list[str]:
+    """Normalize list-like JSON/string values into non-empty strings."""
+    parsed = safe_json_parse(raw)
+    if parsed is None:
+        return []
+    if isinstance(parsed, str):
+        text = parsed.strip()
+        return [text] if text else []
+    if isinstance(parsed, (list, tuple, set)):
+        out: list[str] = []
+        for item in parsed:
+            text = str(item).strip()
+            if text:
+                out.append(text)
+        return out
+    return []
+
+
+def _assessment_value(row: dict[str, Any]) -> str | None:
+    raw = row.get("assessment")
+    if raw is None:
+        return None
+    assessment = str(raw).strip().upper()
+    return assessment or None
+
+
+def _question_result_from_row(row: dict[str, Any]) -> QuestionResult:
+    """Project a persisted eval row into the standalone transparency contract."""
+    inputs = row.get("inputs") if isinstance(row.get("inputs"), dict) else {}
+    q_text = str(
+        row.get("inputs/question")
+        or inputs.get("question", "")
+        or row.get("question")
+        or row.get("question_text")
+        or ""
+    ).strip()
+
+    request = row.get("request") or {}
+    if isinstance(request, str):
+        request = safe_json_parse(request)
+        if not isinstance(request, dict):
+            request = {}
+    request_kwargs = request.get("kwargs", {}) if isinstance(request, dict) else {}
+
+    if not q_text:
+        q_text = str(
+            request_kwargs.get("question")
+            or (request.get("question") if isinstance(request, dict) else None)
+            or ""
+        ).strip()
+
+    q_id = str(
+        row.get("inputs/question_id")
+        or inputs.get("question_id", "")
+        or row.get("question_id")
+        or row.get("request_id")
+        or request_kwargs.get("question_id")
+        or (request.get("question_id") if isinstance(request, dict) else None)
+        or ""
+    )
+    if not q_id and q_text:
+        q_id = q_text[:80]
+
+    verdicts: dict[str, str] = {}
+    failure_types: list[str] = []
+    for key, val in row.items():
+        if key.endswith("/value") and "/" in key:
+            judge_name = key.rsplit("/value", 1)[0]
+            verdicts[judge_name] = str(val)
+
+    rc = row.get("result_correctness/value", row.get("result_correctness"))
+    if rc:
+        verdicts.setdefault("result_correctness", str(rc))
+
+    match_type = None
+    gen_sql = None
+    expected_sql = None
+    if isinstance(row.get("outputs"), dict):
+        comp = row["outputs"].get("comparison", {})
+        if isinstance(comp, dict):
+            match_type = comp.get("match_type")
+        gen_sql = str(row["outputs"].get("generated_sql", ""))[:500] or None
+        expected_sql = str(row["outputs"].get("expected_sql", ""))[:500] or None
+    if gen_sql is None and row.get("generated_sql") is not None:
+        gen_sql = str(row.get("generated_sql", ""))[:500] or None
+    if expected_sql is None and row.get("expected_sql") is not None:
+        expected_sql = str(row.get("expected_sql", ""))[:500] or None
+
+    excl = row.get("exclusion") if isinstance(row.get("exclusion"), dict) else None
+    is_excluded = bool(excl)
+    excl_code = str(excl.get("reason_code") or "") if excl else None
+    excl_detail = str(excl.get("reason_detail") or "") if excl else None
+
+    assessment = _assessment_value(row)
+    manual_assessment = _is_truthy(row.get("manual_assessment"))
+    needs_review = (
+        _is_truthy(row.get("needs_review"))
+        or assessment == "NEEDS_REVIEW"
+        or manual_assessment
+    )
+
+    return QuestionResult(
+        questionId=q_id,
+        question=q_text,
+        resultCorrectness=verdicts.get("result_correctness"),
+        judgeVerdicts=verdicts,
+        failureTypes=failure_types,
+        matchType=match_type,
+        expectedSql=expected_sql,
+        generatedSql=gen_sql,
+        assessment=assessment,
+        manualAssessment=manual_assessment,
+        assessmentReasons=_list_of_str(row.get("assessment_reasons")),
+        needsReview=needs_review,
+        excluded=is_excluded,
+        exclusionReasonCode=excl_code or None,
+        exclusionReasonDetail=excl_detail or None,
+    )
+
+
 def _derive_lever_status(stages: list[dict]) -> str:
     statuses = {str(s.get("status", "")).upper() for s in stages}
     if "ROLLED_BACK" in statuses:
@@ -1984,6 +2104,7 @@ def get_iterations(run_id: str, config: Dependencies.Config):
                 correctCount=_counts["correct"],
                 excludedCount=_counts["excluded"],
                 quarantinedCount=_counts["quarantined"],
+                needsReviewCount=_safe_int(row.get("num_needs_review")) or 0,
                 repeatabilityPct=_safe_float(row.get("repeatability_pct")),
                 thresholdsMet=bool(row.get("thresholds_met", False)),
                 judgeScores={str(k): _safe_float(v) for k, v in scores.items()},
@@ -2324,6 +2445,7 @@ def get_iteration_detail(run_id: str, config: Dependencies.Config):
         evaluated_c = _iter_counts["evaluated"]
         excluded_c = _iter_counts["excluded"]
         quarantined_c = _iter_counts["quarantined"]
+        needs_review_c = _safe_int(full_row.get("num_needs_review")) or 0
 
         # Bug #2 (PR #79 review #4) — serve the derived accuracy so the
         # iteration detail tile agrees with the KPI card and iteration
@@ -2434,80 +2556,11 @@ def get_iteration_detail(run_id: str, config: Dependencies.Config):
             for row in rows_json:
                 if not isinstance(row, dict):
                     continue
-                q_text = str(
-                    row.get("inputs/question")
-                    or (row.get("inputs") or {}).get("question", "")
-                    or row.get("question")
-                    or row.get("question_text")
-                    or ""
-                ).strip()
+                question = _question_result_from_row(row)
+                questions.append(question)
 
-                _rq = row.get("request") or {}
-                if isinstance(_rq, str):
-                    try:
-                        _rq = json.loads(_rq)
-                    except (json.JSONDecodeError, TypeError):
-                        _rq = {}
-                _rqk = _rq.get("kwargs", {}) if isinstance(_rq, dict) else {}
-
-                if not q_text:
-                    q_text = str(
-                        _rqk.get("question")
-                        or (_rq.get("question") if isinstance(_rq, dict) else None)
-                        or ""
-                    ).strip()
-
-                q_id = str(
-                    row.get("inputs/question_id")
-                    or (row.get("inputs") or {}).get("question_id", "")
-                    or row.get("question_id")
-                    or row.get("request_id")
-                    or _rqk.get("question_id")
-                    or (_rq.get("question_id") if isinstance(_rq, dict) else None)
-                    or ""
-                )
-                if not q_id and q_text:
-                    q_id = q_text[:80]
-
-                verdicts: dict[str, str] = {}
-                failure_types: list[str] = []
-                for key, val in row.items():
-                    if key.endswith("/value") and "/" in key:
-                        judge_name = key.rsplit("/value", 1)[0]
-                        verdicts[judge_name] = str(val)
-
-                rc = row.get("result_correctness/value", row.get("result_correctness"))
-                if rc:
-                    verdicts.setdefault("result_correctness", str(rc))
-
-                match_type = None
-                gen_sql = None
-                expected_sql = None
-                if isinstance(row.get("outputs"), dict):
-                    comp = row["outputs"].get("comparison", {})
-                    if isinstance(comp, dict):
-                        match_type = comp.get("match_type")
-                    gen_sql = str(row["outputs"].get("generated_sql", ""))[:500] or None
-                    expected_sql = str(row["outputs"].get("expected_sql", ""))[:500] or None
-
-                _excl = row.get("exclusion") if isinstance(row.get("exclusion"), dict) else None
-                _is_excluded = bool(_excl)
-                _excl_code = str(_excl.get("reason_code") or "") if _excl else None
-                _excl_detail = str(_excl.get("reason_detail") or "") if _excl else None
-
-                questions.append(QuestionResult(
-                    questionId=q_id,
-                    question=q_text,
-                    resultCorrectness=verdicts.get("result_correctness"),
-                    judgeVerdicts=verdicts,
-                    failureTypes=failure_types,
-                    matchType=match_type,
-                    expectedSql=expected_sql,
-                    generatedSql=gen_sql,
-                    excluded=_is_excluded,
-                    exclusionReasonCode=_excl_code or None,
-                    exclusionReasonDetail=_excl_detail or None,
-                ))
+        if needs_review_c == 0:
+            needs_review_c = sum(1 for q in questions if q.needsReview)
 
         iterations.append(IterationDetail(
             iteration=it_num,
@@ -2520,6 +2573,7 @@ def get_iteration_detail(run_id: str, config: Dependencies.Config):
             correctCount=correct_c,
             excludedCount=excluded_c,
             quarantinedCount=quarantined_c,
+            needsReviewCount=needs_review_c,
             mlflowRunId=mlflow_rid,
             modelId=model_id,
             gates=gates,

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/components/InsightTabs.tsx
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/components/InsightTabs.tsx
@@ -41,6 +41,13 @@ import type {
   ProactiveChanges,
   QuestionResult,
 } from "@/lib/transparency-api";
+import {
+  isQuestionNeedsReview,
+  needsReviewCount,
+  questionOutcome,
+  questionPassed,
+  reviewReasonText,
+} from "@/lib/review-signal";
 import type { StageEvent } from "@/components/StageTimeline";
 import { IterationChart } from "@/components/IterationChart";
 import { StageTimeline, formatStageDisplayName } from "@/components/StageTimeline";
@@ -52,14 +59,7 @@ interface InsightTabsProps {
   links?: { label: string; url: string; category: string }[];
 }
 
-type QuestionFilter = "all" | "failing" | "fixed" | "regressed" | "persistent";
-
-function questionPassed(r: QuestionResult | undefined): boolean {
-  if (!r) return false;
-  const arbiter = r.judgeVerdicts?.arbiter;
-  if (arbiter === "both_correct" || arbiter === "genie_correct") return true;
-  return r.resultCorrectness === "yes" || r.resultCorrectness === "pass";
-}
+type QuestionFilter = "all" | "failing" | "review" | "fixed" | "regressed" | "persistent";
 
 export type FlagCategory = "persistence" | "tvf_removal" | "strategist" | "other";
 
@@ -362,6 +362,8 @@ function OverviewTab({
 
 function QuestionsTab({ detail }: { detail: IterationDetailResponse }) {
   const [filter, setFilter] = useState<QuestionFilter>("all");
+  const finalIteration = detail.iterations[detail.iterations.length - 1];
+  const finalNeedsReviewCount = finalIteration ? needsReviewCount(finalIteration) : 0;
 
   const flaggedMap = useMemo(() => {
     const m = new Map<string, FlaggedInfo>();
@@ -424,6 +426,7 @@ function QuestionsTab({ detail }: { detail: IterationDetailResponse }) {
       const finalPassed = questionPassed(finalResult);
 
       if (filter === "failing") return !finalPassed;
+      if (filter === "review") return isQuestionNeedsReview(finalResult);
       if (filter === "fixed") return !basePassed && finalPassed;
       if (filter === "regressed") return basePassed && !finalPassed;
       if (filter === "persistent") return data.persistentFail || (data.flagged && !finalPassed);
@@ -435,9 +438,16 @@ function QuestionsTab({ detail }: { detail: IterationDetailResponse }) {
     <Card>
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
-          <CardTitle className="text-sm">Question Journey</CardTitle>
+          <div className="flex items-center gap-2">
+            <CardTitle className="text-sm">Question Journey</CardTitle>
+            {finalNeedsReviewCount > 0 && (
+              <Badge variant="outline" className="border-amber-300 text-amber-700 text-[10px]">
+                {finalNeedsReviewCount} need review
+              </Badge>
+            )}
+          </div>
           <div className="flex gap-1">
-            {(["all", "failing", "fixed", "regressed", "persistent"] as QuestionFilter[]).map(
+            {(["all", "failing", "review", "fixed", "regressed", "persistent"] as QuestionFilter[]).map(
               (f) => (
                 <Button
                   key={f}
@@ -476,12 +486,23 @@ function QuestionsTab({ detail }: { detail: IterationDetailResponse }) {
                   </TableCell>
                   {iters.map((it) => {
                     const r = data.results.get(it);
-                    if (!r) return <TableCell key={it} className="text-center text-xs">—</TableCell>;
-                    const passed = questionPassed(r);
+                    if (!r) {
+                      return (
+                        <TableCell key={it} className="text-center text-xs">
+                          —
+                        </TableCell>
+                      );
+                    }
+                    const outcome = questionOutcome(r);
                     return (
                       <TableCell key={it} className="text-center">
-                        {passed ? (
+                        {outcome === "pass" ? (
                           <CheckCircle2 className="mx-auto h-4 w-4 text-green-500" />
+                        ) : outcome === "review" ? (
+                          <AlertTriangle
+                            className="mx-auto h-4 w-4 text-amber-500"
+                            aria-label="Needs review"
+                          />
                         ) : (
                           <XCircle className="mx-auto h-4 w-4 text-red-400" />
                         )}
@@ -490,6 +511,23 @@ function QuestionsTab({ detail }: { detail: IterationDetailResponse }) {
                   })}
                   <TableCell className="text-center">
                     <div className="flex items-center justify-center gap-1">
+                      {isQuestionNeedsReview(data.results.get(iters[iters.length - 1])) && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Badge
+                                variant="outline"
+                                className="cursor-help border-amber-300 bg-amber-50 text-[10px] text-amber-700"
+                              >
+                                Needs Review
+                              </Badge>
+                            </TooltipTrigger>
+                            <TooltipContent side="left" className="max-w-xs text-xs">
+                              {reviewReasonText(data.results.get(iters[iters.length - 1])!)}
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
                       {data.persistentFail && !data.flagInfo && (
                         <Badge variant="destructive" className="text-[10px]">
                           Persistent
@@ -551,12 +589,27 @@ function QuestionsTab({ detail }: { detail: IterationDetailResponse }) {
 function RecommendationsCard({ detail }: { detail: IterationDetailResponse }) {
   const recommendations = useMemo(() => {
     const items: {
-      category: FlagCategory;
+      category: FlagCategory | "native_review";
       title: string;
       description: string;
       questions: string[];
-      icon: "tvf" | "persistence" | "strategist";
+      icon: "tvf" | "persistence" | "strategist" | "review";
     }[] = [];
+
+    const finalIteration = detail.iterations[detail.iterations.length - 1];
+    const nativeReviewQuestions =
+      finalIteration?.questions.filter((q) => isQuestionNeedsReview(q)) ?? [];
+    if (nativeReviewQuestions.length > 0) {
+      items.push({
+        category: "native_review",
+        title: `${nativeReviewQuestions.length} Native Benchmark Review${nativeReviewQuestions.length > 1 ? "s" : ""}`,
+        description:
+          "The Genie Benchmark assessment returned NEEDS_REVIEW for these questions. " +
+          "Review the benchmark outcome before treating them as ordinary failures.",
+        questions: nativeReviewQuestions.map((q) => q.questionId || q.question).filter(Boolean),
+        icon: "review",
+      });
+    }
 
     const byCategory = new Map<FlagCategory, { reasons: string[]; questions: string[] }>();
     for (const fq of detail.flaggedQuestions) {
@@ -617,7 +670,7 @@ function RecommendationsCard({ detail }: { detail: IterationDetailResponse }) {
     }
 
     return items;
-  }, [detail.flaggedQuestions, detail.labelingSessionUrl]);
+  }, [detail.flaggedQuestions, detail.iterations, detail.labelingSessionUrl]);
 
   if (recommendations.length === 0) return null;
 
@@ -638,7 +691,9 @@ function RecommendationsCard({ detail }: { detail: IterationDetailResponse }) {
                 ? "border-orange-200 bg-orange-50/50"
                 : rec.icon === "persistence"
                   ? "border-red-200 bg-red-50/50"
-                  : "border-amber-200 bg-amber-50/50"
+                  : rec.icon === "review"
+                    ? "border-amber-200 bg-amber-50/50"
+                    : "border-amber-200 bg-amber-50/50"
             }`}
           >
             <div className="flex items-start gap-3">
@@ -646,6 +701,8 @@ function RecommendationsCard({ detail }: { detail: IterationDetailResponse }) {
                 <Trash2 className="mt-0.5 h-4 w-4 shrink-0 text-orange-600" />
               ) : rec.icon === "persistence" ? (
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-600" />
+              ) : rec.icon === "review" ? (
+                <UserCheck className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
               ) : (
                 <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
               )}

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/components/IterationExplorer.tsx
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/components/IterationExplorer.tsx
@@ -32,6 +32,11 @@ import type {
   IterationDetailResponse,
 } from "@/lib/transparency-api";
 import { computeBaselineCounts, humanizeExclusionReason } from "@/lib/exclusions";
+import {
+  needsReviewCount,
+  questionOutcome,
+  reviewReasonText,
+} from "@/lib/review-signal";
 
 interface IterationExplorerProps {
   detail: IterationDetailResponse;
@@ -203,10 +208,11 @@ function IterationView({
   if (iteration.iteration === 0) {
     return <BaselineView iteration={iteration} detail={detail} experimentLink={experimentLink} />;
   }
+  const reviewCount = needsReviewCount(iteration);
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-4 sm:grid-cols-3">
+      <div className="grid gap-4 sm:grid-cols-4">
         <Card>
           <CardHeader className="pb-1">
             <CardTitle className="text-xs uppercase tracking-wide text-muted">
@@ -241,6 +247,18 @@ function IterationView({
           <CardContent>
             <span className="text-2xl font-bold">
               {Object.keys(iteration.judgeScores).length}
+            </span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-xs uppercase tracking-wide text-muted">
+              Needs Review
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span className="text-2xl font-bold text-amber-600">
+              {reviewCount}
             </span>
           </CardContent>
         </Card>
@@ -538,7 +556,7 @@ function BaselineView({
 }) {
   const [showAll, setShowAll] = useState(false);
   const [showExclusions, setShowExclusions] = useState(false);
-  const displayed = showAll ? iteration.questions : iteration.questions.slice(0, 20);
+  const reviewCount = needsReviewCount(iteration);
 
   // Bug #2 denominator contract + Bug #3 exclusion partitioning — derived in
   // a pure helper so it can be unit-tested without React/JSDOM. The helper
@@ -554,7 +572,7 @@ function BaselineView({
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-4 sm:grid-cols-3">
+      <div className="grid gap-4 sm:grid-cols-4">
         <Card>
           <CardHeader className="pb-1">
             <CardTitle className="text-xs uppercase tracking-wide text-muted">
@@ -603,6 +621,18 @@ function BaselineView({
             </span>
           </CardContent>
         </Card>
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-xs uppercase tracking-wide text-muted">
+              Needs Review
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span className="text-2xl font-bold text-amber-600">
+              {reviewCount}
+            </span>
+          </CardContent>
+        </Card>
       </div>
 
       {/* Score breakdown */}
@@ -645,18 +675,25 @@ function BaselineView({
                 </TableHeader>
                 <TableBody>
                   {(showAll ? evaluatedQuestions : evaluatedQuestions.slice(0, 20)).map((q) => {
-                    const passed =
-                      q.resultCorrectness === "yes" || q.resultCorrectness === "pass";
+                    const outcome = questionOutcome(q);
                     return (
                       <TableRow key={q.questionId}>
                         <TableCell className="max-w-[400px] truncate text-xs" title={q.question}>
                           {q.question || q.questionId}
                         </TableCell>
                         <TableCell className="text-center">
-                          {passed ? (
+                          {outcome === "pass" ? (
                             <CheckCircle2 className="mx-auto h-4 w-4 text-green-500" />
+                          ) : outcome === "review" ? (
+                            <AlertTriangle
+                              className="mx-auto h-4 w-4 text-amber-500"
+                              aria-label="Needs review"
+                            />
                           ) : (
                             <XCircle className="mx-auto h-4 w-4 text-red-400" />
+                          )}
+                          {outcome === "review" && (
+                            <span className="sr-only">{reviewReasonText(q)}</span>
                           )}
                         </TableCell>
                         <TableCell className="text-center text-xs">

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/exclusions.test.ts
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/exclusions.test.ts
@@ -58,6 +58,7 @@ function iteration(
     correctCount: 0,
     excludedCount: 0,
     quarantinedCount: 0,
+    needsReviewCount: 0,
     mlflowRunId: null,
     modelId: null,
     gates: [],
@@ -67,6 +68,13 @@ function iteration(
     quarantinedBenchmarks: [],
     clusterInfo: null,
     timestamp: null,
+    leakageCountByType: {},
+    firewallRejectionCountByType: {},
+    secondaryMiningBlocked: 0,
+    synthesisSlotsPersisted: 0,
+    arbiterRejectionCount: 0,
+    clusterFallbackToInstructionCount: 0,
+    synthesisArchetypeDistribution: {},
     ...partial,
   };
 }

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/review-signal.test.ts
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/review-signal.test.ts
@@ -74,12 +74,23 @@ describe("review signal helpers", () => {
     expect(reviewReasonText(review)).toBe("LLM_JUDGE_OTHER");
   });
 
-  test("manualAssessment and needsReview booleans also trigger review state", () => {
-    expect(questionOutcome(q({ manualAssessment: true }))).toBe("review");
+  test("manualAssessment alone is metadata, not a review signal", () => {
+    const manualPass = q({
+      assessment: "GOOD",
+      manualAssessment: true,
+      resultCorrectness: "yes",
+    });
+
+    expect(isQuestionNeedsReview(manualPass)).toBe(false);
+    expect(questionPassed(manualPass)).toBe(true);
+    expect(questionOutcome(manualPass)).toBe("pass");
+  });
+
+  test("explicit needsReview boolean still triggers review state", () => {
     expect(questionOutcome(q({ needsReview: true }))).toBe("review");
   });
 
-  test("ordinary pass and fail outcomes remain binary", () => {
+  test("older rows without native fields remain pass/fail", () => {
     expect(questionOutcome(q({ resultCorrectness: "yes" }))).toBe("pass");
     expect(questionOutcome(q({ resultCorrectness: "no" }))).toBe("fail");
   });

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/review-signal.test.ts
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/review-signal.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  isQuestionNeedsReview,
+  needsReviewCount,
+  questionOutcome,
+  questionPassed,
+  reviewReasonText,
+} from "./review-signal";
+import type { IterationDetail, QuestionResult } from "./transparency-api";
+
+function q(opts: Partial<QuestionResult> = {}): QuestionResult {
+  return {
+    questionId: opts.questionId ?? "q1",
+    question: opts.question ?? "Question",
+    resultCorrectness: opts.resultCorrectness ?? "yes",
+    judgeVerdicts: opts.judgeVerdicts ?? {},
+    failureTypes: opts.failureTypes ?? [],
+    matchType: opts.matchType ?? null,
+    expectedSql: opts.expectedSql ?? null,
+    generatedSql: opts.generatedSql ?? null,
+    assessment: opts.assessment,
+    manualAssessment: opts.manualAssessment,
+    assessmentReasons: opts.assessmentReasons,
+    needsReview: opts.needsReview,
+  };
+}
+
+function iteration(partial: Partial<IterationDetail> = {}): IterationDetail {
+  return {
+    iteration: 0,
+    agId: null,
+    status: "baseline",
+    overallAccuracy: 0,
+    judgeScores: {},
+    totalQuestions: 0,
+    evaluatedCount: 0,
+    correctCount: 0,
+    excludedCount: 0,
+    quarantinedCount: 0,
+    needsReviewCount: 0,
+    mlflowRunId: null,
+    modelId: null,
+    gates: [],
+    patches: [],
+    reflection: null,
+    questions: [],
+    quarantinedBenchmarks: [],
+    clusterInfo: null,
+    timestamp: null,
+    leakageCountByType: {},
+    firewallRejectionCountByType: {},
+    secondaryMiningBlocked: 0,
+    synthesisSlotsPersisted: 0,
+    arbiterRejectionCount: 0,
+    clusterFallbackToInstructionCount: 0,
+    synthesisArchetypeDistribution: {},
+    ...partial,
+  };
+}
+
+describe("review signal helpers", () => {
+  test("NEEDS_REVIEW is a third state, not a failed outcome", () => {
+    const review = q({
+      resultCorrectness: "no",
+      assessment: "NEEDS_REVIEW",
+      manualAssessment: true,
+      assessmentReasons: ["LLM_JUDGE_OTHER"],
+    });
+
+    expect(isQuestionNeedsReview(review)).toBe(true);
+    expect(questionPassed(review)).toBe(false);
+    expect(questionOutcome(review)).toBe("review");
+    expect(reviewReasonText(review)).toBe("LLM_JUDGE_OTHER");
+  });
+
+  test("manualAssessment and needsReview booleans also trigger review state", () => {
+    expect(questionOutcome(q({ manualAssessment: true }))).toBe("review");
+    expect(questionOutcome(q({ needsReview: true }))).toBe("review");
+  });
+
+  test("ordinary pass and fail outcomes remain binary", () => {
+    expect(questionOutcome(q({ resultCorrectness: "yes" }))).toBe("pass");
+    expect(questionOutcome(q({ resultCorrectness: "no" }))).toBe("fail");
+  });
+
+  test("needsReviewCount prefers server count and falls back to row flags", () => {
+    expect(needsReviewCount(iteration({ needsReviewCount: 3 }))).toBe(3);
+    expect(
+      needsReviewCount(
+        iteration({
+          needsReviewCount: undefined as unknown as number,
+          questions: [
+            q({ questionId: "q1", assessment: "NEEDS_REVIEW" }),
+            q({ questionId: "q2", resultCorrectness: "no" }),
+          ],
+        }),
+      ),
+    ).toBe(1);
+  });
+});

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/review-signal.ts
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/review-signal.ts
@@ -9,7 +9,6 @@ export function isQuestionNeedsReview(
   const assessment = question.assessment?.trim().toUpperCase();
   return (
     question.needsReview === true ||
-    question.manualAssessment === true ||
     assessment === "NEEDS_REVIEW"
   );
 }

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/review-signal.ts
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/review-signal.ts
@@ -1,0 +1,42 @@
+import type { IterationDetail, QuestionResult } from "./transparency-api";
+
+export type QuestionOutcome = "pass" | "fail" | "review" | "unknown";
+
+export function isQuestionNeedsReview(
+  question: QuestionResult | undefined,
+): boolean {
+  if (!question) return false;
+  const assessment = question.assessment?.trim().toUpperCase();
+  return (
+    question.needsReview === true ||
+    question.manualAssessment === true ||
+    assessment === "NEEDS_REVIEW"
+  );
+}
+
+export function questionPassed(question: QuestionResult | undefined): boolean {
+  if (!question || isQuestionNeedsReview(question)) return false;
+  const arbiter = question.judgeVerdicts?.arbiter;
+  if (arbiter === "both_correct" || arbiter === "genie_correct") return true;
+  return question.resultCorrectness === "yes" || question.resultCorrectness === "pass";
+}
+
+export function questionOutcome(
+  question: QuestionResult | undefined,
+): QuestionOutcome {
+  if (!question) return "unknown";
+  if (isQuestionNeedsReview(question)) return "review";
+  return questionPassed(question) ? "pass" : "fail";
+}
+
+export function needsReviewCount(iteration: IterationDetail): number {
+  return (
+    iteration.needsReviewCount ??
+    iteration.questions.filter((q) => isQuestionNeedsReview(q)).length
+  );
+}
+
+export function reviewReasonText(question: QuestionResult): string {
+  const reasons = question.assessmentReasons?.filter(Boolean) ?? [];
+  return reasons.length > 0 ? reasons.join(", ") : "Native benchmark marked NEEDS_REVIEW";
+}

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/transparency-api.ts
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/ui/lib/transparency-api.ts
@@ -90,6 +90,7 @@ export interface IterationSummary {
   correctCount: number;
   excludedCount: number;
   quarantinedCount: number;
+  needsReviewCount: number;
   repeatabilityPct: number | null;
   thresholdsMet: boolean;
   judgeScores: Record<string, number | null>;
@@ -123,6 +124,10 @@ export interface QuestionResult {
   matchType: string | null;
   expectedSql: string | null;
   generatedSql: string | null;
+  assessment?: string | null;
+  manualAssessment?: boolean;
+  assessmentReasons?: string[];
+  needsReview?: boolean;
   // Bug #3 — runtime exclusion metadata.
   excluded?: boolean;
   exclusionReasonCode?: ExclusionReasonCode | null;
@@ -179,6 +184,7 @@ export interface IterationDetail {
   correctCount: number;
   excludedCount: number;
   quarantinedCount: number;
+  needsReviewCount: number;
   mlflowRunId: string | null;
   modelId: string | null;
   gates: GateResultEntry[];

--- a/packages/genie-space-optimizer/tests/unit/test_iteration_api_contract.py
+++ b/packages/genie-space-optimizer/tests/unit/test_iteration_api_contract.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 
 import json
 
-from genie_space_optimizer.backend.routes.runs import _resolve_eval_counts
+from genie_space_optimizer.backend.routes.runs import (
+    _question_result_from_row,
+    _resolve_eval_counts,
+)
 
 
 def _iter_row(
@@ -309,6 +312,40 @@ def test_get_baseline_and_best_accuracy_uses_derived_values() -> None:
     baseline, best = _get_baseline_and_best_accuracy(iters, run_id="r1")
     assert baseline == 84.21
     assert best == 94.74  # round(100 * 18 / 19, 2)
+
+
+def test_question_result_preserves_native_review_signal() -> None:
+    """Official EvalRunner rows must keep NEEDS_REVIEW distinct from BAD."""
+    question = _question_result_from_row(
+        {
+            "question_id": "q_review",
+            "inputs/question": "Which suppliers need review?",
+            "result_correctness/value": "no",
+            "assessment": "NEEDS_REVIEW",
+            "manual_assessment": True,
+            "assessment_reasons": [
+                "LLM_JUDGE_OTHER",
+                "SINGLE_CELL_DIFFERENCE",
+            ],
+            "needs_review": True,
+            "generated_sql": "select * from generated",
+            "expected_sql": "select * from expected",
+        }
+    )
+
+    payload = question.model_dump()
+
+    assert payload["questionId"] == "q_review"
+    assert payload["resultCorrectness"] == "no"
+    assert payload["assessment"] == "NEEDS_REVIEW"
+    assert payload["manualAssessment"] is True
+    assert payload["assessmentReasons"] == [
+        "LLM_JUDGE_OTHER",
+        "SINGLE_CELL_DIFFERENCE",
+    ]
+    assert payload["needsReview"] is True
+    assert payload["generatedSql"] == "select * from generated"
+    assert payload["expectedSql"] == "select * from expected"
 
 
 def test_all_endpoints_use_same_helper() -> None:

--- a/packages/genie-space-optimizer/tests/unit/test_iteration_api_contract.py
+++ b/packages/genie-space-optimizer/tests/unit/test_iteration_api_contract.py
@@ -348,6 +348,47 @@ def test_question_result_preserves_native_review_signal() -> None:
     assert payload["expectedSql"] == "select * from expected"
 
 
+def test_question_result_manual_assessment_is_metadata_not_review_state() -> None:
+    question = _question_result_from_row(
+        {
+            "question_id": "q_manual_pass",
+            "inputs/question": "Which suppliers passed manual grading?",
+            "result_correctness/value": "yes",
+            "assessment": "GOOD",
+            "manual_assessment": True,
+            "assessment_reasons": [],
+        }
+    )
+
+    payload = question.model_dump()
+
+    assert payload["assessment"] == "GOOD"
+    assert payload["manualAssessment"] is True
+    assert payload["needsReview"] is False
+
+
+def test_question_result_legacy_rows_default_to_pass_fail_not_review() -> None:
+    passed = _question_result_from_row(
+        {
+            "question_id": "q_legacy_pass",
+            "inputs/question": "Legacy passing question",
+            "result_correctness/value": "yes",
+        }
+    )
+    failed = _question_result_from_row(
+        {
+            "question_id": "q_legacy_fail",
+            "inputs/question": "Legacy failing question",
+            "result_correctness/value": "no",
+        }
+    )
+
+    assert passed.needsReview is False
+    assert failed.needsReview is False
+    assert passed.resultCorrectness == "yes"
+    assert failed.resultCorrectness == "no"
+
+
 def test_all_endpoints_use_same_helper() -> None:
     """Regression guard: grep the runs.py source file and confirm every
     call-site that builds a per-iteration counts payload goes through


### PR DESCRIPTION
## Summary

The standalone GSO transparency path already persisted native Genie Benchmark review metadata in `rows_json`, but the API/UI projection collapsed `NEEDS_REVIEW` rows into ordinary failures. This preserves the existing `genie_opt_flagged_questions` banners while carrying the native assessment contract through the standalone backend models, route projection, TypeScript types, and UI helpers.

- Add `assessment`, `manualAssessment`, `assessmentReasons`, `needsReview`, and `needsReviewCount` to the standalone GSO iteration/question contract.
- Project official eval-run row fields from persisted `rows_json` into `QuestionResult`, using `num_needs_review` with a per-row fallback for legacy rows.
- Render native review state as a distinct amber third state in the question journey and iteration explorer, including count cards, a Review filter, a `Needs Review` badge, and a recommended-action entry.
- Keep existing flagged-question banners and categories independent from the native benchmark review signal.

## Test Plan

- [x] Added backend serialization coverage for native review fields in `test_iteration_api_contract.py`.
- [x] Added UI helper coverage for `NEEDS_REVIEW` third-state behavior in `review-signal.test.ts`.
- [x] Ran targeted backend producer/projection tests.
- [x] Ran standalone GSO UI Vitest suite.
- [x] Ran a temporary TypeScript check over touched UI files/tests because the package has no committed `tsconfig*.json`.

## Verification Commands

```bash
uv run pytest packages/genie-space-optimizer/tests/unit/test_eval_runner.py packages/genie-space-optimizer/tests/unit/test_iteration_api_contract.py
cd packages/genie-space-optimizer && npm test
```

## Release / Cross-Review Notes

- Scope is limited to `packages/genie-space-optimizer/`; no main Workbench frontend files were changed.
- This is additive on the API contract: older rows without native fields still fall back to the existing pass/fail path.
- Native `NEEDS_REVIEW` remains non-passing for accuracy math, but is now visibly distinct from ordinary failure in the UI.
