### PR TITLE
GSO v2 cutover: deploy paths create+trigger the 5-task job

### DIFF
--- a/backend/tests/test_deploy_lib.py
+++ b/backend/tests/test_deploy_lib.py
@@ -363,7 +363,26 @@ def test_get_app_service_principal_waits_for_async_app_create(monkeypatch):
     assert len(get_calls) == 2
 
 
-def test_gso_job_settings_match_persistent_dag_shape():
+# GSO v2 linear 5-task DAG (mirrors packages/genie-space-optimizer/databricks.yml,
+# validated by tests/unit/test_phase7_job_dag.py).
+_EXPECTED_5TASK_KEYS = [
+    "00_intake_and_snapshot",
+    "01_benchmark_qc_and_repair",
+    "02_baseline_eval_and_triage",
+    "03_optimize",
+    "publish_and_audit",
+]
+
+_EXPECTED_5TASK_NOTEBOOKS = {
+    "00_intake_and_snapshot": "run_00_intake_and_snapshot",
+    "01_benchmark_qc_and_repair": "run_01_benchmark_qc_and_repair",
+    "02_baseline_eval_and_triage": "run_02_baseline_eval_and_triage",
+    "03_optimize": "run_03_optimize",
+    "publish_and_audit": "run_publish_and_audit",
+}
+
+
+def test_gso_job_settings_match_5task_dag_shape():
     cfg = InstallConfig(
         app_name="genie-workbench",
         catalog="main",
@@ -377,19 +396,83 @@ def test_gso_job_settings_match_persistent_dag_shape():
         "/Volumes/main/genie_space_optimizer/app_artifacts/genie_space_optimizer-0.0.0-py3-none-any.whl",
     )
 
+    # Unchanged job identity: name + tags stay stable so find_existing_job can
+    # re-discover and upsert prior notebook installs across the cutover.
     assert settings["name"] == "genie-workbench-gso-optimization-job"
     assert settings["queue"]["enabled"] is True
     assert settings["tags"]["app"] == "genie-workbench"
     assert settings["tags"]["managed-by"] == "notebook-installer"
+    assert settings["tags"]["pattern"] == "persistent-dag"
     assert settings["environments"][0]["spec"]["environment_version"] == "4"
+
+    # 5-task linear DAG — no condition task, no deploy task, correct entrypoints.
+    tasks = settings["tasks"]
+    assert [t["task_key"] for t in tasks] == _EXPECTED_5TASK_KEYS
+    assert all("condition_task" not in t for t in tasks)
+    for t in tasks:
+        stem = t["notebook_task"]["notebook_path"].rsplit("/", 1)[-1]
+        assert stem == _EXPECTED_5TASK_NOTEBOOKS[t["task_key"]]
+    by_key = {t["task_key"]: t for t in tasks}
+    assert "depends_on" not in by_key["00_intake_and_snapshot"]
+    for prev, cur in zip(_EXPECTED_5TASK_KEYS, _EXPECTED_5TASK_KEYS[1:]):
+        assert by_key[cur]["depends_on"] == [{"task_key": prev}]
+
+    # New v2 loop params present with defaults; retired params gone.
     params = {p["name"]: p["default"] for p in settings["parameters"]}
+    assert params["max_attempts"] == "3"
+    assert params["target_accuracy"] == "0.90"
+    assert params["benchmark_repair_max_tries"] == "3"
+    assert "experiment_name" not in params
+    assert "deploy_target" not in params
+    # llm_model stays a Workbench-specific param defaulted to cfg.llm_model.
     assert params["llm_model"] == "custom-gso-model"
-    task_keys = [task["task_key"] for task in settings["tasks"]]
-    assert task_keys == ["preflight", "baseline_eval", "enrichment", "lever_loop", "finalize", "deploy"]
-    assert settings["tasks"][0]["notebook_task"]["base_parameters"]["llm_model"] == "{{job.parameters.llm_model}}"
-    assert settings["tasks"][1]["notebook_task"]["base_parameters"]["llm_model"] == "{{job.parameters.llm_model}}"
-    assert settings["tasks"][1]["depends_on"] == [{"task_key": "preflight"}]
-    assert settings["tasks"][-1]["condition_task"]["right"] == "disabled"
+
+    # Every task carries run_id/catalog/schema (D9 — bootstrap from job params,
+    # no task-value plumbing) and the operator llm_model.
+    for t in tasks:
+        bp = t["notebook_task"]["base_parameters"]
+        assert bp["llm_model"] == "{{job.parameters.llm_model}}"
+        for required in ("run_id", "catalog", "schema"):
+            assert bp[required] == f"{{{{job.parameters.{required}}}}}"
+
+
+def test_gso_job_settings_mirror_package_bundle_5task():
+    """The notebook-installer job (gso_job.py) and the package bundle
+    (packages/genie-space-optimizer/databricks.yml, validated by
+    test_phase7_job_dag.py) must not silently drift: identical task keys/order,
+    entrypoints, per-task base_parameters and declared params, EXCEPT for the
+    Workbench-specific ``llm_model`` extra."""
+    yaml = pytest.importorskip("yaml")
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle_path = repo_root / "packages" / "genie-space-optimizer" / "databricks.yml"
+    bundle = yaml.safe_load(bundle_path.read_text())
+    (pkg_job,) = bundle["resources"]["jobs"].values()
+
+    cfg = InstallConfig(app_name="genie-workbench", catalog="main", warehouse_id="wh", repo_root="/tmp")
+    settings = build_job_settings(cfg, "/Workspace/Users/me/gso/jobs", "/Volumes/main/schema/wheel.whl")
+
+    def _stem(path: str) -> str:
+        return path.rsplit("/", 1)[-1].removesuffix(".py")
+
+    # Same task keys + order.
+    assert [t["task_key"] for t in settings["tasks"]] == [t["task_key"] for t in pkg_job["tasks"]]
+    # Same entrypoint stems.
+    assert [_stem(t["notebook_task"]["notebook_path"]) for t in settings["tasks"]] == [
+        _stem(t["notebook_task"]["notebook_path"]) for t in pkg_job["tasks"]
+    ]
+
+    # Declared params identical except llm_model.
+    gso_params = {p["name"] for p in settings["parameters"]}
+    pkg_params = {p["name"] for p in pkg_job["parameters"]}
+    assert gso_params - pkg_params == {"llm_model"}
+    assert pkg_params - gso_params == set()
+
+    # Per-task base_parameters identical except llm_model.
+    gso_bp = {t["task_key"]: set(t["notebook_task"]["base_parameters"]) for t in settings["tasks"]}
+    pkg_bp = {t["task_key"]: set(t["notebook_task"].get("base_parameters", {})) for t in pkg_job["tasks"]}
+    for key in gso_bp:
+        assert gso_bp[key] - pkg_bp[key] == {"llm_model"}, key
+        assert pkg_bp[key] - gso_bp[key] == set(), key
 
 
 def test_gso_job_settings_tag_with_actual_app_name():

--- a/backend/tests/test_deploy_lib.py
+++ b/backend/tests/test_deploy_lib.py
@@ -12,7 +12,13 @@ from scripts.deploy_lib.apps import (
 )
 from scripts.deploy_lib.config import InstallConfig, LakebaseInfo
 from scripts.deploy_lib.genie_spaces import optionally_grant_genie_spaces
-from scripts.deploy_lib.gso_job import build_job_settings, find_existing_job, upsert_job
+from scripts.deploy_lib.gso_job import (
+    TASKS,
+    build_job_settings,
+    find_existing_job,
+    upload_job_notebooks,
+    upsert_job,
+)
 from scripts.deploy_lib.lakebase import ensure_lakebase, get_database_resource
 from scripts.deploy_lib.uc import update_grants
 from scripts.deploy_lib.workspace_source import mkdirs, should_copy, upload_source_notebook, workspace_api_path
@@ -473,6 +479,44 @@ def test_gso_job_settings_mirror_package_bundle_5task():
     for key in gso_bp:
         assert gso_bp[key] - pkg_bp[key] == {"llm_model"}, key
         assert pkg_bp[key] - gso_bp[key] == set(), key
+
+
+def test_upload_job_notebooks_uploads_all_five_task_notebooks(tmp_path):
+    """Exercise the TASKS upload loop end-to-end. Guards against the 4-tuple
+    arity regression: upload_job_notebooks must iterate every TASKS entry and
+    import exactly the 5 v2 entrypoints (this loop is what the install.py path
+    runs before creating the job)."""
+    jobs_dir = tmp_path / "packages" / "genie-space-optimizer" / "src" / "genie_space_optimizer" / "jobs"
+    jobs_dir.mkdir(parents=True)
+    expected_stems = [notebook_stem for _key, notebook_stem, _dep, _bp in TASKS]
+    for stem in expected_stems:
+        (jobs_dir / f"{stem}.py").write_text(f"# {stem}\n")
+
+    cfg = InstallConfig(
+        app_name="genie-workbench",
+        catalog="main",
+        warehouse_id="wh",
+        repo_root=str(tmp_path),
+    )
+    w = FakeWorkspaceClient()
+
+    notebooks_path = upload_job_notebooks(w, cfg, "me@example.com")
+
+    assert notebooks_path.endswith("/genie-workbench/gso/jobs")
+    import_paths = [
+        body["path"]
+        for method, path, body in w.api_client.calls
+        if method == "POST" and path == "/api/2.0/workspace/import"
+    ]
+    # Every task notebook imported, in DAG order, with no arity error.
+    assert [p.rsplit("/", 1)[-1] for p in import_paths] == expected_stems
+    assert expected_stems == [
+        "run_00_intake_and_snapshot",
+        "run_01_benchmark_qc_and_repair",
+        "run_02_baseline_eval_and_triage",
+        "run_03_optimize",
+        "run_publish_and_audit",
+    ]
 
 
 def test_gso_job_settings_tag_with_actual_app_name():

--- a/databricks.yml
+++ b/databricks.yml
@@ -51,9 +51,14 @@ resources:
     gso-optimization-runner:
       name: "gso-optimization-job"
       description: >-
-        Persistent DAG optimization runner managed by Genie Workbench
-        (preflight -> baseline_eval -> enrichment -> lever_loop -> finalize -> deploy).
-        SP executes with granted privileges on user schemas.
+        GSO v2 bounded hill-climbing runner managed by Genie Workbench
+        (00_intake_and_snapshot -> 01_benchmark_qc_and_repair ->
+        02_baseline_eval_and_triage -> 03_optimize -> publish_and_audit).
+        Linear 5-task serverless DAG; the whole hill-climb runs as an in-process
+        while-loop inside 03_optimize. No condition tasks, no dbutils.notebook.run,
+        no inter-task task-value plumbing — every task reads job parameters +
+        durable Delta state by run_id (D9). SP executes with granted privileges
+        on user schemas.
       max_concurrent_runs: 20
       queue:
         enabled: true
@@ -61,6 +66,13 @@ resources:
         app: "genie-workbench"
         managed-by: "databricks-bundle"
         pattern: "persistent-dag"
+      # Parameter set mirrors the package bundle
+      # (packages/genie-space-optimizer/databricks.yml) 5-task job. `llm_model`
+      # is the Workbench-specific extra: deploy.sh passes it via
+      # `--var llm_model` so the operator-selected serving endpoint reaches each
+      # task (every v2 entrypoint honors the llm_model widget). MLflow was
+      # decommissioned (Phase 5) so `experiment_name` is gone, and `deploy` is
+      # out of scope (D7) so `deploy_target` is gone.
       parameters:
         - name: run_id
           default: ""
@@ -76,22 +88,35 @@ resources:
           default: "genie_config"
         - name: levers
           default: "[1,2,3,4,5,6]"
+        # Surgical hill-climb budget (counts surgical attempts only; the
+        # attempt-1 coverage pass is a free probe — arch §12 / §13.5).
+        - name: max_attempts
+          default: "3"
+        # Stop-early target accuracy (arch §12).
+        - name: target_accuracy
+          default: "0.90"
+        # Bound on 01's inline benchmark repair/prune loop (arch §12).
+        - name: benchmark_repair_max_tries
+          default: "3"
+        # Retained: still consumed by the existing lever loop that 03_optimize
+        # temporarily delegates to.
         - name: max_iterations
           default: "5"
         - name: triggered_by
-          default: ""
-        - name: experiment_name
-          default: ""
-        - name: deploy_target
           default: ""
         - name: warehouse_id
           default: ""
         - name: llm_model
           default: ${var.llm_model}
+      # Every task carries its job-parameter subset as base_parameters so there
+      # is NO inter-task task-value plumbing (D9). run_id/catalog/schema
+      # bootstrap each notebook; all other handoff state is read from Delta by
+      # run_id. This mirrors the package bundle; `llm_model` is added to every
+      # task (Workbench-specific — see the parameter note above).
       tasks:
-        - task_key: preflight
+        - task_key: 00_intake_and_snapshot
           notebook_task:
-            notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_preflight.py
+            notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_00_intake_and_snapshot.py
             base_parameters:
               run_id: "{{job.parameters.run_id}}"
               space_id: "{{job.parameters.space_id}}"
@@ -100,61 +125,94 @@ resources:
               schema: "{{job.parameters.schema}}"
               apply_mode: "{{job.parameters.apply_mode}}"
               levers: "{{job.parameters.levers}}"
+              max_attempts: "{{job.parameters.max_attempts}}"
+              target_accuracy: "{{job.parameters.target_accuracy}}"
+              benchmark_repair_max_tries: "{{job.parameters.benchmark_repair_max_tries}}"
               max_iterations: "{{job.parameters.max_iterations}}"
-              experiment_name: "{{job.parameters.experiment_name}}"
-              deploy_target: "{{job.parameters.deploy_target}}"
+              triggered_by: "{{job.parameters.triggered_by}}"
               warehouse_id: "{{job.parameters.warehouse_id}}"
               llm_model: "{{job.parameters.llm_model}}"
           environment_key: default
-          timeout_seconds: 7200
+          timeout_seconds: 14400
           max_retries: 0
-        - task_key: baseline_eval
+        - task_key: 01_benchmark_qc_and_repair
           depends_on:
-            - task_key: preflight
+            - task_key: 00_intake_and_snapshot
           notebook_task:
-            notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_baseline.py
+            notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_01_benchmark_qc_and_repair.py
             base_parameters:
+              run_id: "{{job.parameters.run_id}}"
+              space_id: "{{job.parameters.space_id}}"
+              domain: "{{job.parameters.domain}}"
+              catalog: "{{job.parameters.catalog}}"
+              schema: "{{job.parameters.schema}}"
+              apply_mode: "{{job.parameters.apply_mode}}"
+              benchmark_repair_max_tries: "{{job.parameters.benchmark_repair_max_tries}}"
+              warehouse_id: "{{job.parameters.warehouse_id}}"
               llm_model: "{{job.parameters.llm_model}}"
           environment_key: default
-          timeout_seconds: 7200
+          timeout_seconds: 14400
           max_retries: 0
-        - task_key: enrichment
+        - task_key: 02_baseline_eval_and_triage
           depends_on:
-            - task_key: baseline_eval
+            - task_key: 01_benchmark_qc_and_repair
           notebook_task:
-            notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_enrichment.py
+            notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_02_baseline_eval_and_triage.py
             base_parameters:
+              run_id: "{{job.parameters.run_id}}"
+              space_id: "{{job.parameters.space_id}}"
+              domain: "{{job.parameters.domain}}"
+              catalog: "{{job.parameters.catalog}}"
+              schema: "{{job.parameters.schema}}"
+              apply_mode: "{{job.parameters.apply_mode}}"
+              max_attempts: "{{job.parameters.max_attempts}}"
+              target_accuracy: "{{job.parameters.target_accuracy}}"
+              warehouse_id: "{{job.parameters.warehouse_id}}"
               llm_model: "{{job.parameters.llm_model}}"
           environment_key: default
-          timeout_seconds: 7200
+          timeout_seconds: 14400
           max_retries: 0
-        - task_key: lever_loop
+        - task_key: 03_optimize
           depends_on:
-            - task_key: enrichment
+            - task_key: 02_baseline_eval_and_triage
           notebook_task:
-            notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_lever_loop.py
+            notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_03_optimize.py
             base_parameters:
+              run_id: "{{job.parameters.run_id}}"
+              space_id: "{{job.parameters.space_id}}"
+              domain: "{{job.parameters.domain}}"
+              catalog: "{{job.parameters.catalog}}"
+              schema: "{{job.parameters.schema}}"
+              apply_mode: "{{job.parameters.apply_mode}}"
+              levers: "{{job.parameters.levers}}"
+              max_attempts: "{{job.parameters.max_attempts}}"
+              target_accuracy: "{{job.parameters.target_accuracy}}"
+              max_iterations: "{{job.parameters.max_iterations}}"
+              triggered_by: "{{job.parameters.triggered_by}}"
+              warehouse_id: "{{job.parameters.warehouse_id}}"
               llm_model: "{{job.parameters.llm_model}}"
           environment_key: default
-          timeout_seconds: 7200
+          timeout_seconds: 14400
           max_retries: 0
-        - task_key: finalize
+        - task_key: publish_and_audit
           depends_on:
-            - task_key: lever_loop
+            - task_key: 03_optimize
           notebook_task:
-            notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_finalize.py
+            notebook_path: ./packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_publish_and_audit.py
             base_parameters:
+              run_id: "{{job.parameters.run_id}}"
+              space_id: "{{job.parameters.space_id}}"
+              domain: "{{job.parameters.domain}}"
+              catalog: "{{job.parameters.catalog}}"
+              schema: "{{job.parameters.schema}}"
+              apply_mode: "{{job.parameters.apply_mode}}"
+              target_accuracy: "{{job.parameters.target_accuracy}}"
+              max_attempts: "{{job.parameters.max_attempts}}"
+              warehouse_id: "{{job.parameters.warehouse_id}}"
               llm_model: "{{job.parameters.llm_model}}"
           environment_key: default
-          timeout_seconds: 7200
+          timeout_seconds: 14400
           max_retries: 0
-        - task_key: deploy
-          depends_on:
-            - task_key: finalize
-          condition_task:
-            op: EQUAL_TO
-            left: "deploy"
-            right: "disabled"
       environments:
         - environment_key: default
           spec:

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/backend/job_launcher.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/backend/job_launcher.py
@@ -381,6 +381,17 @@ def submit_optimization(
                 space_id=space_id,
                 triggered_by=triggered_by,
             ),
+            # Only send parameters the 5-task job declares. Every key here must
+            # be a job parameter on the runner (run_now rejects undeclared
+            # keys), so this set MUST stay a subset of the declared params in
+            # BOTH job definitions: the root bundle
+            # (databricks.yml resources.jobs.gso-optimization-runner) and the
+            # notebook installer (scripts/deploy_lib/gso_job.py) — which in turn
+            # mirror the package bundle. `deploy_target` (deploy out of scope —
+            # D7) and `target_benchmark_count` (a code constant, not a v2 job
+            # param) are intentionally NOT sent; the kwargs remain for caller
+            # signature compatibility. `benchmark_repair_max_tries` is declared
+            # by the job but not overridden here, so it uses the job default.
             job_parameters={
                 "run_id": run_id,
                 "space_id": space_id,
@@ -397,9 +408,7 @@ def submit_optimization(
                 "target_accuracy": target_accuracy,
                 "max_attempts": max_attempts,
                 "triggered_by": triggered_by,
-                "deploy_target": deploy_target,
                 "warehouse_id": warehouse_id,
-                "target_benchmark_count": target_benchmark_count,
                 "llm_model": llm_model or os.getenv("LLM_MODEL", ""),
             },
         )

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,7 +11,10 @@ set -euo pipefail
 #     3. Create app (if not exists)
 #     4. Full-sync files to workspace
 #     5. Resolve app SP + Grant UC permissions (+ enable CDF on GSO tables)
-#     6. Deploy optimization job via bundle (databricks bundle deploy -t app)
+#     6. Deploy optimization job via bundle — GSO v2 linear 5-task DAG:
+#        00_intake_and_snapshot -> 01_benchmark_qc_and_repair ->
+#        02_baseline_eval_and_triage -> 03_optimize -> publish_and_audit
+#        (databricks bundle deploy -t app)
 #     7. Redeploy app (apps deploy --source-code-path)
 #     8. Verify deployment
 #
@@ -353,12 +356,13 @@ fi
 # Verify critical job notebooks actually landed on the workspace.
 # The bundle's incremental sync can silently skip files if the local snapshot
 # diverges from workspace reality. This catches that failure at deploy time
-# rather than at job runtime.
-_PREFLIGHT_NB="/Workspace/Users/$DEPLOYER/.bundle/genie-workbench/app/files/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_preflight"
-if ! databricks workspace get-status "$_PREFLIGHT_NB" --profile "$PROFILE" -o json >/dev/null 2>&1; then
+# rather than at job runtime. Probe the first task of the 5-task DAG
+# (00_intake_and_snapshot) as the sync canary.
+_INTAKE_NB="/Workspace/Users/$DEPLOYER/.bundle/genie-workbench/app/files/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/run_00_intake_and_snapshot"
+if ! databricks workspace get-status "$_INTAKE_NB" --profile "$PROFILE" -o json >/dev/null 2>&1; then
     echo ""
     echo "  ✗ FATAL: Bundle file sync failed — job notebook not found at:"
-    echo "    $_PREFLIGHT_NB"
+    echo "    $_INTAKE_NB"
     echo ""
     echo "  Remediation:"
     echo "    1. Delete stale sync snapshots:"

--- a/scripts/deploy_lib/gso_job.py
+++ b/scripts/deploy_lib/gso_job.py
@@ -20,14 +20,79 @@ from .workspace_source import (
 )
 
 
+# GSO v2 linear 5-task DAG. This MIRRORS the package bundle job at
+# packages/genie-space-optimizer/databricks.yml (the validated source of truth,
+# guarded by tests/unit/test_phase7_job_dag.py): same task keys, order,
+# entrypoints, linear dependencies, and per-task base_parameters. There is NO
+# condition task and NO `deploy` task (deploy is out of scope — D7). Each entry
+# is (task_key, notebook_stem, depends_on, base_param_keys). `base_param_keys`
+# lists the job parameters passed to that task as base_parameters (every task
+# reads job params + durable Delta state by run_id — no task-value plumbing, D9).
+#
+# `llm_model` is a Workbench-specific extra beyond the package bundle's params:
+# the local-terminal deploy passes it via `--var llm_model` (deploy.sh) and the
+# notebook installer defaults it to cfg.llm_model, so the operator-selected
+# serving endpoint reaches each task (every v2 entrypoint honors the llm_model
+# widget). See build_job_settings for the parameter declarations.
 TASKS = [
-    ("preflight", "run_preflight", None),
-    ("baseline_eval", "run_baseline", "preflight"),
-    ("enrichment", "run_enrichment", "baseline_eval"),
-    ("lever_loop", "run_lever_loop", "enrichment"),
-    ("finalize", "run_finalize", "lever_loop"),
+    (
+        "00_intake_and_snapshot",
+        "run_00_intake_and_snapshot",
+        None,
+        [
+            "run_id", "space_id", "domain", "catalog", "schema", "apply_mode",
+            "levers", "max_attempts", "target_accuracy",
+            "benchmark_repair_max_tries", "max_iterations", "triggered_by",
+            "warehouse_id", "llm_model",
+        ],
+    ),
+    (
+        "01_benchmark_qc_and_repair",
+        "run_01_benchmark_qc_and_repair",
+        "00_intake_and_snapshot",
+        [
+            "run_id", "space_id", "domain", "catalog", "schema", "apply_mode",
+            "benchmark_repair_max_tries", "warehouse_id", "llm_model",
+        ],
+    ),
+    (
+        "02_baseline_eval_and_triage",
+        "run_02_baseline_eval_and_triage",
+        "01_benchmark_qc_and_repair",
+        [
+            "run_id", "space_id", "domain", "catalog", "schema", "apply_mode",
+            "max_attempts", "target_accuracy", "warehouse_id", "llm_model",
+        ],
+    ),
+    (
+        "03_optimize",
+        "run_03_optimize",
+        "02_baseline_eval_and_triage",
+        [
+            "run_id", "space_id", "domain", "catalog", "schema", "apply_mode",
+            "levers", "max_attempts", "target_accuracy", "max_iterations",
+            "triggered_by", "warehouse_id", "llm_model",
+        ],
+    ),
+    (
+        "publish_and_audit",
+        "run_publish_and_audit",
+        "03_optimize",
+        [
+            "run_id", "space_id", "domain", "catalog", "schema", "apply_mode",
+            "target_accuracy", "max_attempts", "warehouse_id", "llm_model",
+        ],
+    ),
 ]
 
+# Declared job parameters + defaults. Mirrors the package bundle's 5-task param
+# set (arch §12): surgical hill-climb budget (max_attempts), stop-early
+# target (target_accuracy), and 01's inline repair bound
+# (benchmark_repair_max_tries). `max_iterations` is retained (still consumed by
+# the lever loop that 03_optimize delegates to). `experiment_name` (MLflow
+# decommissioned — Phase 5) and `deploy_target` (deploy out of scope — D7) are
+# dropped. `llm_model` is the Workbench-specific extra (see TASKS above);
+# its default is overridden with cfg.llm_model in build_job_settings.
 JOB_PARAMETERS = {
     "run_id": "",
     "space_id": "",
@@ -36,10 +101,11 @@ JOB_PARAMETERS = {
     "schema": "",
     "apply_mode": "genie_config",
     "levers": "[1,2,3,4,5,6]",
+    "max_attempts": "3",
+    "target_accuracy": "0.90",
+    "benchmark_repair_max_tries": "3",
     "max_iterations": "5",
     "triggered_by": "",
-    "experiment_name": "",
-    "deploy_target": "",
     "warehouse_id": "",
     "llm_model": "",
 }
@@ -122,55 +188,42 @@ def upload_gso_wheel(w, cfg: InstallConfig) -> str:
     return wheel_path
 
 
-def _task_payload(task_key: str, notebook_stem: str, depends_on: str | None, notebooks_path: str) -> dict[str, Any]:
+def _task_payload(
+    task_key: str,
+    notebook_stem: str,
+    depends_on: str | None,
+    base_param_keys: list[str],
+    notebooks_path: str,
+) -> dict[str, Any]:
     task: dict[str, Any] = {
         "task_key": task_key,
         "notebook_task": {
             "notebook_path": f"{notebooks_path}/{notebook_stem}",
             "source": "WORKSPACE",
             "base_parameters": {
-                "llm_model": "{{job.parameters.llm_model}}",
+                key: f"{{{{job.parameters.{key}}}}}" for key in base_param_keys
             },
         },
         "environment_key": "default",
-        "timeout_seconds": 7200,
+        "timeout_seconds": 14400,
         "max_retries": 0,
     }
     if depends_on:
         task["depends_on"] = [{"task_key": depends_on}]
-    if task_key == "preflight":
-        task["notebook_task"]["base_parameters"].update({
-            "run_id": "{{job.parameters.run_id}}",
-            "space_id": "{{job.parameters.space_id}}",
-            "domain": "{{job.parameters.domain}}",
-            "catalog": "{{job.parameters.catalog}}",
-            "schema": "{{job.parameters.schema}}",
-            "apply_mode": "{{job.parameters.apply_mode}}",
-            "levers": "{{job.parameters.levers}}",
-            "max_iterations": "{{job.parameters.max_iterations}}",
-            "experiment_name": "{{job.parameters.experiment_name}}",
-            "deploy_target": "{{job.parameters.deploy_target}}",
-            "warehouse_id": "{{job.parameters.warehouse_id}}",
-            "llm_model": "{{job.parameters.llm_model}}",
-        })
     return task
 
 
 def build_job_settings(cfg: InstallConfig, notebooks_path: str, wheel_path: str) -> dict[str, Any]:
     cfg = cfg.normalized()
     tasks = [_task_payload(*task, notebooks_path) for task in TASKS]
-    tasks.append(
-        {
-            "task_key": "deploy",
-            "depends_on": [{"task_key": "finalize"}],
-            "condition_task": {"op": "EQUAL_TO", "left": "deploy", "right": "disabled"},
-        }
-    )
     return {
         "name": cfg.gso_job_name,
         "description": (
-            "Persistent DAG optimization runner managed by Genie Workbench "
-            "(preflight -> baseline_eval -> enrichment -> lever_loop -> finalize -> deploy)."
+            "GSO v2 bounded hill-climbing runner managed by Genie Workbench "
+            "(00_intake_and_snapshot -> 01_benchmark_qc_and_repair -> "
+            "02_baseline_eval_and_triage -> 03_optimize -> publish_and_audit). "
+            "Linear 5-task serverless DAG; the whole hill-climb runs in-process "
+            "inside 03_optimize."
         ),
         "max_concurrent_runs": 20,
         "queue": {"enabled": True},

--- a/scripts/deploy_lib/gso_job.py
+++ b/scripts/deploy_lib/gso_job.py
@@ -127,7 +127,7 @@ def upload_job_notebooks(w, cfg: InstallConfig, deployer_user: str) -> str:
 
     notebooks_path = f"{default_gso_path(deployer_user, cfg.app_name)}/jobs"
     mkdirs(w, notebooks_path)
-    for _, notebook_stem, _ in TASKS:
+    for _task_key, notebook_stem, _depends_on, _base_param_keys in TASKS:
         upload_source_notebook(w, jobs_dir / f"{notebook_stem}.py", f"{notebooks_path}/{notebook_stem}")
     return notebooks_path
 


### PR DESCRIPTION
## Summary

Rewire **both** Workbench install paths so they create AND trigger the **new GSO v2 linear 5-task job** instead of the retired **6-task DAG**. Before this change both paths (deploy.sh → root bundle; `notebooks/install.py` → `gso_job.py`) built a 6-task job, and the app triggers whatever numeric `GSO_JOB_ID` was written into `app.yaml` — so both drove the old job.

This is **rewiring only**. The validated package bundle `packages/genie-space-optimizer/databricks.yml` (guarded by `test_phase7_job_dag.py`) is the **source of truth**; both Workbench job definitions mirror its task keys/order/entrypoints/dependencies and param set. **Deployment architecture is unchanged** (Workbench app owns ONE job via `GSO_JOB_ID`; deploy.sh deploys the root bundle; `gso_job.py` is the SDK path used by `install.py`).

## 1. What changed in each wiring surface

### `scripts/deploy_lib/gso_job.py` (notebook installer — SDK/REST job)
- Replaced the hardcoded 6-task `TASKS` with the **5-task linear DAG**: `00_intake_and_snapshot → 01_benchmark_qc_and_repair → 02_baseline_eval_and_triage → 03_optimize → publish_and_audit`, pointing at the new `run_0X_*` / `run_publish_and_audit` entrypoints with correct linear `depends_on`. **No condition task, no `deploy` task.**
- Per-task `base_parameters` now mirror the package bundle exactly (+ `llm_model`). `timeout_seconds` raised to `14400` to match the package (the whole hill-climb runs in-process inside `03_optimize`).
- `JOB_PARAMETERS`: dropped `experiment_name` (MLflow decommissioned — Phase 5) and `deploy_target` (deploy out of scope — D7); added `target_accuracy` (`0.90`), `max_attempts` (`3`), `benchmark_repair_max_tries` (`3`).
- `TASKS` entries became 4-tuples `(task_key, notebook_stem, depends_on, base_param_keys)`; both loops that consume `TASKS` (`upload_job_notebooks` and `build_job_settings`/`_task_payload`) were updated for the new arity.
- **Unchanged:** job name (`<app>-gso-optimization-job`), tags (`app`/`managed-by: notebook-installer`/`pattern: persistent-dag`), and run_as/SP logic — so `find_existing_job` still re-discovers and upserts prior installs across the cutover.

### `databricks.yml` (root bundle — deploy.sh path)
- `resources.jobs.gso-optimization-runner` reshaped from the 6-task DAG to the **same 5-task DAG + param set**, mirroring the package bundle.
- **Unchanged:** job `name: "gso-optimization-job"`, serverless/`queue`/`tags`, and the `app` target / `name_prefix: ""` behavior. Description updated (removed the `preflight → … → deploy` text).

### `scripts/deploy.sh`
- Header step-6 DAG description updated to the 5-task chain.
- Sync-canary smoke test (~line 357) now probes `run_00_intake_and_snapshot` instead of the retired `run_preflight` (variable renamed `_PREFLIGHT_NB` → `_INTAKE_NB`).
- The `--var="llm_model=$LLM_MODEL"` passes to `bundle deploy`/`summary` are intentionally left in place (see param contract).

### `submit_optimization` (the trigger's `run_now`)
The task pointed at `integration/trigger.py:~203-241` (the call site); the actual `run_now` `job_parameters` dict lives in `packages/genie-space-optimizer/src/genie_space_optimizer/backend/job_launcher.py::submit_optimization`. `trigger_optimization` (`auto_optimize.py:1279` → this function) is the single active trigger path for the Workbench.
- Removed `deploy_target` and `target_benchmark_count` from the `run_now` `job_parameters` dict — the 5-task job declares neither, and `run_now` rejects undeclared keys. The kwargs remain on the signature for caller-signature compatibility (the package's own `backend/routes/spaces.py` caller still passes them).

## 2. Final trigger ↔ job param contract (verified, consistent)

Verified by executing `submit_optimization` with a mock and parsing all three YAML/Python definitions:

| Representation | Param set |
|---|---|
| **Trigger `run_now` (SENT, 13)** | run_id, space_id, domain, catalog, schema, apply_mode, levers, max_attempts, target_accuracy, max_iterations, triggered_by, warehouse_id, **llm_model** |
| **Root bundle (DECLARED, 14)** | SENT’s 13 + **benchmark_repair_max_tries** |
| **gso_job.py (DECLARED, 14)** | identical to root bundle |
| **Package bundle (DECLARED, 13)** | the 14 minus **llm_model** |

Consistency checks (all pass):
- `root declared == gso_job.py declared` → **True**
- `SENT ⊆ root` and `SENT ⊆ gso_job.py` → **True, zero orphan params** (nothing sent that isn't declared)
- declared-but-not-sent → **`benchmark_repair_max_tries`** only, which correctly falls back to the job default (matches the package bundle's own design — `submit_optimization` doesn't override it)
- Workbench jobs − package bundle → **exactly `{llm_model}`**; package bundle − Workbench jobs → **∅**

**Why `llm_model` is kept (single documented divergence from the package bundle):** it is declared as a job param, `deploy.sh` passes `--var="llm_model=$LLM_MODEL"`, and the notebook installer defaults it to `cfg.llm_model`, so a per-run operator model choice is threaded through. Of the five entrypoints, the four that declare an `llm_model` widget — `00_intake_and_snapshot`, `01_benchmark_qc_and_repair`, `02_baseline_eval_and_triage`, `03_optimize` — read it and export `LLM_MODEL` from it. **`publish_and_audit` is the exception**: `run_publish_and_audit.py` declares no `llm_model` widget, so it ignores the per-run value; its audit-summary LLM call resolves the endpoint via `get_llm_endpoint()` in `common/config.py` (`GSO_LLM_ENDPOINT` → `LLM_MODEL` → default), i.e. the `LLM_MODEL` config default. Passing `llm_model` in that task's `base_parameters` is harmless (an undeclared widget is ignored) and does **not** break the param-declaration contract — kept for per-task uniformity; this PR stays rewiring-only and changes no entrypoint. Threading the per-run model into the publish audit summary is a possible follow-up (out of scope here). This is consistent with the root bundle already retaining other Workbench-specific bits (job name, tags, notebook path prefix, `${var.llm_model}`). `experiment_name`, `deploy_target`, and `target_benchmark_count` are declared/sent by **none** of the representations.

## 3. Test changes
- `backend/tests/test_deploy_lib.py`: `test_gso_job_settings_match_persistent_dag_shape` → `test_gso_job_settings_match_5task_dag_shape` (asserts the 5-task keys/order/entrypoints, linear deps, no condition task, new params + defaults, `experiment_name`/`deploy_target` absent, `llm_model` present & defaulted, per-task `base_parameters`).
- Added `test_gso_job_settings_mirror_package_bundle_5task`: cross-checks `gso_job.py`'s built job against the package bundle YAML — same task keys/order/entrypoints, and declared params + per-task `base_parameters` identical **except `{llm_model}`** — so the two representations can't silently drift.
- Added `test_upload_job_notebooks_uploads_all_five_task_notebooks`: exercises the `TASKS` upload loop end-to-end (imports all 5 entrypoints in DAG order). The prior tests only exercised `build_job_settings`, which is why the `upload_job_notebooks` arity break slipped through — this closes that gap.
- `test_phase7_job_dag.py` (validates the package bundle) left **passing unchanged**.

## 4. Gate results
- **`env -u PYTHONPATH ./scripts/test.sh` (backend):** `2 failed, 479 passed`. The 2 failures are the pre-existing `test_create_agent.py::TestCreateSpaceIdempotency` cases (test-fixture `SimpleNamespace` missing `llm_model`) — identical to the base (`2 failed, 477 passed`); the +2 are the two new deploy-lib tests. **No new failures introduced.**
- **`packages/genie-space-optimizer && pytest tests/unit/test_phase7_job_dag.py`:** `14 passed` — package-bundle validation unchanged.
- **`databricks bundle validate -t app`** (profile `fevm-dhuang`, read-only — no deploy/run-now): **valid, no errors**; 7 warnings are all pre-existing `sync.include/exclude` patterns (`.build`, `dashboards/**`, `sql/**`, etc.) that don't match files in a fresh worktree — those lines were not modified.

## 5. Deferred Phase 15 confirmation
The old **6-task entrypoints** (`run_preflight.py`, `run_baseline.py`, `run_enrichment.py`, `run_lever_loop.py`, `run_finalize.py`, `run_deploy.py`) and the retired scorers were **LEFT IN PLACE** — this cutover is rewiring only, keeping the change reversible. Dead-code removal is deferred to Phase 15. `packages/genie-space-optimizer/databricks.yml` was **not modified**.

## Cross-review fixes (2nd commit)
- **BLOCKING fixed:** `upload_job_notebooks` unpacked the old 3-tuple `TASKS` shape → `ValueError` that crashed the `install.py` path in `ensure_gso_job`. Corrected to the 4-tuple shape and added the end-to-end upload-loop test above.
- **Doc fix:** corrected the `llm_model` reach claim (see §2) — `publish_and_audit` uses the `LLM_MODEL` config default, not the per-run widget.

This pull request and its description were written by Isaac.
