### PR TITLE
fix(gso): read expected_sql/question in cluster_failures via canonical accessors

### DIFF
--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/eval_row_access.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/eval_row_access.py
@@ -60,10 +60,19 @@ def nested_get(row: dict, *paths: str, default: Any = "") -> Any:
 
 def request_kwargs(row: dict) -> dict:
     request = _json_dict(row.get("request"))
+    if not isinstance(request, dict):
+        return {}
     kwargs = request.get("kwargs")
     if isinstance(kwargs, dict):
-        return kwargs
-    return request if isinstance(request, dict) else {}
+        # The canonical MLflow shape nests every call arg under ``kwargs``
+        # (question_id / question / expected_sql together). Some in-process
+        # rows instead place ``question`` / ``expected_sql`` as request-level
+        # siblings while only ``question_id`` lives under ``kwargs``. Surface
+        # both, with ``kwargs`` taking precedence, so neither shape drops a
+        # field — request-level siblings are no longer hidden by the presence
+        # of a ``kwargs`` sub-dict.
+        return {**request, **kwargs}
+    return request
 
 
 def response_payload(row: dict) -> dict:

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/optimizer.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/optimizer.py
@@ -74,6 +74,11 @@ from genie_space_optimizer.common.config import (
     get_llm_endpoint,
 )
 from genie_space_optimizer.common.genie_schema import ensure_join_spec_fields
+from genie_space_optimizer.optimization.eval_row_access import (
+    row_expected_sql,
+    row_generated_sql,
+    row_question,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2013,13 +2018,15 @@ def cluster_failures(
         if qid and qid in _held_out:
             continue
 
-        _req = row.get("request") or {}
-        if isinstance(_req, str):
-            try:
-                _req = json.loads(_req)
-            except (json.JSONDecodeError, TypeError):
-                _req = {}
-        _req_kwargs = _req.get("kwargs", {}) if isinstance(_req, dict) else {}
+        # ``question`` / ``expected_sql`` / ``generated_sql`` are read via the
+        # canonical path-agnostic accessors in ``eval_row_access`` rather than
+        # ``row["request"]``. The official Benchmark eval runner
+        # (``eval_runner.map_eval_detail_to_row``) never writes a ``request``
+        # key — it carries the gold SQL at top-level ``expected_sql`` /
+        # ``inputs/expected_response`` / ``expectations.expected_response`` and
+        # the question at ``inputs/question``. The legacy in-process row builder
+        # (``harness.py``) emits ``request``; the accessors resolve both shapes.
+        # ``comparison`` still lives under ``response`` for both runners.
         _resp = row.get("response") or {}
         if isinstance(_resp, str):
             try:
@@ -2031,10 +2038,13 @@ def cluster_failures(
 
         # S2: disambiguate duplicate qids by request signature. Signature is
         # (question_text, expected_sql) — stable across the benchmark row
-        # identity but unique across distinct rows that share an id.
-        _row_question = _req.get("question", "") if isinstance(_req, dict) else ""
-        _row_expected = _req.get("expected_sql", "") if isinstance(_req, dict) else ""
-        _row_signature = (str(_row_question).strip(), str(_row_expected).strip())
+        # identity but unique across distinct rows that share an id. Read via
+        # the accessors so official rows (no ``request`` key) produce a real
+        # signature instead of collapsing to ``("", "")`` and being dropped as
+        # spurious pure-duplicates.
+        _row_question = row_question(row)
+        _row_expected = row_expected_sql(row)
+        _row_signature = (_row_question, _row_expected)
         # Tier 2.12: capture the base question_id (the real benchmark id)
         # separately so ``:vN`` tokens never propagate into outward-facing
         # fields. Downstream consumers that need to map back to a benchmark
@@ -2058,9 +2068,9 @@ def cluster_failures(
             _qid_version[question_id] = 1
 
         sql_ctx = {
-            "question": _req.get("question", "") if isinstance(_req, dict) else "",
-            "expected_sql": _req.get("expected_sql", "") if isinstance(_req, dict) else "",
-            "generated_sql": _resp.get("response", "") if isinstance(_resp, dict) else "",
+            "question": row_question(row),
+            "expected_sql": row_expected_sql(row),
+            "generated_sql": row_generated_sql(row),
             "comparison": _resp.get("comparison", {}) if isinstance(_resp, dict) else {},
         }
 

--- a/packages/genie-space-optimizer/tests/unit/test_root_cause_cascade.py
+++ b/packages/genie-space-optimizer/tests/unit/test_root_cause_cascade.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from genie_space_optimizer.common.config import _LEVER_TO_PATCH_TYPE
 from genie_space_optimizer.optimization.optimizer import (
     _blame_set_matches_metadata,
@@ -194,3 +196,157 @@ def test_metadata_asset_tokens_includes_identifier_and_parts():
 def test_metadata_asset_tokens_gracefully_handles_missing_shape():
     assert _metadata_asset_tokens({}) == set()
     assert _metadata_asset_tokens({"data_sources": {}}) == set()
+
+
+# ── Official-runner row shape (no ``request`` key) ─────────────────────
+#
+# Regression for the bug where ``cluster_failures`` read ``expected_sql`` and
+# ``question`` from ``row["request"]``. The official Benchmark eval runner
+# (``eval_runner.map_eval_detail_to_row``) NEVER writes a ``request`` key — it
+# carries the gold SQL at top-level ``expected_sql`` /
+# ``inputs/expected_response`` / ``expectations.expected_response`` and the
+# question at ``inputs/question``. So official rows silently lost their
+# ``expected_sql`` + ``question`` (``generated_sql`` survived only because it
+# was read from ``response.response``), and verifiable failures were
+# mislabelled ``unverifiable_no_expected_sql``. The fix routes all three reads
+# through ``eval_row_access`` accessors, which resolve both row shapes.
+
+# Expected has a WHERE filter the generated SQL drops → a verifiable
+# ``missing_filter`` diff. The question avoids the "by <x>" / filter-keyword
+# heuristics in ``_classify_generated_sql_quality`` so that WITHOUT a resolved
+# expected_sql the cascade lands on ``unverifiable_no_expected_sql`` — i.e.
+# this row reproduces the bug on the pre-fix code.
+_EXPECTED_SQL = (
+    "SELECT category, SUM(amount) AS total FROM sales "
+    "WHERE region = 'US' GROUP BY category"
+)
+_GENERATED_SQL = "SELECT category, SUM(amount) AS total FROM sales GROUP BY category"
+_QUESTION = "What is the total sales amount per product category?"
+
+
+def _official_row(
+    *,
+    qid: str,
+    question: str,
+    expected_sql: str,
+    generated_sql: str,
+    judge: str = "result_correctness",
+) -> dict[str, Any]:
+    """Build an OFFICIAL-runner eval row (mirrors ``map_eval_detail_to_row``).
+
+    Crucially carries NO ``request`` key: the gold SQL lives at top-level
+    ``expected_sql`` + ``inputs/expected_response`` + nested
+    ``expectations.expected_response``; the generated SQL lives at
+    ``response.response`` + ``outputs/response`` + ``generated_sql``; and the
+    question lives at top-level ``question`` + ``inputs/question``.
+    """
+    return {
+        "question_id": qid,
+        "inputs/question_id": qid,
+        "question": question,
+        "inputs/question": question,
+        "assessment": "BAD",
+        "assessment_reasons": [],
+        "manual_assessment": False,
+        "needs_review": False,
+        # A failing judge so the row produces a failure entry.
+        "result_correctness/value": "no",
+        f"feedback/{judge}/value": "no",
+        "arbiter/value": "skipped",
+        # Generated SQL: nested response shape + flat aliases. No ``request``.
+        "response": {"response": generated_sql, "comparison": {}},
+        "expectations": {"expected_response": expected_sql},
+        "inputs/expected_response": expected_sql,
+        "outputs/response": generated_sql,
+        "generated_sql": generated_sql,
+        "expected_sql": expected_sql,
+        "_eval_source": "official_benchmark",
+    }
+
+
+def test_official_row_resolves_expected_sql_and_question():
+    """Official rows (no ``request``) must keep expected_sql + question and
+    classify to a verifiable root cause — not ``unverifiable_no_expected_sql``."""
+    rows = [
+        _official_row(
+            qid="q-official",
+            question=_QUESTION,
+            expected_sql=_EXPECTED_SQL,
+            generated_sql=_GENERATED_SQL,
+        )
+    ]
+    assert "request" not in rows[0], "official rows must not carry a request key"
+
+    clusters = cluster_failures(
+        {"eval_results": rows}, _metadata_with_tables([]), verbose=False
+    )
+    assert clusters, "expected at least one cluster"
+    cluster = clusters[0]
+
+    ctx = cluster["sql_contexts"][0]
+    assert ctx["expected_sql"].strip(), (
+        "expected_sql must be resolved from the official row (top-level / "
+        "inputs.expected_response / expectations.expected_response)"
+    )
+    assert ctx["question"].strip(), (
+        "question must be resolved from the official row (inputs/question)"
+    )
+    assert ctx["generated_sql"].strip(), "generated_sql must be resolved"
+
+    assert cluster["root_cause"] != "unverifiable_no_expected_sql", (
+        "official row carries both expected and generated SQL; the root cause "
+        f"should be verifiable, got {cluster['root_cause']!r}"
+    )
+
+
+def _legacy_row(
+    *,
+    qid: str,
+    question: str,
+    expected_sql: str,
+    generated_sql: str,
+    nest_kwargs: bool,
+    judge: str = "correctness",
+) -> dict[str, Any]:
+    """Build a LEGACY in-process eval row carrying a ``request`` key.
+
+    The harness emits two real ``request`` shapes — siblings
+    (``request: {question, expected_sql}``, harness.py:4756/4881) and the
+    MLflow kwargs-nested form (``request: {kwargs: {question, expected_sql}}``).
+    Both must resolve via ``eval_row_access`` accessors.
+    """
+    inner = {"question": question, "expected_sql": expected_sql}
+    request = {"kwargs": {**inner, "question_id": qid}} if nest_kwargs else inner
+    return {
+        "question_id": qid,
+        "request": request,
+        "response": {"response": generated_sql, "comparison": {}},
+        f"feedback/{judge}/value": "no",
+    }
+
+
+@pytest.mark.parametrize("nest_kwargs", [False, True], ids=["siblings", "kwargs_nested"])
+def test_legacy_request_row_still_resolves_expected_sql_and_question(nest_kwargs):
+    """Legacy in-process rows (``request`` key present) must keep working for
+    both the sibling and kwargs-nested request shapes."""
+    rows = [
+        _legacy_row(
+            qid="q-legacy",
+            question=_QUESTION,
+            expected_sql=_EXPECTED_SQL,
+            generated_sql=_GENERATED_SQL,
+            nest_kwargs=nest_kwargs,
+        )
+    ]
+    assert "request" in rows[0], "legacy rows carry a request key"
+
+    clusters = cluster_failures(
+        {"eval_results": rows}, _metadata_with_tables([]), verbose=False
+    )
+    assert clusters, "expected at least one cluster"
+    cluster = clusters[0]
+
+    ctx = cluster["sql_contexts"][0]
+    assert ctx["expected_sql"].strip()
+    assert ctx["question"].strip()
+    assert cluster["root_cause"] != "unverifiable_no_expected_sql"


### PR DESCRIPTION
## Root cause

The official Benchmark eval runner (`eval_runner.map_eval_detail_to_row`)
**never writes a `request` key**. Official eval rows carry the gold SQL at
top-level `expected_sql` plus `inputs/expected_response` and
`expectations.expected_response`, and the question at `inputs/question` /
top-level `question`. The generated SQL lives at `response.response` /
`outputs/response` / `generated_sql`.

But `cluster_failures` (in `optimization/optimizer.py`) built its per-row
`sql_context` by reading `expected_sql` and `question` from
`row["request"]`:

```python
_req = row.get("request") or {}
sql_ctx = {
    "question":      _req.get("question", ""),
    "expected_sql":  _req.get("expected_sql", ""),
    "generated_sql": _resp.get("response", ""),   # survives — read from response
    ...
}
```

So for official rows, `expected_sql` and `question` were silently dropped
(only `generated_sql` survived, because it was read from `response.response`).
With no expected SQL, the root-cause classifier
(`_classify_sql_diff` → `_classify_generated_sql_quality`) mislabelled
otherwise-verifiable failures as **`unverifiable_no_expected_sql`**. That
empties RCA findings, trips the `rca_ungrounded` gate, and yields **zero
applied lever-loop patches**.

The sibling S2 dedup-signature reads (`_row_question` / `_row_expected`)
read from `request` the same way, so official rows collapsed to the
signature `("", "")` and distinct rows sharing a qid were dropped as
spurious pure-duplicates.

The legacy in-process row builder (`harness.py`) *does* emit `request`, so
the bug only affected official-runner rows.

## Fix

Consumer-side only — the RCA-groundedness gate, the levers, benchmark
publishing, and `eval_runner`'s row writer are **untouched**.

- `cluster_failures` now builds `sql_ctx`'s `question` / `expected_sql` /
  `generated_sql` and the S2 dedup signature via the canonical,
  path-agnostic accessors in `eval_row_access` — `row_question`,
  `row_expected_sql`, `row_generated_sql` — which already resolve both the
  official shape (`inputs/expected_response`, `expectations.expected_response`,
  top-level `expected_sql`, `inputs/question`, `response.response`,
  `outputs/response`, `generated_sql`) and the legacy `request`-based shape.
  The existing `comparison` handling (read from `response`) is preserved.
- `request_kwargs` now also surfaces request-level siblings (with `kwargs`
  taking precedence) so legacy in-process rows that place
  `question` / `expected_sql` beside a `kwargs` sub-dict no longer drop those
  fields. This keeps the dedup signature meaningful for every real and
  legacy row shape and is strictly additive (kwargs still wins).

## Regression test

Added to `packages/genie-space-optimizer/tests/unit/test_root_cause_cascade.py`:

- `test_official_row_resolves_expected_sql_and_question` — constructs an
  OFFICIAL-shape failing row (top-level `expected_sql` +
  `inputs/expected_response` + `response.response`/`generated_sql`, **no
  `request` key**) with both expected and generated SQL present, runs it
  through `cluster_failures`, and asserts (a) the resulting failure's
  `sql_context.expected_sql` and `question` are non-empty and (b) the
  resolved root cause is **not** `unverifiable_no_expected_sql`.
- `test_legacy_request_row_still_resolves_expected_sql_and_question`
  (parametrized over the sibling and kwargs-nested request shapes) — proves
  legacy in-process rows still resolve and classify correctly.

Verified the new tests **fail on the pre-fix code** (official row →
`unverifiable_no_expected_sql` with empty `expected_sql`; kwargs-nested
legacy row also broken) and **pass after the fix**.

## Test / lint / typecheck results

Run from `packages/genie-space-optimizer/`:

- `uv run --frozen pytest tests/unit` → **3917 passed, 1 skipped, 3 xfailed,
  2 failed**. Both failures
  (`test_unified_rca_prompt_alignment::test_leak_safe_example_synthesis_contract_constant_exists`
  and
  `test_arbiter_approved_mining::TestRunEnrichmentSignature::test_signature_has_held_out_benchmarks_kwonly`)
  are **pre-existing on the base commit** (confirmed by stashing this change
  and re-running) and unrelated to this fix.
- `uv run --frozen ty check src/.../optimizer.py src/.../eval_row_access.py`
  → **84 diagnostics, identical to baseline** (no new diagnostics introduced;
  all are pre-existing dynamic-dict-access warnings). `ty` is the package's
  only configured Python static-analysis tool — there is no ruff/flake8/mypy
  /pyright config.
- `uv lock --check` → clean (no dependency changes).

## Files changed

- `packages/genie-space-optimizer/src/genie_space_optimizer/optimization/optimizer.py`
- `packages/genie-space-optimizer/src/genie_space_optimizer/optimization/eval_row_access.py`
- `packages/genie-space-optimizer/tests/unit/test_root_cause_cascade.py`

This pull request and its description were written by Isaac.
