### PR TITLE
fix(gso): finalize skip path uses post-enrichment scorecard, not stale baseline

### DIFF
--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/_handoff.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/_handoff.py
@@ -445,6 +445,7 @@ def get_enrichment_state(
 from genie_space_optimizer.optimization.state import (
     load_iterations,
     load_latest_full_iteration,
+    load_latest_state_iteration,
 )
 
 
@@ -596,6 +597,61 @@ def select_finalize_skip_scores(
     if lever_loop_scores:
         return lever_loop_scores
     return baseline_scores or {}
+
+
+def resolve_finalize_skip_scores(
+    spark: "SparkSession",
+    *,
+    run_id: str,
+    catalog: str,
+    schema: str,
+    lever_loop_scores: HandoffValue,
+    baseline_scores: Any,
+) -> Any:
+    """Resolve the scorecard finalize scores on the lever-loop skip path.
+
+    Resolution priority:
+
+    1. **Authoritative published skip scorecard** — when
+       ``lever_loop.scores`` came straight from task values, the lever-
+       loop skip path already resolved it (baseline OR post-enrichment),
+       so it is the source of truth.
+    2. **Repair / Delta fallback** — when task values were lost,
+       ``get_lever_loop_outputs`` resolves ``lever_loop.scores`` from
+       ``load_latest_full_iteration`` (``eval_scope='full'``), which on a
+       skip is the *stale baseline* row. That leaks the pre-enrichment
+       scorecard for a ``post_enrichment_meets_thresholds`` skip and makes
+       finalize stall. Re-resolve via ``load_latest_state_iteration``
+       (``eval_scope IN ('full', 'enrichment')``, enrichment preferred so
+       the newer iter-0 row wins) so the post-enrichment scorecard is
+       chosen instead.
+    3. **Baseline scorecard** — last resort when neither a published nor a
+       Delta state scorecard exists.
+
+    Args:
+        spark: Active Spark session for the Delta read.
+        run_id, catalog, schema: Locate the run's iteration state.
+        lever_loop_scores: The ``lever_loop.scores`` HandoffValue (carries
+            the ``HandoffSource`` so authoritative task values can be told
+            apart from the stale full-row Delta fallback).
+        baseline_scores: ``baseline_eval`` scores (dict) or ``None``.
+
+    Returns:
+        The scorecard dict to feed ``_run_finalize`` (never ``None``).
+    """
+    if (
+        lever_loop_scores.source is HandoffSource.TASK_VALUES
+        and lever_loop_scores.value
+    ):
+        return lever_loop_scores.value
+
+    state_row = (
+        load_latest_state_iteration(spark, run_id, catalog, schema) or {}
+    )
+    return select_finalize_skip_scores(
+        lever_loop_scores=state_row.get("scores_json"),
+        baseline_scores=baseline_scores,
+    )
 
 
 def assert_lever_loop_inputs_sane(state: dict[str, HandoffValue]) -> None:

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/_handoff.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/_handoff.py
@@ -562,6 +562,42 @@ def get_lever_loop_outputs(
     return out
 
 
+def select_finalize_skip_scores(
+    *,
+    lever_loop_scores: Any,
+    baseline_scores: Any,
+) -> Any:
+    """Pick the scorecard finalize evaluates when the lever loop skipped.
+
+    ``jobs/run_lever_loop.py`` publishes the *resolved* current scorecard
+    (baseline OR post-enrichment) into the ``lever_loop.scores`` task
+    value before exiting on its starting-point gate — see the skip path
+    in that notebook. So when enrichment raised accuracy above thresholds
+    and the loop skipped with ``post_enrichment_meets_thresholds``, the
+    post-enrichment scorecard is what lives in ``lever_loop.scores``.
+
+    Historically the finalize task read ``baseline_eval.scores`` whenever
+    the loop was skipped. That leaked the *stale pre-enrichment*
+    scorecard: ``_run_finalize`` then evaluated thresholds against numbers
+    below target and finalized a genuinely CONVERGED run as STALLED
+    (``no_further_improvement``). The lever_loop scores are authoritative
+    whenever present; the baseline scorecard is only a degraded fallback
+    for the recovery path where the skip never published scores.
+
+    Args:
+        lever_loop_scores: Scores published by ``lever_loop`` (dict) or a
+            falsy value (``None`` / ``{}``) if the task value and Delta
+            fallback were both empty.
+        baseline_scores: Scores from ``baseline_eval`` (dict) or ``None``.
+
+    Returns:
+        The scorecard dict to feed ``_run_finalize`` (never ``None``).
+    """
+    if lever_loop_scores:
+        return lever_loop_scores
+    return baseline_scores or {}
+
+
 def assert_lever_loop_inputs_sane(state: dict[str, HandoffValue]) -> None:
     """Refuse to run the lever loop with degenerate baseline inputs.
 

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
@@ -177,7 +177,7 @@ from genie_space_optimizer.jobs._handoff import (
     get_baseline_eval_state,
     get_lever_loop_outputs,
     get_run_context,
-    select_finalize_skip_scores,
+    resolve_finalize_skip_scores,
 )
 
 ctx = get_run_context(
@@ -230,16 +230,24 @@ baseline = get_baseline_eval_state(
 _baseline_mlflow_run_id = baseline["mlflow_run_id"].value or ""
 
 if lever_skipped:
-    # PR 34: the lever_loop skip path publishes the *resolved* current
-    # scorecard (baseline OR post-enrichment) as ``lever_loop.scores``.
-    # Reading baseline_eval.scores here would leak the stale pre-
-    # enrichment scorecard whenever enrichment raised accuracy above
-    # thresholds — _run_finalize would then evaluate thresholds against
-    # numbers below target and finalize a CONVERGED run as STALLED
-    # (no_further_improvement). Prefer the lever_loop scorecard; fall
-    # back to baseline only for the recovery path where it is empty.
-    prev_scores = select_finalize_skip_scores(
-        lever_loop_scores=ll["scores"].value,
+    # PR 34 + cross-review: the lever_loop skip path publishes the
+    # *resolved* current scorecard (baseline OR post-enrichment) as
+    # ``lever_loop.scores``. Reading baseline_eval.scores here would leak
+    # the stale pre-enrichment scorecard whenever enrichment raised
+    # accuracy above thresholds — _run_finalize would then evaluate
+    # thresholds against numbers below target and finalize a CONVERGED
+    # run as STALLED (no_further_improvement).
+    #
+    # ``resolve_finalize_skip_scores`` prefers the authoritative published
+    # task value; on a repair run where task values were lost it re-reads
+    # the skip-aware Delta state row (enrichment preferred over the stale
+    # baseline full row) before falling back to baseline.
+    prev_scores = resolve_finalize_skip_scores(
+        spark,
+        run_id=run_id,
+        catalog=catalog,
+        schema=schema,
+        lever_loop_scores=ll["scores"],
         baseline_scores=baseline["scores"].value,
     )
     all_eval_mlflow_run_ids = (

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
@@ -32,7 +32,7 @@
 # MAGIC
 # MAGIC > **📝 Note:** This task reads scores and model metadata from **either** `lever_loop` **or** `baseline_eval`, depending on whether the lever loop was skipped. The `skipped` task value from `lever_loop` determines which source to use.
 # MAGIC
-# MAGIC - **If lever loop was skipped** (baseline already met all thresholds): reads from `baseline_eval` — scores, model_id, and iteration_counter=0.
+# MAGIC - **If lever loop was skipped** (baseline OR post-enrichment already met all thresholds): reads `scores`/`model_id` from `lever_loop` (the skip path publishes the resolved current scorecard there) with iteration_counter=0.
 # MAGIC - **If lever loop ran**: reads from `lever_loop` — scores, model_id, and iteration_counter from the last iteration.
 # MAGIC
 # MAGIC ## ⚠️ What Happens If This Task Fails
@@ -143,12 +143,12 @@ _log = partial(_log_base, _TASK_LABEL)
 # MAGIC **From lever_loop or baseline_eval (conditional):**
 # MAGIC
 # MAGIC | Key | Source when skipped | Source when ran | Purpose |
-# MAGIC |-----|--------------------|-----------------|---------| 
-# MAGIC | `scores` | `baseline_eval` | `lever_loop` | Per-judge score dict |
-# MAGIC | `model_id` | `baseline_eval` | `lever_loop` | Best model version ID |
-# MAGIC | `iteration_counter` | `0` (hardcoded) | `lever_loop` | Number of lever iterations completed |
+# MAGIC |-----|--------------------|-----------------|---------|
+# MAGIC | `scores` | `lever_loop` (resolved skip scorecard) | `lever_loop` | Per-judge score dict |
+# MAGIC | `model_id` | `lever_loop` | `lever_loop` | Best model version ID |
+# MAGIC | `iteration_counter` | `0` | `lever_loop` | Number of lever iterations completed |
 # MAGIC
-# MAGIC > **📝 Note:** The `skipped` key from `lever_loop` determines which source to use. When `True`, baseline values are used directly since no optimization was needed.
+# MAGIC > **📝 Note:** The `skipped` key from `lever_loop` flags that no optimization iterations ran. Even on a skip the scorecard comes from `lever_loop`, because the skip path publishes the *resolved current* scorecard (baseline OR post-enrichment) — reading `baseline_eval.scores` would leak the stale pre-enrichment numbers and mis-finalize a post-enrichment-converged run as STALLED.
 
 # COMMAND ----------
 
@@ -177,6 +177,7 @@ from genie_space_optimizer.jobs._handoff import (
     get_baseline_eval_state,
     get_lever_loop_outputs,
     get_run_context,
+    select_finalize_skip_scores,
 )
 
 ctx = get_run_context(
@@ -229,7 +230,18 @@ baseline = get_baseline_eval_state(
 _baseline_mlflow_run_id = baseline["mlflow_run_id"].value or ""
 
 if lever_skipped:
-    prev_scores = baseline["scores"].value
+    # PR 34: the lever_loop skip path publishes the *resolved* current
+    # scorecard (baseline OR post-enrichment) as ``lever_loop.scores``.
+    # Reading baseline_eval.scores here would leak the stale pre-
+    # enrichment scorecard whenever enrichment raised accuracy above
+    # thresholds — _run_finalize would then evaluate thresholds against
+    # numbers below target and finalize a CONVERGED run as STALLED
+    # (no_further_improvement). Prefer the lever_loop scorecard; fall
+    # back to baseline only for the recovery path where it is empty.
+    prev_scores = select_finalize_skip_scores(
+        lever_loop_scores=ll["scores"].value,
+        baseline_scores=baseline["scores"].value,
+    )
     all_eval_mlflow_run_ids = (
         [_baseline_mlflow_run_id] if _baseline_mlflow_run_id else []
     )

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
@@ -23541,6 +23541,48 @@ def _run_lever_loop(
 # ── Stage 4: FINALIZE ───────────────────────────────────────────────
 
 
+def _resolve_finalize_terminal_status(
+    prev_scores: dict[str, float] | Any,
+    iteration_counter: int,
+    max_iterations: int,
+    thresholds: dict[str, float] | None = None,
+) -> tuple[str, str]:
+    """Resolve the terminal ``(status, convergence_reason)`` for a run.
+
+    The verdict is a pure function of the *final scorecard* fed to
+    finalize, the iteration count, and the thresholds:
+
+    * post-arbiter objective met (accuracy == target) → ``CONVERGED`` /
+      ``post_arbiter_objective_met``
+    * all thresholds met → ``CONVERGED`` / ``threshold_met``
+    * iteration budget exhausted → ``MAX_ITERATIONS`` / ``max_iterations``
+    * otherwise → ``STALLED`` / ``no_further_improvement``
+
+    Extracted from ``_run_finalize`` so the verdict can be unit-tested
+    directly — it is the exact decision the finalize stage applies.
+    Feeding it the *stale baseline* scorecard on the lever-loop skip path
+    is what produced the post-enrichment-converged-as-STALLED bug; see
+    ``jobs/run_finalize.py`` and
+    ``jobs/_handoff.select_finalize_skip_scores``.
+    """
+    from genie_space_optimizer.optimization.acceptance_policy import (
+        arbiter_objective_complete,
+    )
+
+    thresholds = thresholds or DEFAULT_THRESHOLDS
+    prev_accuracy = (
+        float(prev_scores.get("accuracy", 0.0))
+        if isinstance(prev_scores, dict) else 0.0
+    )
+    if arbiter_objective_complete(float(prev_accuracy)):
+        return "CONVERGED", "post_arbiter_objective_met"
+    if all_thresholds_met(prev_scores, thresholds):
+        return "CONVERGED", "threshold_met"
+    if iteration_counter >= max_iterations:
+        return "MAX_ITERATIONS", "max_iterations"
+    return "STALLED", "no_further_improvement"
+
+
 def _run_finalize(
     w: WorkspaceClient,
     spark: SparkSession,
@@ -24001,25 +24043,10 @@ def _run_finalize(
         print("\n".join(_term_lines))
 
         _check_timeout("resolve_terminal_status")
-        from genie_space_optimizer.optimization.acceptance_policy import (
-            arbiter_objective_complete,
-        )
 
-        prev_accuracy = float(prev_scores.get("accuracy", 0.0)) if isinstance(prev_scores, dict) else 0.0
-        objective_met = arbiter_objective_complete(float(prev_accuracy))
-        thresholds_met = all_thresholds_met(prev_scores, thresholds)
-        if objective_met:
-            status = "CONVERGED"
-            reason = "post_arbiter_objective_met"
-        elif thresholds_met:
-            status = "CONVERGED"
-            reason = "threshold_met"
-        elif iteration_counter >= max_iterations:
-            status = "MAX_ITERATIONS"
-            reason = "max_iterations"
-        else:
-            status = "STALLED"
-            reason = "no_further_improvement"
+        status, reason = _resolve_finalize_terminal_status(
+            prev_scores, iteration_counter, max_iterations, thresholds,
+        )
 
         terminal_reason = f"finalize_completed:{reason}"
 

--- a/packages/genie-space-optimizer/tests/unit/test_finalize_skip_path_post_enrichment.py
+++ b/packages/genie-space-optimizer/tests/unit/test_finalize_skip_path_post_enrichment.py
@@ -16,11 +16,18 @@ Production divergence:
   ``{"status": "STALLED", "convergence_reason": "no_further_improvement"}``
   even though the live Genie Space was genuinely above threshold.
 
-These tests lock the fix at both layers:
+These tests lock the fix at three layers:
 
-* :func:`select_finalize_skip_scores` — the skip path prefers the
-  lever_loop (post-enrichment) scorecard, falling back to baseline only
+* :func:`select_finalize_skip_scores` — the pure priority core: prefer
+  the lever_loop (post-enrichment) scorecard, fall back to baseline only
   when no skip scores were published.
+* :func:`resolve_finalize_skip_scores` — the wired resolver. On the happy
+  path it returns the authoritative published task value; on a **repair**
+  run where task values were lost (so ``lever_loop.scores`` fell back to
+  the stale baseline *full* row), it re-reads the skip-aware Delta state
+  row (``eval_scope IN ('full', 'enrichment')``, enrichment preferred) so
+  a ``post_enrichment_meets_thresholds`` skip still resolves to the
+  post-enrichment scorecard.
 * :func:`_resolve_finalize_terminal_status` — the exact verdict
   ``_run_finalize`` applies. Wiring the correct scorecard through it must
   yield ``CONVERGED`` / ``threshold_met``, and the stale baseline
@@ -30,8 +37,15 @@ These tests lock the fix at both layers:
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 from genie_space_optimizer.common.config import DEFAULT_THRESHOLDS
-from genie_space_optimizer.jobs._handoff import select_finalize_skip_scores
+from genie_space_optimizer.jobs._handoff import (
+    HandoffSource,
+    HandoffValue,
+    resolve_finalize_skip_scores,
+    select_finalize_skip_scores,
+)
 from genie_space_optimizer.optimization.harness import (
     _resolve_finalize_terminal_status,
 )
@@ -166,3 +180,113 @@ def test_verdict_perfect_accuracy_is_arbiter_objective_met():
     )
     assert status == "CONVERGED"
     assert reason == "post_arbiter_objective_met"
+
+
+# ── Layer 3: wired skip-score resolver (incl. repair / Delta path) ────
+
+
+def _scores_hv(value, source):
+    """Build a ``lever_loop.scores`` HandoffValue for the resolver."""
+    return HandoffValue(key="scores", value=value, source=source)
+
+
+def _patch_state_row(scores_json):
+    """Patch ``load_latest_state_iteration`` to return a Delta state row
+    (or ``None``) with the given ``scores_json``."""
+    row = None if scores_json is None else {"iteration": 0, "scores_json": scores_json}
+    return patch(
+        "genie_space_optimizer.jobs._handoff.load_latest_state_iteration",
+        return_value=row,
+    )
+
+
+def test_resolver_authoritative_task_value_short_circuits_delta_read():
+    """Happy path: when ``lever_loop.scores`` came from task values it is
+    authoritative — the resolver returns it without touching Delta."""
+    hv = _scores_hv(_POST_ENRICHMENT_SCORES, HandoffSource.TASK_VALUES)
+    with patch(
+        "genie_space_optimizer.jobs._handoff.load_latest_state_iteration",
+    ) as mock_state:
+        resolved = resolve_finalize_skip_scores(
+            MagicMock(),
+            run_id="r", catalog="c", schema="s",
+            lever_loop_scores=hv,
+            baseline_scores=_BASELINE_SCORES,
+        )
+    mock_state.assert_not_called()
+    assert resolved == _POST_ENRICHMENT_SCORES
+
+
+def test_resolver_repair_path_prefers_enrichment_state_over_stale_baseline():
+    """Repair / Delta-fallback regression (the cross-review blocker):
+
+    lever_loop task values were lost, so ``get_lever_loop_outputs``
+    resolved ``lever_loop.scores`` from ``load_latest_full_iteration`` —
+    the stale baseline *full* row (83.33%, below threshold). The skip-
+    aware resolver must instead pick the enrichment state row (86.67%,
+    above threshold) so finalize converges rather than stalls.
+    """
+    # ll["scores"] is the stale baseline full row, NOT from task values.
+    stale_ll = _scores_hv(_BASELINE_SCORES, HandoffSource.DELTA_FALLBACK)
+    with _patch_state_row(_POST_ENRICHMENT_SCORES):
+        resolved = resolve_finalize_skip_scores(
+            MagicMock(),
+            run_id="r", catalog="c", schema="s",
+            lever_loop_scores=stale_ll,
+            baseline_scores=_BASELINE_SCORES,
+        )
+    assert resolved == _POST_ENRICHMENT_SCORES
+
+    status, reason = _resolve_finalize_terminal_status(
+        resolved, _SKIP_ITERATION_COUNTER, _MAX_ITERATIONS,
+    )
+    assert (status, reason) == ("CONVERGED", "threshold_met"), (
+        "repair path must converge on the enrichment scorecard, not stall "
+        "on the stale baseline full row"
+    )
+
+
+def test_resolver_repair_path_baseline_meets_thresholds_unchanged():
+    """``baseline_meets_thresholds`` skip on a repair: enrichment was
+    skipped so there is no enrichment row, and ``load_latest_state_iteration``
+    returns the baseline full row. The resolver returns those baseline
+    scores — the legacy skip case is preserved."""
+    baseline_above = {"result_correctness": 90.0, "accuracy": 90.0}
+    stale_ll = _scores_hv(None, HandoffSource.MISSING)
+    with _patch_state_row(baseline_above):
+        resolved = resolve_finalize_skip_scores(
+            MagicMock(),
+            run_id="r", catalog="c", schema="s",
+            lever_loop_scores=stale_ll,
+            baseline_scores=baseline_above,
+        )
+    assert resolved == baseline_above
+
+
+def test_resolver_repair_path_falls_back_to_baseline_when_state_empty():
+    """Last resort: task values lost AND no Delta state row at all → fall
+    back to the baseline scorecard rather than an empty dict."""
+    stale_ll = _scores_hv(None, HandoffSource.MISSING)
+    with _patch_state_row(None):
+        resolved = resolve_finalize_skip_scores(
+            MagicMock(),
+            run_id="r", catalog="c", schema="s",
+            lever_loop_scores=stale_ll,
+            baseline_scores=_BASELINE_SCORES,
+        )
+    assert resolved == _BASELINE_SCORES
+
+
+def test_resolver_empty_authoritative_value_falls_through_to_state_read():
+    """Defensive: a TASK_VALUES source carrying an empty scorecard must not
+    short-circuit — the resolver falls through to the skip-aware state
+    read so an empty published value never wins over real Delta scores."""
+    empty_auth = _scores_hv({}, HandoffSource.TASK_VALUES)
+    with _patch_state_row(_POST_ENRICHMENT_SCORES):
+        resolved = resolve_finalize_skip_scores(
+            MagicMock(),
+            run_id="r", catalog="c", schema="s",
+            lever_loop_scores=empty_auth,
+            baseline_scores=_BASELINE_SCORES,
+        )
+    assert resolved == _POST_ENRICHMENT_SCORES

--- a/packages/genie-space-optimizer/tests/unit/test_finalize_skip_path_post_enrichment.py
+++ b/packages/genie-space-optimizer/tests/unit/test_finalize_skip_path_post_enrichment.py
@@ -1,0 +1,168 @@
+"""Regression: finalize skip path must use the post-enrichment scorecard.
+
+Production divergence:
+
+* Baseline eval reported 83.33% accuracy — **below** the 85% threshold.
+* Proactive enrichment (Task 3) raised accuracy to 86.67% — **above** the
+  threshold — and published ``post_enrichment_thresholds_met=True``.
+* The lever loop (Task 4) skipped with
+  ``SKIPPED: post_enrichment_meets_thresholds`` and published the
+  *resolved* post-enrichment scorecard into the ``lever_loop.scores``
+  task value.
+* Finalize (Task 5), on ``lever_skipped=True``, read ``baseline_eval``'s
+  *stale* 83.33% scorecard instead of the lever_loop scorecard. The
+  terminal-status verdict then evaluated thresholds against 83.33% (below
+  target) with ``iteration_counter=0`` and finalized the run as
+  ``{"status": "STALLED", "convergence_reason": "no_further_improvement"}``
+  even though the live Genie Space was genuinely above threshold.
+
+These tests lock the fix at both layers:
+
+* :func:`select_finalize_skip_scores` — the skip path prefers the
+  lever_loop (post-enrichment) scorecard, falling back to baseline only
+  when no skip scores were published.
+* :func:`_resolve_finalize_terminal_status` — the exact verdict
+  ``_run_finalize`` applies. Wiring the correct scorecard through it must
+  yield ``CONVERGED`` / ``threshold_met``, and the stale baseline
+  scorecard must still reproduce the old ``STALLED`` verdict (proving the
+  regression is score-source driven).
+"""
+
+from __future__ import annotations
+
+from genie_space_optimizer.common.config import DEFAULT_THRESHOLDS
+from genie_space_optimizer.jobs._handoff import select_finalize_skip_scores
+from genie_space_optimizer.optimization.harness import (
+    _resolve_finalize_terminal_status,
+)
+
+# The production scenario from the bug report. ``result_correctness`` is the
+# accuracy carrier key that ``all_thresholds_met`` gates on (target 85.0).
+_BASELINE_SCORES = {"result_correctness": 83.33, "accuracy": 83.33}
+_POST_ENRICHMENT_SCORES = {"result_correctness": 86.67, "accuracy": 86.67}
+_SKIP_ITERATION_COUNTER = 0
+_MAX_ITERATIONS = 6
+
+
+def test_threshold_fixture_brackets_target():
+    """Guard: the fixture must straddle the gate so the test is meaningful."""
+    target = DEFAULT_THRESHOLDS["result_correctness"]
+    assert _BASELINE_SCORES["result_correctness"] < target
+    assert _POST_ENRICHMENT_SCORES["result_correctness"] >= target
+
+
+# ── Layer 1: skip-path score selection ────────────────────────────────
+
+
+def test_skip_path_prefers_lever_loop_post_enrichment_scores():
+    """When enrichment met thresholds, the lever_loop scorecard (post-
+    enrichment) must win over the stale baseline scorecard."""
+    resolved = select_finalize_skip_scores(
+        lever_loop_scores=_POST_ENRICHMENT_SCORES,
+        baseline_scores=_BASELINE_SCORES,
+    )
+    assert resolved == _POST_ENRICHMENT_SCORES
+
+
+def test_skip_path_baseline_meets_thresholds_is_unchanged():
+    """``baseline_meets_thresholds`` skips publish the baseline scorecard as
+    ``lever_loop.scores`` — selection returns identical numbers, so the
+    legacy skip case is preserved."""
+    resolved = select_finalize_skip_scores(
+        lever_loop_scores=_BASELINE_SCORES,
+        baseline_scores=_BASELINE_SCORES,
+    )
+    assert resolved == _BASELINE_SCORES
+
+
+def test_skip_path_falls_back_to_baseline_when_lever_loop_empty():
+    """Recovery path: a skip that never published scores (lost task values,
+    empty Delta) must fall back to the baseline scorecard rather than an
+    empty dict."""
+    assert (
+        select_finalize_skip_scores(
+            lever_loop_scores=None, baseline_scores=_BASELINE_SCORES
+        )
+        == _BASELINE_SCORES
+    )
+    assert (
+        select_finalize_skip_scores(
+            lever_loop_scores={}, baseline_scores=_BASELINE_SCORES
+        )
+        == _BASELINE_SCORES
+    )
+
+
+def test_skip_path_returns_empty_dict_when_both_missing():
+    """Never returns ``None`` — finalize expects a dict to score against."""
+    assert select_finalize_skip_scores(
+        lever_loop_scores=None, baseline_scores=None
+    ) == {}
+
+
+# ── Layer 2: terminal-status verdict ──────────────────────────────────
+
+
+def test_post_enrichment_scorecard_yields_converged():
+    """The fixed wiring (lever_loop post-enrichment scorecard → verdict)
+    must finalize as CONVERGED / threshold_met."""
+    status, reason = _resolve_finalize_terminal_status(
+        _POST_ENRICHMENT_SCORES, _SKIP_ITERATION_COUNTER, _MAX_ITERATIONS,
+    )
+    assert status == "CONVERGED"
+    assert reason == "threshold_met"
+
+
+def test_stale_baseline_scorecard_reproduces_old_stalled_verdict():
+    """The pre-fix wiring (baseline scorecard → verdict) reproduces the
+    reported STALLED / no_further_improvement bug — confirming the verdict
+    flip is driven purely by the scorecard source."""
+    status, reason = _resolve_finalize_terminal_status(
+        _BASELINE_SCORES, _SKIP_ITERATION_COUNTER, _MAX_ITERATIONS,
+    )
+    assert status == "STALLED"
+    assert reason == "no_further_improvement"
+
+
+def test_end_to_end_skip_path_baseline_below_post_enrichment_above_converges():
+    """End-to-end on the skip path: baseline below threshold + post-
+    enrichment above threshold must yield CONVERGED.
+
+    Routes the published scorecards through the real selection helper and
+    the real verdict resolver — the two functions that together govern the
+    finalize skip-path terminal status.
+    """
+    prev_scores = select_finalize_skip_scores(
+        lever_loop_scores=_POST_ENRICHMENT_SCORES,
+        baseline_scores=_BASELINE_SCORES,
+    )
+    status, reason = _resolve_finalize_terminal_status(
+        prev_scores, _SKIP_ITERATION_COUNTER, _MAX_ITERATIONS,
+    )
+    assert (status, reason) == ("CONVERGED", "threshold_met"), (
+        "post-enrichment skip path must converge, not stall on the stale "
+        "baseline scorecard"
+    )
+
+
+def test_verdict_max_iterations_preserved_for_non_skip_path():
+    """Non-skip behavior guard: a below-threshold scorecard with the
+    iteration budget exhausted is MAX_ITERATIONS, not STALLED — the
+    extraction must preserve the full verdict ladder."""
+    status, reason = _resolve_finalize_terminal_status(
+        _BASELINE_SCORES, _MAX_ITERATIONS, _MAX_ITERATIONS,
+    )
+    assert status == "MAX_ITERATIONS"
+    assert reason == "max_iterations"
+
+
+def test_verdict_perfect_accuracy_is_arbiter_objective_met():
+    """A 100% scorecard converges via the post-arbiter objective branch,
+    ahead of the plain threshold branch."""
+    status, reason = _resolve_finalize_terminal_status(
+        {"result_correctness": 100.0, "accuracy": 100.0},
+        _SKIP_ITERATION_COUNTER,
+        _MAX_ITERATIONS,
+    )
+    assert status == "CONVERGED"
+    assert reason == "post_arbiter_objective_met"

--- a/packages/genie-space-optimizer/tests/unit/test_unified_rca_control_plane.py
+++ b/packages/genie-space-optimizer/tests/unit/test_unified_rca_control_plane.py
@@ -41,10 +41,16 @@ def test_finalize_uses_arbiter_objective_for_converged_status() -> None:
 
     from genie_space_optimizer.optimization import harness
 
-    src = inspect.getsource(harness._run_finalize)
+    # The terminal-status verdict (incl. the arbiter-objective branch) was
+    # extracted from ``_run_finalize`` into a pure, unit-testable helper.
+    # ``_run_finalize`` must still delegate to it, and the helper must keep
+    # gating CONVERGED on the arbiter objective.
+    finalize_src = inspect.getsource(harness._run_finalize)
+    assert "_resolve_finalize_terminal_status" in finalize_src
 
-    assert "arbiter_objective_complete" in src
-    assert 'reason = "post_arbiter_objective_met"' in src
+    verdict_src = inspect.getsource(harness._resolve_finalize_terminal_status)
+    assert "arbiter_objective_complete" in verdict_src
+    assert '"post_arbiter_objective_met"' in verdict_src
 
 
 def test_fn_mtd_or_mtday_rca_flow_forces_non_lever5_paths_and_grounding() -> None:


### PR DESCRIPTION
## Problem

When the lever loop skipped because **post-enrichment** eval met thresholds (`SKIPPED: post_enrichment_meets_thresholds`), the run was finalized as `{"status":"STALLED","convergence_reason":"no_further_improvement"}` even though the live Genie Space was genuinely above threshold.

Reproduced scenario:
- Baseline accuracy **83.33%** — below the 85% `result_correctness` gate.
- Proactive enrichment raised accuracy to **86.67%** — above the gate — and published `post_enrichment_thresholds_met=True`.
- The lever loop (`jobs/run_lever_loop.py`) skipped and published the **resolved post-enrichment scorecard** into the `lever_loop.scores` task value.
- Finalize (`jobs/run_finalize.py`), on `lever_skipped=True`, read the **stale** `baseline_eval` scorecard (83.33%) instead of the lever_loop scorecard. `_run_finalize` then evaluated thresholds against 83.33% with `iteration_counter=0` → STALLED / `no_further_improvement`.

## Fix

- `jobs/run_finalize.py`: on the skip path, select the `lever_loop` scorecard (which the skip path resolves to baseline **or** post-enrichment) via a new pure helper `jobs/_handoff.select_finalize_skip_scores`, falling back to the baseline scorecard only for the recovery path where the skip never published scores.
- The `baseline_meets_thresholds` skip case is **unchanged** — `run_lever_loop` publishes the baseline scorecard into `lever_loop.scores` there too, so the selected numbers are identical. Non-skip paths are untouched.
- Extracted the inline finalize terminal-status verdict into a pure, behavior-preserving helper `harness._resolve_finalize_terminal_status` so the CONVERGED/STALLED decision is unit-testable directly.

## Tests

New `tests/unit/test_finalize_skip_path_post_enrichment.py` proves:
- baseline-below-threshold + post-enrichment-above-threshold yields **CONVERGED / threshold_met** on the skip path (routed through the real selection + verdict helpers);
- the stale baseline scorecard reproduces the old **STALLED / no_further_improvement** verdict (confirming the flip is score-source driven);
- the recovery fallback (empty lever_loop scores → baseline) and the full verdict ladder (MAX_ITERATIONS, post-arbiter objective) are preserved.

Updated the source-inspection guard in `test_unified_rca_control_plane.py` for the verdict extraction.

Full GSO unit suite: 3906 passed, 2 failures pre-existing on the base branch (unrelated: `_run_enrichment` signature + a prompt constant).

This pull request and its description were written by Isaac.