### PR TITLE
GSO v2: make _handoff.py Delta-only (fix taskValues crash) + skip retired-table migrations

### DIFF
--- a/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/_handoff.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/jobs/_handoff.py
@@ -1,22 +1,24 @@
-"""Cross-task state resilience helpers for the GSO 6-task DAG.
+"""Cross-task state helpers for the GSO v2 5-task DAG (Delta-only handoff).
 
-Every notebook task in the optimization DAG reads upstream state via
-``dbutils.jobs.taskValues.get(...)``. On a Repair Run, taskValues from
-prior runs are NOT propagated, so each call returns the empty default
-and the task silently runs on degenerate inputs.
+Design note D9 (Delta-only): the v2 DAG
+(``00_intake_and_snapshot`` -> ``01_benchmark_qc_and_repair`` ->
+``02_baseline_eval_and_triage`` -> ``03_optimize`` -> ``publish_and_audit``)
+publishes NO Databricks task values. Every cross-task read is served from the
+durable Delta state persisted in ``genie_opt_runs`` and ``genie_opt_iterations``.
+This is both simpler and Repair-Run safe: Databricks does not propagate task
+values to repaired downstream tasks, but Delta rows survive, so reading straight
+from Delta is the single source of truth.
 
-This module wraps every cross-task read with a 3-step lookup:
+Each read returns a ``HandoffValue`` carrying the ``HandoffSource`` it came from
+so log readers can distinguish a value reconstructed from Delta
+(``DELTA_FALLBACK``) from a value that was never persisted (``MISSING``).
 
-  1. taskValues first (the happy path).
-  2. Delta fallback against the durable state already persisted in
-     ``genie_opt_runs`` and ``genie_opt_iterations``.
-  3. Loud failure (or documented default) if neither exists.
-
-Each value carries the ``HandoffSource`` it came from so log readers can
-distinguish "the run resumed correctly" from "the run silently fell
-back to Delta state". See the cross-task state resilience plan
-(``docs/2026-05-01-cross-task-state-resilience-plan.md``) for the
-problem statement and design.
+Historical note: an earlier design probed the Databricks job task-value store
+first and fell back to Delta. Under the v2 DAG those probes targeted task keys
+from the retired 6-task DAG (``preflight``, ``baseline_eval``, ``enrichment``,
+``lever_loop``) that no longer exist in a run, and the probe raised
+``ValueError: Task key does not exist in run`` before the Delta fallback could
+run. The task-value probe has been removed; Delta is now the ONLY source.
 """
 from __future__ import annotations
 
@@ -26,12 +28,20 @@ from typing import Any
 
 
 class HandoffSource(str, Enum):
-    """Where a HandoffValue was sourced from."""
+    """Where a HandoffValue was sourced from.
 
-    TASK_VALUES = "task_values"       # taskValues returned a real value
-    DELTA_FALLBACK = "delta_fallback"  # taskValues empty; Delta filled in
-    DEFAULT = "default"               # both empty; documented default applied
-    MISSING = "missing"               # both empty; no default — caller decides
+    Under D9 (Delta-only handoff) the helpers in this module only ever emit
+    ``DELTA_FALLBACK`` or ``MISSING``. ``TASK_VALUES`` is retained for direct /
+    authoritative reads that never pass through Delta — the ``catalog`` /
+    ``schema`` job-widget bootstrap keys in ``get_run_context`` and the
+    published-scorecard check in ``resolve_finalize_skip_scores`` — and for the
+    ``DEFAULT`` documented-default case.
+    """
+
+    TASK_VALUES = "task_values"        # direct/authoritative read (e.g. job widget)
+    DELTA_FALLBACK = "delta_fallback"  # reconstructed from durable Delta state
+    DEFAULT = "default"                # documented default applied
+    MISSING = "missing"                # not found anywhere — caller decides
 
 
 @dataclass(frozen=True)
@@ -67,33 +77,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _tv_get(dbutils, taskKey: str, key: str, default: str = "") -> str:
-    """Tiny wrapper so tests can swap in a mock and the prod call site
-    does not duplicate ``dbutils.jobs.taskValues.get`` boilerplate."""
-    return dbutils.jobs.taskValues.get(taskKey=taskKey, key=key, default=default)
-
-
 def _resolve(
-    raw_tv: str,
     *,
-    delta_value,
-    parser=lambda s: s,
+    delta_value: Any,
     key: str,
     delta_query: Optional[str] = None,
 ) -> HandoffValue:
-    """Pick taskValues if non-empty, else Delta if non-None, else MISSING.
+    """Delta-only cross-task resolution (D9).
 
-    ``parser`` converts the raw string to its typed value; on parse error
-    the string is treated as empty so Delta wins.
+    A non-``None`` ``delta_value`` is the resolved value (source
+    ``DELTA_FALLBACK``); ``None`` means the upstream task never persisted it
+    (source ``MISSING`` — the caller decides whether that is fatal). Callers pass
+    ``delta_value`` already typed (e.g. ``overall_accuracy`` as a float,
+    ``scores_json`` parsed to a dict by the ``_load_*`` helpers), so this function
+    does no parsing of its own.
     """
-    if raw_tv not in ("", None):
-        try:
-            return HandoffValue(
-                key=key, value=parser(raw_tv),
-                source=HandoffSource.TASK_VALUES,
-            )
-        except (ValueError, json.JSONDecodeError, TypeError):
-            pass  # fall through to Delta
     if delta_value is not None:
         return HandoffValue(
             key=key, value=delta_value,
@@ -111,103 +109,82 @@ def get_run_context(
     run_id_widget: str,
     catalog_widget: str,
     schema_widget: str,
-    dbutils,
+    dbutils: Any = None,
 ) -> dict[str, HandoffValue]:
-    """Read all preflight-published values, with Delta fallback to genie_opt_runs.
+    """Read all run-level context from ``genie_opt_runs`` (Delta-only, D9).
 
-    The widgets ``run_id_widget``, ``catalog_widget``, ``schema_widget``
-    are required because they are the only values we can rely on at the
-    very start of any task — Databricks Jobs widgets DO survive Repair
-    Run, while taskValues do not.
+    The widgets ``run_id_widget``, ``catalog_widget``, ``schema_widget`` are the
+    only bootstrap inputs every task can rely on — Databricks Jobs widgets /
+    parameters survive Repair Run. ``run_id_widget`` locates the durable run row;
+    ``catalog`` / ``schema`` are echoed straight back as the bootstrap keys.
+
+    ``dbutils`` is accepted for call-site compatibility but is no longer used: v2
+    tasks publish NO Databricks task values (D9), so every field is read from Delta.
 
     Returns a dict of ``HandoffValue`` keyed by logical name.
 
     Raises:
-        RuntimeError: if ``run_id_widget`` is empty AND no taskValue ran_id
-            is available — there is nothing to look up in Delta.
+        RuntimeError: if ``run_id_widget`` is empty (nothing to look up), or if
+            there is no ``genie_opt_runs`` row for it (the run was never created).
     """
-    # Cycle 5 T6 — Repair-Run widget context preservation. Widgets
-    # SHOULD survive Repair Run, but tests confirm there are paths
-    # where the widget arrives empty even on Repair Runs (e.g., when
-    # the operator triggers Repair via the API before the notebook
-    # widget DOM has finished bootstrapping). Defer the
-    # widget-required raise to AFTER the taskValues fallback so a
-    # Repair Run with non-empty taskValues survives a transient
-    # empty widget. The "both empty" path below still raises with a
-    # clear message.
-    tv_run_id = _tv_get(dbutils, "preflight", "run_id")
-    bootstrap_run_id = tv_run_id or run_id_widget
-    if not bootstrap_run_id:
+    del dbutils  # D9: Delta-only handoff — no task values are consulted.
+
+    if not run_id_widget:
         raise RuntimeError(
-            "get_run_context: run_id is required. Both "
-            "run_id_widget and dbutils.jobs.taskValues "
-            "preflight.run_id are empty — Repair Run cannot "
-            "proceed."
+            "get_run_context: run_id_widget is required — there is no run_id to "
+            "look up in Delta."
         )
 
     delta_query = (
         f"SELECT * FROM {catalog_widget}.{schema_widget}.genie_opt_runs "
-        f"WHERE run_id = '{bootstrap_run_id}' LIMIT 1"
+        f"WHERE run_id = '{run_id_widget}' LIMIT 1"
     )
-    run_row = load_run(spark, bootstrap_run_id, catalog_widget, schema_widget)
+    run_row = load_run(spark, run_id_widget, catalog_widget, schema_widget)
 
-    if run_row is None and not tv_run_id:
-        # Both taskValues and Delta empty — we know nothing about this run.
+    if run_row is None:
+        # No durable run row — we know nothing about this run.
         raise RuntimeError(
             f"get_run_context: no run context available for run_id="
-            f"{bootstrap_run_id!r}. taskValues are empty AND no row in "
-            f"{catalog_widget}.{schema_widget}.genie_opt_runs. Repair "
-            f"Run cannot proceed."
+            f"{run_id_widget!r}. No row in "
+            f"{catalog_widget}.{schema_widget}.genie_opt_runs — the intake task "
+            f"(00_intake_and_snapshot) must create the run row first."
         )
 
-    # Per-key resolution. Each entry: (logical_key, taskValues_key,
-    # delta_row_key, parser).
+    # Per-key resolution. Each entry: (logical_key, genie_opt_runs column).
     spec = [
-        ("run_id", "run_id", "run_id", str),
-        ("space_id", "space_id", "space_id", str),
-        ("domain", "domain", "domain", str),
-        ("experiment_name", "experiment_name", "experiment_name", str),
-        ("apply_mode", "apply_mode", "apply_mode", str),
-        ("triggered_by", "triggered_by", "triggered_by", str),
-        ("warehouse_id", "warehouse_id", "warehouse_id", str),
-        ("max_iterations", "max_iterations", "max_iterations", int),
-        ("levers", "levers", "levers", json.loads),
-        (
-            "max_benchmark_count",
-            "max_benchmark_count",
-            "max_benchmark_count",
-            int,
-        ),
-        (
-            "human_corrections",
-            "human_corrections",
-            "human_corrections_json",
-            json.loads,
-        ),
+        ("run_id", "run_id"),
+        ("space_id", "space_id"),
+        ("domain", "domain"),
+        ("experiment_name", "experiment_name"),
+        ("apply_mode", "apply_mode"),
+        ("triggered_by", "triggered_by"),
+        ("warehouse_id", "warehouse_id"),
+        ("max_iterations", "max_iterations"),
+        ("levers", "levers"),
+        ("max_benchmark_count", "max_benchmark_count"),
+        ("human_corrections", "human_corrections_json"),
     ]
 
     out: dict[str, HandoffValue] = {}
-    for logical, tv_key, delta_key, parser in spec:
-        raw = _tv_get(dbutils, "preflight", tv_key)
-        delta_val = (run_row or {}).get(delta_key)
+    for logical, delta_key in spec:
+        delta_val = run_row.get(delta_key)
         # JSON columns (levers, human_corrections_json) come back from
         # load_run as strings. Parse them here so callers always see a
-        # typed value regardless of source.
+        # typed value.
         if logical in ("levers", "human_corrections") and isinstance(delta_val, str):
             try:
                 delta_val = json.loads(delta_val)
             except (ValueError, TypeError):
                 delta_val = None
         out[logical] = _resolve(
-            raw,
             delta_value=delta_val,
-            parser=parser,
             key=logical,
             delta_query=delta_query,
         )
 
-    # ``catalog`` and ``schema`` are passed in as widgets, never read from
-    # taskValues — they ARE the bootstrap keys.
+    # ``catalog`` and ``schema`` come straight from the job widgets — they ARE
+    # the bootstrap keys, not fields stored in the run row, so they are marked
+    # as a direct/authoritative read (TASK_VALUES) rather than DELTA_FALLBACK.
     out["catalog"] = HandoffValue(
         key="catalog", value=catalog_widget,
         source=HandoffSource.TASK_VALUES,
@@ -255,79 +232,58 @@ def get_baseline_eval_state(
     run_id: str,
     catalog: str,
     schema: str,
-    dbutils,
+    dbutils: Any = None,
 ) -> dict[str, HandoffValue]:
-    """Read baseline_eval task values, falling back to genie_opt_iterations.
+    """Read baseline eval state from ``genie_opt_iterations`` (Delta-only, D9).
 
-    Returns ``HandoffValue`` for: ``scores``, ``overall_accuracy``,
-    ``thresholds_met``, ``model_id``, ``mlflow_run_id``.
+    Reads the iteration=0 / ``eval_scope='full'`` row written by the baseline eval
+    task (``02_baseline_eval_and_triage``). Returns ``HandoffValue`` for:
+    ``scores``, ``overall_accuracy``, ``thresholds_met``, ``model_id``,
+    ``mlflow_run_id``. ``dbutils`` is accepted for call-site compatibility but
+    unused (D9 — no task values).
 
     Raises:
-        RuntimeError: if neither taskValues nor a Delta iteration=0 row
-            is available — the baseline never ran.
+        RuntimeError: if there is no Delta iteration=0 baseline row — the baseline
+            eval never completed.
     """
+    del dbutils  # D9: Delta-only handoff — no task values are consulted.
+
     delta_query = (
         f"SELECT * FROM {catalog}.{schema}.genie_opt_iterations "
         f"WHERE run_id = '{run_id}' AND iteration = 0 "
         f"AND eval_scope = 'full' LIMIT 1"
     )
 
-    raw_scores = _tv_get(dbutils, "baseline_eval", "scores")
-    raw_acc = _tv_get(dbutils, "baseline_eval", "overall_accuracy")
-    raw_thr = _tv_get(dbutils, "baseline_eval", "thresholds_met")
-    raw_mid = _tv_get(dbutils, "baseline_eval", "model_id")
-    raw_mlid = _tv_get(dbutils, "baseline_eval", "mlflow_run_id")
+    delta_row = _load_baseline_iteration_row(spark, run_id, catalog, schema)
 
-    delta_row = None
-    if raw_scores in ("", None) or raw_acc in ("", None):
-        delta_row = _load_baseline_iteration_row(
-            spark, run_id, catalog, schema,
-        )
-
-    if (
-        raw_scores in ("", None)
-        and raw_acc in ("", None)
-        and delta_row is None
-    ):
+    if delta_row is None:
         raise RuntimeError(
             f"get_baseline_eval_state: no baseline state available for "
-            f"run_id={run_id!r}. taskValues empty AND no row in "
-            f"{catalog}.{schema}.genie_opt_iterations at iteration=0. "
-            f"baseline_eval task must complete before lever_loop / finalize."
+            f"run_id={run_id!r}. No row in "
+            f"{catalog}.{schema}.genie_opt_iterations at iteration=0 "
+            f"(eval_scope='full') — the baseline eval task "
+            f"(02_baseline_eval_and_triage) must complete before optimize / publish."
         )
-
-    def _bool(s: str) -> bool:
-        return str(s).lower() in ("true", "1")
 
     out = {
         "scores": _resolve(
-            raw_scores,
-            delta_value=(delta_row or {}).get("scores_json"),
-            parser=json.loads,
+            delta_value=delta_row.get("scores_json"),
             key="scores", delta_query=delta_query,
         ),
         "overall_accuracy": _resolve(
-            raw_acc,
-            delta_value=(delta_row or {}).get("overall_accuracy"),
-            parser=float,
+            delta_value=delta_row.get("overall_accuracy"),
             key="overall_accuracy", delta_query=delta_query,
         ),
         "thresholds_met": _resolve(
-            raw_thr,
-            delta_value=(delta_row or {}).get("thresholds_met"),
-            parser=_bool,
+            delta_value=delta_row.get("thresholds_met"),
             key="thresholds_met", delta_query=delta_query,
         ),
         "model_id": _resolve(
-            raw_mid,
-            delta_value=(delta_row or {}).get("model_id"),
-            parser=str,
+            delta_value=delta_row.get("model_id"),
             key="model_id", delta_query=delta_query,
         ),
         "mlflow_run_id": _resolve(
-            raw_mlid,
-            delta_value=(delta_row or {}).get("mlflow_run_id"),
-            parser=str,
+            delta_value=delta_row.get("mlflow_run_id"),
             key="mlflow_run_id", delta_query=delta_query,
         ),
     }
@@ -366,77 +322,55 @@ def get_enrichment_state(
     run_id: str,
     catalog: str,
     schema: str,
-    dbutils,
+    dbutils: Any = None,
 ) -> dict[str, HandoffValue]:
-    """Read enrichment task values, falling back to genie_opt_iterations.
+    """Read enrichment state from ``genie_opt_iterations`` (Delta-only, D9).
 
     Returns ``HandoffValue`` for: ``enrichment_model_id``,
     ``enrichment_skipped``, ``post_enrichment_accuracy``,
     ``post_enrichment_scores``, ``post_enrichment_model_id``,
-    ``post_enrichment_thresholds_met``.
+    ``post_enrichment_thresholds_met``. ``dbutils`` is accepted for call-site
+    compatibility but unused (D9 — no task values).
 
     Absence of a Delta enrichment row -> ``enrichment_skipped=True`` with
     source=DELTA_FALLBACK; all post_* values are MISSING. This is a valid
     state and does NOT raise.
     """
+    del dbutils  # D9: Delta-only handoff — no task values are consulted.
+
     delta_query = (
         f"SELECT * FROM {catalog}.{schema}.genie_opt_iterations "
         f"WHERE run_id = '{run_id}' AND eval_scope = 'enrichment' LIMIT 1"
     )
 
-    raw_skipped = _tv_get(dbutils, "enrichment", "enrichment_skipped")
-    if raw_skipped not in ("", None):
-        # Operator-supplied skip signal -- trust it.
-        skipped_val = str(raw_skipped).lower() in ("true", "1")
-        skipped_hv = HandoffValue(
-            key="enrichment_skipped", value=skipped_val,
-            source=HandoffSource.TASK_VALUES,
-        )
-        delta_row = None
-    else:
-        delta_row = _load_enrichment_iteration_row(
-            spark, run_id, catalog, schema,
-        )
-        skipped_val = delta_row is None
-        skipped_hv = HandoffValue(
-            key="enrichment_skipped", value=skipped_val,
-            source=HandoffSource.DELTA_FALLBACK,
-            delta_query=delta_query,
-        )
-
-    def _bool(s: str) -> bool:
-        return str(s).lower() in ("true", "1")
+    delta_row = _load_enrichment_iteration_row(spark, run_id, catalog, schema)
+    skipped_val = delta_row is None
+    skipped_hv = HandoffValue(
+        key="enrichment_skipped", value=skipped_val,
+        source=HandoffSource.DELTA_FALLBACK,
+        delta_query=delta_query,
+    )
 
     out: dict[str, HandoffValue] = {"enrichment_skipped": skipped_hv}
 
     out["enrichment_model_id"] = _resolve(
-        _tv_get(dbutils, "enrichment", "enrichment_model_id"),
         delta_value=(delta_row or {}).get("model_id"),
-        parser=str,
         key="enrichment_model_id", delta_query=delta_query,
     )
     out["post_enrichment_accuracy"] = _resolve(
-        _tv_get(dbutils, "enrichment", "post_enrichment_accuracy"),
         delta_value=(delta_row or {}).get("overall_accuracy"),
-        parser=float,
         key="post_enrichment_accuracy", delta_query=delta_query,
     )
     out["post_enrichment_scores"] = _resolve(
-        _tv_get(dbutils, "enrichment", "post_enrichment_scores"),
         delta_value=(delta_row or {}).get("scores_json"),
-        parser=json.loads,
         key="post_enrichment_scores", delta_query=delta_query,
     )
     out["post_enrichment_model_id"] = _resolve(
-        _tv_get(dbutils, "enrichment", "post_enrichment_model_id"),
         delta_value=(delta_row or {}).get("model_id"),
-        parser=str,
         key="post_enrichment_model_id", delta_query=delta_query,
     )
     out["post_enrichment_thresholds_met"] = _resolve(
-        _tv_get(dbutils, "enrichment", "post_enrichment_thresholds_met"),
         delta_value=(delta_row or {}).get("thresholds_met"),
-        parser=_bool,
         key="post_enrichment_thresholds_met", delta_query=delta_query,
     )
     return out
@@ -455,47 +389,36 @@ def get_lever_loop_outputs(
     run_id: str,
     catalog: str,
     schema: str,
-    dbutils,
+    dbutils: Any = None,
 ) -> dict[str, HandoffValue]:
-    """Read lever_loop task values, falling back to Delta state."""
+    """Read lever-loop / optimize outputs from Delta state (Delta-only, D9).
+
+    Reconstructs the loop outputs from ``genie_opt_runs`` (best-* columns) and the
+    latest ``eval_scope='full'`` ``genie_opt_iterations`` row. ``dbutils`` is
+    accepted for call-site compatibility but unused (D9 — no task values).
+
+    Raises:
+        RuntimeError: if there is no run row AND no full-scope iteration row — the
+            optimize task never completed.
+    """
+    del dbutils  # D9: Delta-only handoff — no task values are consulted.
+
     delta_query = (
         f"SELECT * FROM {catalog}.{schema}.genie_opt_iterations "
         f"WHERE run_id = '{run_id}' AND eval_scope = 'full' "
         f"ORDER BY iteration DESC LIMIT 1"
     )
 
-    _run_row = None
-    _latest_iter = None
-    _iters_df = None
-
-    def _need_delta() -> bool:
-        return any(
-            _tv_get(dbutils, "lever_loop", k) in ("", None)
-            for k in (
-                "scores", "accuracy", "model_id", "iteration_counter",
-                "best_iteration", "skipped",
-                "all_eval_mlflow_run_ids", "all_failure_question_ids",
-            )
+    _run_row = load_run(spark, run_id, catalog, schema)
+    _latest_iter = load_latest_full_iteration(spark, run_id, catalog, schema)
+    if _run_row is None and _latest_iter is None:
+        raise RuntimeError(
+            f"get_lever_loop_outputs: no state available for run_id="
+            f"{run_id!r}. No rows in "
+            f"{catalog}.{schema}.genie_opt_runs / genie_opt_iterations — the "
+            f"optimize task (03_optimize) must complete before publish / deploy."
         )
-
-    if _need_delta():
-        _run_row = load_run(spark, run_id, catalog, schema)
-        _latest_iter = load_latest_full_iteration(
-            spark, run_id, catalog, schema,
-        )
-        if _run_row is None and _latest_iter is None and not any(
-            _tv_get(dbutils, "lever_loop", k) for k in ("scores", "model_id")
-        ):
-            raise RuntimeError(
-                f"get_lever_loop_outputs: no state available for run_id="
-                f"{run_id!r}. taskValues empty AND no rows in "
-                f"{catalog}.{schema}.genie_opt_runs / genie_opt_iterations. "
-                f"lever_loop task must complete before finalize / deploy."
-            )
-        _iters_df = load_iterations(spark, run_id, catalog, schema)
-
-    def _bool(s: str) -> bool:
-        return str(s).lower() in ("true", "1")
+    _iters_df = load_iterations(spark, run_id, catalog, schema)
 
     delta_skipped = (
         _latest_iter is not None and int(_latest_iter.get("iteration", 0)) == 0
@@ -511,52 +434,36 @@ def get_lever_loop_outputs(
 
     out = {
         "scores": _resolve(
-            _tv_get(dbutils, "lever_loop", "scores"),
             delta_value=(_latest_iter or {}).get("scores_json"),
-            parser=json.loads,
             key="scores", delta_query=delta_query,
         ),
         "accuracy": _resolve(
-            _tv_get(dbutils, "lever_loop", "accuracy"),
             delta_value=(_latest_iter or {}).get("overall_accuracy"),
-            parser=float,
             key="accuracy", delta_query=delta_query,
         ),
         "model_id": _resolve(
-            _tv_get(dbutils, "lever_loop", "model_id"),
             delta_value=(_latest_iter or {}).get("model_id")
             or (_run_row or {}).get("best_model_id"),
-            parser=str,
             key="model_id", delta_query=delta_query,
         ),
         "iteration_counter": _resolve(
-            _tv_get(dbutils, "lever_loop", "iteration_counter"),
             delta_value=(_latest_iter or {}).get("iteration"),
-            parser=int,
             key="iteration_counter", delta_query=delta_query,
         ),
         "best_iteration": _resolve(
-            _tv_get(dbutils, "lever_loop", "best_iteration"),
             delta_value=(_run_row or {}).get("best_iteration"),
-            parser=int,
             key="best_iteration", delta_query=delta_query,
         ),
         "skipped": _resolve(
-            _tv_get(dbutils, "lever_loop", "skipped"),
             delta_value=delta_skipped if _latest_iter is not None else None,
-            parser=_bool,
             key="skipped", delta_query=delta_query,
         ),
         "all_eval_mlflow_run_ids": _resolve(
-            _tv_get(dbutils, "lever_loop", "all_eval_mlflow_run_ids"),
             delta_value=delta_eval_ids,
-            parser=json.loads,
             key="all_eval_mlflow_run_ids", delta_query=delta_query,
         ),
         "all_failure_question_ids": _resolve(
-            _tv_get(dbutils, "lever_loop", "all_failure_question_ids"),
             delta_value=(_latest_iter or {}).get("failures_json"),
-            parser=json.loads,
             key="all_failure_question_ids", delta_query=delta_query,
         ),
     }
@@ -657,7 +564,7 @@ def resolve_finalize_skip_scores(
 def assert_lever_loop_inputs_sane(state: dict[str, HandoffValue]) -> None:
     """Refuse to run the lever loop with degenerate baseline inputs.
 
-    The fingerprint of a Repair Run that lost taskValues is:
+    The fingerprint of a Repair Run whose baseline state never persisted is:
     ``overall_accuracy`` is 0.0/None AND ``scores`` is empty AND both
     are sourced from MISSING (Delta also empty). When this happens, the
     loop will silently terminate as ``plateau_no_open_failures`` and
@@ -671,7 +578,7 @@ def assert_lever_loop_inputs_sane(state: dict[str, HandoffValue]) -> None:
             ``overall_accuracy`` and ``scores``.
 
     Raises:
-        RuntimeError: if inputs are degenerate AND not from taskValues.
+        RuntimeError: if inputs are degenerate AND not a direct/authoritative read.
     """
     acc_hv = state["overall_accuracy"]
     scores_hv = state["scores"]
@@ -698,8 +605,8 @@ def assert_lever_loop_inputs_sane(state: dict[str, HandoffValue]) -> None:
         f"assert_lever_loop_inputs_sane: degenerate baseline state "
         f"detected (overall_accuracy={acc_val!r} from {acc_hv.source.value}, "
         f"scores={scores_val!r} from {scores_hv.source.value}). "
-        f"This is the Repair Run silent-success fingerprint: taskValues "
-        f"did not propagate AND Delta has no row to fall back to. "
+        f"This is the Repair Run silent-success fingerprint: no baseline state "
+        f"was persisted AND Delta has no row to fall back to. "
         f"Re-run the full DAG, or pass --override-baseline-from-delta "
         f"with a known-good run_id."
     )

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/state.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/state.py
@@ -199,6 +199,20 @@ def _migrate_add_columns(spark: SparkSession, catalog: str, schema: str) -> None
     _try_enable_column_defaults(spark, _fqn(catalog, schema, TABLE_ITERATIONS))
 
     for table, col, col_def in ADDITIVE_COLUMN_MIGRATIONS:
+        # GSO v2 (Phase 7): several ADDITIVE_COLUMN_MIGRATIONS entries still
+        # target tables that v2 RETIRED (removed from ``_ALL_DDL`` — see
+        # ``ddl.RETIRED_TABLES``). On a fresh v2 install those tables are never
+        # created, so ``ALTER TABLE`` would fail with TABLE_OR_VIEW_NOT_FOUND,
+        # get swallowed, and spam ``[MIGRATION FAILED]`` ERROR logs. Skip any
+        # entry whose target table is not in the active DDL set — there is no
+        # table to migrate.
+        if table not in _ALL_DDL:
+            logger.debug(
+                "  [SKIP] %s (retired / not in active DDL set) — no migration for %s",
+                _fqn(catalog, schema, table), col,
+            )
+            continue
+
         fqn = _fqn(catalog, schema, table)
         try:
             existing = {

--- a/packages/genie-space-optimizer/tests/unit/test_handoff_baseline_state.py
+++ b/packages/genie-space-optimizer/tests/unit/test_handoff_baseline_state.py
@@ -1,5 +1,12 @@
-"""Tests for get_baseline_eval_state() — reads baseline_eval state with Delta fallback."""
-import json
+"""Tests for get_baseline_eval_state() — Delta-only baseline read (D9).
+
+D9 (Delta-only handoff): v2 tasks publish NO Databricks task values, so the
+baseline eval state is read straight from ``genie_opt_iterations`` (iteration=0,
+eval_scope='full'). These tests lock that the helper never probes
+``dbutils.jobs.taskValues`` (which, under the v2 5-task DAG, would raise
+``ValueError: Task key does not exist in run: baseline_eval`` — the original
+crash) and returns the Delta row shape unchanged.
+"""
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,35 +17,22 @@ from genie_space_optimizer.jobs._handoff import (
 )
 
 
-def _make_dbutils(values):
+def _hostile_dbutils():
+    """A dbutils whose taskValues probe raises the v2 crash if ever called.
+
+    Mirrors the real Databricks behavior on the v2 DAG: the retired
+    ``baseline_eval`` task key does not exist in the run, so
+    ``dbutils.jobs.taskValues.get`` raises ``ValueError`` BEFORE any default can
+    apply. If the Delta-only helper touches it, the test fails loudly.
+    """
     dbu = MagicMock()
-    def _get(taskKey, key, default=""):
-        return values.get((taskKey, key), default)
-    dbu.jobs.taskValues.get.side_effect = _get
+    dbu.jobs.taskValues.get.side_effect = ValueError(
+        "Task key does not exist in run: baseline_eval"
+    )
     return dbu
 
 
-def test_baseline_state_happy_path_uses_task_values():
-    dbu = _make_dbutils({
-        ("baseline_eval", "scores"): json.dumps({"syntax_validity": 95.0}),
-        ("baseline_eval", "overall_accuracy"): "85.7",
-        ("baseline_eval", "thresholds_met"): "false",
-        ("baseline_eval", "model_id"): "m-abc",
-        ("baseline_eval", "mlflow_run_id"): "mr-001",
-    })
-    spark = MagicMock()
-    state = get_baseline_eval_state(
-        spark, run_id="run-001", catalog="cat", schema="sch", dbutils=dbu,
-    )
-    assert state["scores"].value == {"syntax_validity": 95.0}
-    assert state["scores"].source is HandoffSource.TASK_VALUES
-    assert state["overall_accuracy"].value == 85.7
-    assert state["thresholds_met"].value is False
-    assert state["model_id"].value == "m-abc"
-
-
-def test_baseline_state_falls_back_to_delta_iteration_zero():
-    dbu = _make_dbutils({})
+def test_baseline_state_reads_from_delta_iteration_zero():
     spark = MagicMock()
     fake_iter = {
         "iteration": 0,
@@ -55,17 +49,69 @@ def test_baseline_state_falls_back_to_delta_iteration_zero():
     ):
         state = get_baseline_eval_state(
             spark, run_id="run-001", catalog="cat", schema="sch",
-            dbutils=dbu,
         )
     assert state["scores"].value == {"syntax_validity": 95.0}
     assert state["scores"].source is HandoffSource.DELTA_FALLBACK
     assert state["overall_accuracy"].value == 85.7
     assert state["thresholds_met"].value is False
     assert state["model_id"].value == "m-abc"
+    assert state["mlflow_run_id"].value == "mr-001"
 
 
-def test_baseline_state_raises_when_task_values_and_delta_both_empty():
-    dbu = _make_dbutils({})
+def test_baseline_state_does_not_probe_task_values():
+    """Regression for the v2 crash: passing a dbutils whose taskValues probe
+    raises must NOT propagate — the helper reads Delta only."""
+    spark = MagicMock()
+    fake_iter = {
+        "iteration": 0,
+        "eval_scope": "full",
+        "scores_json": {"syntax_validity": 95.0},
+        "overall_accuracy": 85.7,
+        "thresholds_met": False,
+        "model_id": "m-abc",
+        "mlflow_run_id": "mr-001",
+    }
+    dbu = _hostile_dbutils()
+    with patch(
+        "genie_space_optimizer.jobs._handoff._load_baseline_iteration_row",
+        return_value=fake_iter,
+    ):
+        state = get_baseline_eval_state(
+            spark, run_id="run-001", catalog="cat", schema="sch", dbutils=dbu,
+        )
+    assert state["overall_accuracy"].value == 85.7
+    dbu.jobs.taskValues.get.assert_not_called()
+
+
+def test_baseline_state_missing_fields_are_missing_not_defaulted():
+    """A baseline row present but with NULL scorecard/model columns yields
+    MISSING (value None) for those keys — the row shape is preserved."""
+    spark = MagicMock()
+    fake_iter = {
+        "iteration": 0,
+        "eval_scope": "full",
+        "scores_json": None,
+        "overall_accuracy": 0.0,
+        "thresholds_met": False,
+        "model_id": None,
+        "mlflow_run_id": None,
+    }
+    with patch(
+        "genie_space_optimizer.jobs._handoff._load_baseline_iteration_row",
+        return_value=fake_iter,
+    ):
+        state = get_baseline_eval_state(
+            spark, run_id="run-001", catalog="cat", schema="sch",
+        )
+    assert state["scores"].value is None
+    assert state["scores"].source is HandoffSource.MISSING
+    # overall_accuracy=0.0 is a real persisted value, not MISSING.
+    assert state["overall_accuracy"].value == 0.0
+    assert state["overall_accuracy"].source is HandoffSource.DELTA_FALLBACK
+    assert state["model_id"].source is HandoffSource.MISSING
+
+
+def test_baseline_state_raises_when_no_delta_row():
     spark = MagicMock()
     with patch(
         "genie_space_optimizer.jobs._handoff._load_baseline_iteration_row",
@@ -74,5 +120,4 @@ def test_baseline_state_raises_when_task_values_and_delta_both_empty():
         with pytest.raises(RuntimeError, match="baseline"):
             get_baseline_eval_state(
                 spark, run_id="run-001", catalog="cat", schema="sch",
-                dbutils=dbu,
             )

--- a/packages/genie-space-optimizer/tests/unit/test_handoff_enrichment_state.py
+++ b/packages/genie-space-optimizer/tests/unit/test_handoff_enrichment_state.py
@@ -1,5 +1,9 @@
-"""Tests for get_enrichment_state()."""
-import json
+"""Tests for get_enrichment_state() — Delta-only enrichment read (D9).
+
+D9 (Delta-only handoff): enrichment state is read straight from the
+``eval_scope='enrichment'`` ``genie_opt_iterations`` row. Absence of that row is
+a VALID state (enrichment was skipped), not an error. No task values consulted.
+"""
 from unittest.mock import MagicMock, patch
 
 from genie_space_optimizer.jobs._handoff import (
@@ -8,37 +12,16 @@ from genie_space_optimizer.jobs._handoff import (
 )
 
 
-def _make_dbutils(values):
+def _hostile_dbutils():
+    """dbutils whose taskValues probe raises the retired-key crash if called."""
     dbu = MagicMock()
-    def _get(taskKey, key, default=""):
-        return values.get((taskKey, key), default)
-    dbu.jobs.taskValues.get.side_effect = _get
+    dbu.jobs.taskValues.get.side_effect = ValueError(
+        "Task key does not exist in run: enrichment"
+    )
     return dbu
 
 
-def test_enrichment_state_happy_path_uses_task_values():
-    dbu = _make_dbutils({
-        ("enrichment", "enrichment_model_id"): "enr-m-001",
-        ("enrichment", "enrichment_skipped"): "false",
-        ("enrichment", "post_enrichment_accuracy"): "87.5",
-        ("enrichment", "post_enrichment_scores"): json.dumps({"x": 1}),
-        ("enrichment", "post_enrichment_model_id"): "post-m-001",
-        ("enrichment", "post_enrichment_thresholds_met"): "false",
-    })
-    spark = MagicMock()
-    state = get_enrichment_state(
-        spark, run_id="run-001", catalog="cat", schema="sch", dbutils=dbu,
-    )
-    assert state["enrichment_model_id"].value == "enr-m-001"
-    assert state["enrichment_skipped"].value is False
-    assert state["post_enrichment_accuracy"].value == 87.5
-    assert state["post_enrichment_scores"].value == {"x": 1}
-    assert state["post_enrichment_thresholds_met"].value is False
-    assert state["enrichment_model_id"].source is HandoffSource.TASK_VALUES
-
-
-def test_enrichment_state_falls_back_to_delta_when_task_values_empty():
-    dbu = _make_dbutils({})
+def test_enrichment_state_reads_from_delta():
     spark = MagicMock()
     fake_row = {
         "iteration": 0,
@@ -54,13 +37,13 @@ def test_enrichment_state_falls_back_to_delta_when_task_values_empty():
     ):
         state = get_enrichment_state(
             spark, run_id="run-001", catalog="cat", schema="sch",
-            dbutils=dbu,
         )
     assert state["enrichment_model_id"].value == "enr-m-001"
     assert state["enrichment_model_id"].source is HandoffSource.DELTA_FALLBACK
     assert state["enrichment_skipped"].value is False
     assert state["post_enrichment_accuracy"].value == 87.5
     assert state["post_enrichment_scores"].value == {"x": 1}
+    assert state["post_enrichment_thresholds_met"].value is False
 
 
 def test_enrichment_skipped_when_no_row_present():
@@ -68,7 +51,6 @@ def test_enrichment_skipped_when_no_row_present():
 
     This must NOT raise. enrichment_skipped=True, all post_* values are MISSING.
     """
-    dbu = _make_dbutils({})
     spark = MagicMock()
     with patch(
         "genie_space_optimizer.jobs._handoff._load_enrichment_iteration_row",
@@ -76,7 +58,6 @@ def test_enrichment_skipped_when_no_row_present():
     ):
         state = get_enrichment_state(
             spark, run_id="run-001", catalog="cat", schema="sch",
-            dbutils=dbu,
         )
     assert state["enrichment_skipped"].value is True
     assert state["enrichment_skipped"].source is HandoffSource.DELTA_FALLBACK
@@ -85,20 +66,17 @@ def test_enrichment_skipped_when_no_row_present():
     assert state["post_enrichment_accuracy"].source is HandoffSource.MISSING
 
 
-def test_enrichment_state_explicit_skipped_taskvalue_wins():
-    """When the operator explicitly set enrichment_skipped=true via
-    taskValues, do not query Delta to "second-guess" — trust the signal."""
-    dbu = _make_dbutils({
-        ("enrichment", "enrichment_skipped"): "true",
-    })
+def test_enrichment_state_does_not_probe_task_values():
+    """Regression for the v2 crash: a hostile dbutils whose taskValues probe
+    raises must not propagate — enrichment state comes from Delta only."""
     spark = MagicMock()
+    dbu = _hostile_dbutils()
     with patch(
         "genie_space_optimizer.jobs._handoff._load_enrichment_iteration_row",
-    ) as load_mock:
+        return_value=None,
+    ):
         state = get_enrichment_state(
-            spark, run_id="run-001", catalog="cat", schema="sch",
-            dbutils=dbu,
+            spark, run_id="run-001", catalog="cat", schema="sch", dbutils=dbu,
         )
-    load_mock.assert_not_called()
     assert state["enrichment_skipped"].value is True
-    assert state["enrichment_skipped"].source is HandoffSource.TASK_VALUES
+    dbu.jobs.taskValues.get.assert_not_called()

--- a/packages/genie-space-optimizer/tests/unit/test_handoff_lever_loop_outputs.py
+++ b/packages/genie-space-optimizer/tests/unit/test_handoff_lever_loop_outputs.py
@@ -1,5 +1,9 @@
-"""Tests for get_lever_loop_outputs() — finalize / deploy fallback."""
-import json
+"""Tests for get_lever_loop_outputs() — Delta-only optimize/loop read (D9).
+
+D9 (Delta-only handoff): the loop outputs are reconstructed from
+``genie_opt_runs`` (best-* columns) and the latest ``eval_scope='full'``
+``genie_opt_iterations`` row. No Databricks task values are consulted.
+"""
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,43 +14,16 @@ from genie_space_optimizer.jobs._handoff import (
 )
 
 
-def _make_dbutils(values):
+def _hostile_dbutils():
+    """dbutils whose taskValues probe raises the retired-key crash if called."""
     dbu = MagicMock()
-    def _get(taskKey, key, default=""):
-        return values.get((taskKey, key), default)
-    dbu.jobs.taskValues.get.side_effect = _get
+    dbu.jobs.taskValues.get.side_effect = ValueError(
+        "Task key does not exist in run: lever_loop"
+    )
     return dbu
 
 
-def test_lever_loop_outputs_happy_path_uses_task_values():
-    dbu = _make_dbutils({
-        ("lever_loop", "scores"): json.dumps({"x": 90}),
-        ("lever_loop", "accuracy"): "92.5",
-        ("lever_loop", "model_id"): "m-final",
-        ("lever_loop", "iteration_counter"): "3",
-        ("lever_loop", "best_iteration"): "2",
-        ("lever_loop", "skipped"): "false",
-        ("lever_loop", "all_eval_mlflow_run_ids"): json.dumps(["r1", "r2"]),
-        ("lever_loop", "all_failure_question_ids"): json.dumps(["q1"]),
-    })
-    spark = MagicMock()
-    state = get_lever_loop_outputs(
-        spark, run_id="run-001", catalog="cat", schema="sch", dbutils=dbu,
-    )
-    assert state["scores"].value == {"x": 90}
-    assert state["accuracy"].value == 92.5
-    assert state["model_id"].value == "m-final"
-    assert state["iteration_counter"].value == 3
-    assert state["best_iteration"].value == 2
-    assert state["skipped"].value is False
-    assert state["all_eval_mlflow_run_ids"].value == ["r1", "r2"]
-    assert state["all_failure_question_ids"].value == ["q1"]
-    assert state["scores"].source is HandoffSource.TASK_VALUES
-
-
-def test_lever_loop_outputs_fall_back_to_delta():
-    dbu = _make_dbutils({})
-    spark = MagicMock()
+def _delta_fixtures():
     fake_run = {
         "best_iteration": 2,
         "best_model_id": "m-final",
@@ -65,6 +42,12 @@ def test_lever_loop_outputs_fall_back_to_delta():
     fake_iters_df.get.return_value.dropna.return_value.tolist.return_value = [
         "r1", "r2",
     ]
+    return fake_run, fake_latest, fake_iters_df
+
+
+def test_lever_loop_outputs_read_from_delta():
+    spark = MagicMock()
+    fake_run, fake_latest, fake_iters_df = _delta_fixtures()
 
     with patch(
         "genie_space_optimizer.jobs._handoff.load_run",
@@ -78,7 +61,6 @@ def test_lever_loop_outputs_fall_back_to_delta():
     ):
         state = get_lever_loop_outputs(
             spark, run_id="run-001", catalog="cat", schema="sch",
-            dbutils=dbu,
         )
     assert state["scores"].value == {"x": 90}
     assert state["scores"].source is HandoffSource.DELTA_FALLBACK
@@ -91,8 +73,61 @@ def test_lever_loop_outputs_fall_back_to_delta():
     assert state["all_failure_question_ids"].value == ["q1"]
 
 
-def test_lever_loop_outputs_raise_when_both_empty():
-    dbu = _make_dbutils({})
+def test_lever_loop_outputs_skipped_true_when_latest_is_iteration_zero():
+    """``skipped`` is derived from Delta: latest full row at iteration 0 means
+    the loop was skipped (no optimization iterations ran)."""
+    spark = MagicMock()
+    fake_run = {"best_iteration": 0, "best_model_id": "m0"}
+    fake_latest = {
+        "iteration": 0,
+        "scores_json": {"x": 80},
+        "overall_accuracy": 80.0,
+        "model_id": "m0",
+        "failures_json": [],
+    }
+    fake_iters_df = MagicMock()
+    fake_iters_df.empty = True
+    with patch(
+        "genie_space_optimizer.jobs._handoff.load_run",
+        return_value=fake_run,
+    ), patch(
+        "genie_space_optimizer.jobs._handoff.load_latest_full_iteration",
+        return_value=fake_latest,
+    ), patch(
+        "genie_space_optimizer.jobs._handoff.load_iterations",
+        return_value=fake_iters_df,
+    ):
+        state = get_lever_loop_outputs(
+            spark, run_id="run-001", catalog="cat", schema="sch",
+        )
+    assert state["skipped"].value is True
+    assert state["iteration_counter"].value == 0
+
+
+def test_lever_loop_outputs_do_not_probe_task_values():
+    """Regression for the v2 crash: a hostile dbutils whose taskValues probe
+    raises must not propagate — loop outputs come from Delta only."""
+    spark = MagicMock()
+    fake_run, fake_latest, fake_iters_df = _delta_fixtures()
+    dbu = _hostile_dbutils()
+    with patch(
+        "genie_space_optimizer.jobs._handoff.load_run",
+        return_value=fake_run,
+    ), patch(
+        "genie_space_optimizer.jobs._handoff.load_latest_full_iteration",
+        return_value=fake_latest,
+    ), patch(
+        "genie_space_optimizer.jobs._handoff.load_iterations",
+        return_value=fake_iters_df,
+    ):
+        state = get_lever_loop_outputs(
+            spark, run_id="run-001", catalog="cat", schema="sch", dbutils=dbu,
+        )
+    assert state["accuracy"].value == 92.5
+    dbu.jobs.taskValues.get.assert_not_called()
+
+
+def test_lever_loop_outputs_raise_when_no_state():
     spark = MagicMock()
     with patch(
         "genie_space_optimizer.jobs._handoff.load_run",
@@ -104,5 +139,4 @@ def test_lever_loop_outputs_raise_when_both_empty():
         with pytest.raises(RuntimeError, match="lever_loop"):
             get_lever_loop_outputs(
                 spark, run_id="run-001", catalog="cat", schema="sch",
-                dbutils=dbu,
             )

--- a/packages/genie-space-optimizer/tests/unit/test_handoff_run_context.py
+++ b/packages/genie-space-optimizer/tests/unit/test_handoff_run_context.py
@@ -1,4 +1,9 @@
-"""Tests for get_run_context() — reads preflight state with Delta fallback."""
+"""Tests for get_run_context() — Delta-only run-context read (D9).
+
+D9 (Delta-only handoff): run-level context is read straight from
+``genie_opt_runs`` keyed by the ``run_id`` job widget; ``catalog`` / ``schema``
+are echoed from their widgets. No Databricks task values are consulted.
+"""
 import json
 from unittest.mock import MagicMock, patch
 
@@ -10,55 +15,16 @@ from genie_space_optimizer.jobs._handoff import (
 )
 
 
-def _make_dbutils(values):
-    """Build a mock dbutils.jobs.taskValues.get(...) returning ``values``.
-
-    ``values`` maps (taskKey, key) tuples to the value to return.
-    Missing keys return the default kwarg.
-    """
+def _hostile_dbutils():
+    """dbutils whose taskValues probe raises the retired-key crash if called."""
     dbu = MagicMock()
-    def _get(taskKey, key, default=""):
-        return values.get((taskKey, key), default)
-    dbu.jobs.taskValues.get.side_effect = _get
+    dbu.jobs.taskValues.get.side_effect = ValueError(
+        "Task key does not exist in run: preflight"
+    )
     return dbu
 
 
-def test_run_context_happy_path_uses_task_values():
-    dbu = _make_dbutils({
-        ("preflight", "run_id"): "run-001",
-        ("preflight", "space_id"): "space-abc",
-        ("preflight", "domain"): "revenue",
-        ("preflight", "catalog"): "cat",
-        ("preflight", "schema"): "sch",
-        ("preflight", "experiment_name"): "/exp",
-        ("preflight", "max_iterations"): "10",
-        ("preflight", "levers"): "[1,2,3]",
-        ("preflight", "apply_mode"): "genie_config",
-        ("preflight", "triggered_by"): "user@x.com",
-        ("preflight", "warehouse_id"): "wh-xyz",
-        ("preflight", "human_corrections"): "[]",
-        ("preflight", "max_benchmark_count"): "42",
-    })
-    spark = MagicMock()
-
-    ctx = get_run_context(
-        spark,
-        run_id_widget="run-001",
-        catalog_widget="cat",
-        schema_widget="sch",
-        dbutils=dbu,
-    )
-
-    assert ctx["run_id"].value == "run-001"
-    assert ctx["run_id"].source is HandoffSource.TASK_VALUES
-    assert ctx["levers"].value == [1, 2, 3]
-    assert ctx["max_iterations"].value == 10
-    assert ctx["max_benchmark_count"].value == 42
-    assert ctx["human_corrections"].value == []
-
-
-def test_run_context_falls_back_to_delta_when_task_values_empty():
-    dbu = _make_dbutils({})  # everything empty / default
+def test_run_context_reads_from_delta():
     spark = MagicMock()
     fake_run_row = {
         "run_id": "run-001",
@@ -84,7 +50,6 @@ def test_run_context_falls_back_to_delta_when_task_values_empty():
             run_id_widget="run-001",
             catalog_widget="cat",
             schema_widget="sch",
-            dbutils=dbu,
         )
 
     assert ctx["run_id"].value == "run-001"
@@ -97,8 +62,86 @@ def test_run_context_falls_back_to_delta_when_task_values_empty():
     assert ctx["max_benchmark_count"].value == 42
 
 
-def test_run_context_raises_when_task_values_and_delta_both_empty():
-    dbu = _make_dbutils({})
+def test_run_context_parses_json_columns_stored_as_strings():
+    """``levers`` / ``human_corrections_json`` come back from load_run as JSON
+    strings; the helper parses them so callers always see typed values."""
+    spark = MagicMock()
+    fake_run_row = {
+        "run_id": "run-001",
+        "space_id": "space-abc",
+        "levers": "[1, 2, 3]",
+        "human_corrections_json": "[{\"qid\": \"q1\"}]",
+    }
+    with patch(
+        "genie_space_optimizer.jobs._handoff.load_run",
+        return_value=fake_run_row,
+    ):
+        ctx = get_run_context(
+            spark,
+            run_id_widget="run-001",
+            catalog_widget="cat",
+            schema_widget="sch",
+        )
+    assert ctx["levers"].value == [1, 2, 3]
+    assert ctx["human_corrections"].value == [{"qid": "q1"}]
+
+
+def test_run_context_does_not_probe_task_values():
+    """Regression for the v2 crash: a hostile dbutils whose taskValues probe
+    raises must not propagate — context comes from Delta only."""
+    spark = MagicMock()
+    fake_run_row = {"run_id": "run-001", "space_id": "space-abc"}
+    dbu = _hostile_dbutils()
+    with patch(
+        "genie_space_optimizer.jobs._handoff.load_run",
+        return_value=fake_run_row,
+    ):
+        ctx = get_run_context(
+            spark,
+            run_id_widget="run-001",
+            catalog_widget="cat",
+            schema_widget="sch",
+            dbutils=dbu,
+        )
+    assert ctx["run_id"].value == "run-001"
+    dbu.jobs.taskValues.get.assert_not_called()
+
+
+def test_run_context_catalog_schema_come_from_widgets():
+    """``catalog`` / ``schema`` are the bootstrap job widgets — authoritative
+    direct reads (TASK_VALUES source), not reconstructed from Delta."""
+    spark = MagicMock()
+    fake_run_row = {"run_id": "run-001", "space_id": "space-abc"}
+    with patch(
+        "genie_space_optimizer.jobs._handoff.load_run",
+        return_value=fake_run_row,
+    ) as load_mock:
+        ctx = get_run_context(
+            spark,
+            run_id_widget="run-001",
+            catalog_widget="cat",
+            schema_widget="sch",
+        )
+
+    load_mock.assert_called_once_with(spark, "run-001", "cat", "sch")
+    assert ctx["catalog"].value == "cat"
+    assert ctx["catalog"].source is HandoffSource.TASK_VALUES  # came from widget
+    assert ctx["schema"].source is HandoffSource.TASK_VALUES
+    assert ctx["space_id"].source is HandoffSource.DELTA_FALLBACK
+
+
+def test_run_context_raises_when_run_id_widget_empty():
+    spark = MagicMock()
+    with pytest.raises(RuntimeError, match="run_id_widget is required"):
+        get_run_context(
+            spark,
+            run_id_widget="",
+            catalog_widget="cat",
+            schema_widget="sch",
+        )
+
+
+def test_run_context_raises_when_no_delta_row():
     spark = MagicMock()
     with patch(
         "genie_space_optimizer.jobs._handoff.load_run",
@@ -110,40 +153,4 @@ def test_run_context_raises_when_task_values_and_delta_both_empty():
                 run_id_widget="run-001",
                 catalog_widget="cat",
                 schema_widget="sch",
-                dbutils=dbu,
             )
-
-
-def test_run_context_bootstraps_from_widgets_when_task_values_empty():
-    """Repair Run case: taskValues empty, widgets carry run_id/catalog/schema,
-    Delta fills the rest."""
-    dbu = _make_dbutils({})
-    spark = MagicMock()
-    fake_run_row = {
-        "run_id": "run-001",
-        "space_id": "space-abc",
-        "domain": "revenue",
-        "catalog": "cat",
-        "uc_schema": "cat.sch",
-        "experiment_name": "/exp",
-        "max_iterations": 10,
-        "levers": [1, 2, 3],
-        "apply_mode": "genie_config",
-    }
-    with patch(
-        "genie_space_optimizer.jobs._handoff.load_run",
-        return_value=fake_run_row,
-    ) as load_mock:
-        ctx = get_run_context(
-            spark,
-            run_id_widget="run-001",
-            catalog_widget="cat",
-            schema_widget="sch",
-            dbutils=dbu,
-        )
-
-    load_mock.assert_called_once_with(spark, "run-001", "cat", "sch")
-    assert ctx["run_id"].value == "run-001"
-    assert ctx["space_id"].value == "space-abc"
-    assert ctx["catalog"].source is HandoffSource.TASK_VALUES  # came from widget
-    assert ctx["space_id"].source is HandoffSource.DELTA_FALLBACK

--- a/packages/genie-space-optimizer/tests/unit/test_state_migration.py
+++ b/packages/genie-space-optimizer/tests/unit/test_state_migration.py
@@ -309,3 +309,95 @@ def test_migration_verifies_target_columns_present_after_loop(caplog):
         "expected loud ERROR naming the missing 'rolled_back' column; "
         f"got: {error_msgs}"
     )
+
+
+# ── GSO v2: retired-table migration skip (log-noise cleanup) ──────────────
+
+
+_FULL_ITERATION_COLS = [
+    "run_id", "iteration", "lever", "eval_scope", "timestamp",
+    "mlflow_run_id", "model_id", "overall_accuracy",
+    "total_questions", "correct_count", "scores_json",
+    "failures_json", "remaining_failures", "arbiter_actions_json",
+    "repeatability_pct", "repeatability_json", "thresholds_met",
+    "rows_json", "reflection_json", "evaluated_count", "excluded_count",
+    "quarantined_benchmarks_json", "leakage_count_by_type",
+    "firewall_rejection_count_by_type", "secondary_mining_blocked",
+    "synthesis_slots_persisted", "arbiter_rejection_count",
+    "cluster_fallback_to_instruction_count", "synthesis_archetype_distribution",
+    "rolled_back", "rolled_back_at", "rollback_reason",
+    "both_correct_count", "both_correct_rate",
+    # Writer-required columns verified by _verify_required_columns — include
+    # them so the post-loop verify does not log a spurious [MIGRATION INCOMPLETE].
+    "config_json", "is_champion",
+    "num_needs_review", "eval_run_id", "eval_run_status",
+]
+
+
+class _SparkRetiredTablesAbsent(_FakeSpark):
+    """Fake Spark where ANY statement touching a retired table raises
+    TABLE_OR_VIEW_NOT_FOUND — exactly the fresh-v2-install condition that
+    produced ``[MIGRATION FAILED]`` ERROR spam before the skip landed.
+    """
+
+    def __init__(self, retired: tuple[str, ...], **kwargs):
+        super().__init__(**kwargs)
+        self._retired = retired
+
+    def sql(self, stmt: str):
+        if any(t in stmt for t in self._retired):
+            self.sql_calls.append(stmt)
+            raise RuntimeError(
+                "[TABLE_OR_VIEW_NOT_FOUND] The table or view cannot be found."
+            )
+        return super().sql(stmt)
+
+
+def test_migration_skips_retired_tables_no_spam(caplog):
+    """ADDITIVE_COLUMN_MIGRATIONS still lists entries for tables v2 retired
+    (e.g. genie_eval_asi_results, genie_opt_data_access_grants). On a fresh v2
+    install those tables don't exist, so migrating them would throw
+    TABLE_OR_VIEW_NOT_FOUND and log ``[MIGRATION FAILED]``. The loop must skip
+    any entry whose target table is not in the active DDL set — so no SQL is
+    ever issued against a retired table and no MIGRATION FAILED is logged.
+    """
+    import logging
+
+    from genie_space_optimizer.optimization.ddl import (
+        ADDITIVE_COLUMN_MIGRATIONS,
+        RETIRED_TABLES,
+        _ALL_DDL,
+    )
+
+    # Guard: the scenario is only meaningful if some migration entry actually
+    # targets a retired table.
+    retired_targets = {
+        table for table, _c, _d in ADDITIVE_COLUMN_MIGRATIONS
+        if table in RETIRED_TABLES
+    }
+    assert retired_targets, (
+        "expected at least one ADDITIVE_COLUMN_MIGRATIONS entry targeting a "
+        "retired table for this regression to be meaningful"
+    )
+    assert retired_targets.isdisjoint(_ALL_DDL), (
+        "retired tables must not be in the active DDL set"
+    )
+
+    spark = _SparkRetiredTablesAbsent(
+        RETIRED_TABLES, existing_cols=list(_FULL_ITERATION_COLS),
+    )
+
+    with caplog.at_level(logging.ERROR, logger=state_mod.__name__):
+        state_mod._migrate_add_columns(spark, "cat", "sch")
+
+    # No SQL statement ever referenced a retired table.
+    for table in RETIRED_TABLES:
+        touched = [s for s in spark.sql_calls if table in s]
+        assert not touched, f"retired table {table} was touched by: {touched}"
+
+    # No MIGRATION FAILED / MIGRATION INCOMPLETE ERROR spam.
+    error_msgs = " ".join(
+        r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR
+    )
+    assert "MIGRATION FAILED" not in error_msgs, error_msgs
+    assert "MIGRATION INCOMPLETE" not in error_msgs, error_msgs


### PR DESCRIPTION
## Root cause

The Phase-7 v2 rearchitecture (commit `9a2d9449`) moved the optimizer to a **Delta-only handoff** model (design note **D9** — v2 notebooks publish NO Databricks task values) and renamed the DAG from the old 6-task design to the 5-task v2 DAG:

`00_intake_and_snapshot` → `01_benchmark_qc_and_repair` → `02_baseline_eval_and_triage` → `03_optimize` → `publish_and_audit`

But `jobs/_handoff.py` still probed `dbutils.jobs.taskValues.get(...)` with **stale task-key literals from the retired 6-task DAG** (`preflight`, `baseline_eval`, `enrichment`, `lever_loop`). Those keys don't exist in a v2 run, so `taskValues.get` raises `ValueError: Task key does not exist in run: <key>` **before** its `default=` / Delta fallback can run — a hard crash.

- **Confirmed crash:** `run_03_optimize.py` → `get_baseline_eval_state` (probed `baseline_eval`).
- **Latent siblings (same bug):** `get_run_context` (`preflight`), `get_enrichment_state` (`enrichment`), `get_lever_loop_outputs` (`lever_loop`).

## What changed

### Task 1 — `_handoff.py` is now Delta-only
- Deleted `_tv_get` and removed the task-value probe from all four helpers (`get_run_context`, `get_baseline_eval_state`, `get_enrichment_state`, `get_lever_loop_outputs`). Each now reads straight from its existing Delta source with **return shapes/semantics preserved**:
  - `get_run_context` → `genie_opt_runs` (via `load_run`), keyed by the `run_id` job widget; `catalog`/`schema` still echoed from widgets (kept `TASK_VALUES` source — they're authoritative direct inputs).
  - `get_baseline_eval_state` → `genie_opt_iterations` iteration=0, `eval_scope='full'` (written by `02_baseline_eval_and_triage` via `harness.baseline_persist_state`).
  - `get_enrichment_state` → `genie_opt_iterations` `eval_scope='enrichment'` (absent row ⇒ `enrichment_skipped=True`, no raise — unchanged).
  - `get_lever_loop_outputs` → `genie_opt_runs` best-* columns + latest `eval_scope='full'` iteration row.
- `_resolve` simplified to Delta-only: `DELTA_FALLBACK` when the Delta value is present, else `MISSING`.
- `dbutils` is retained as an **optional, ignored** kwarg so every existing call site keeps working with zero notebook edits.
- Scrubbed all `taskValues`/`taskKey` references (including docstrings & error messages). **Grep proves zero remain.**

### Task 2 — publish path verified
The live v2 publish task is `run_publish_and_audit.py`, which is already Delta-only and does **not** use `_handoff`. The legacy `run_finalize.py` caller of `get_baseline_eval_state` stays correct (signature-compatible, identical return shape). See "Notes / discrepancies" below.

### Task 3 — skip retired-table additive migrations
`_migrate_add_columns` now skips any `ADDITIVE_COLUMN_MIGRATIONS` entry whose target table is **not in the active DDL set** (`_ALL_DDL`) — i.e. `RETIRED_TABLES`. This stops the `[MIGRATION FAILED]` `TABLE_OR_VIEW_NOT_FOUND` ERROR spam on a fresh v2 install.

### Tests
- Rewrote the handoff unit tests for the Delta-only path, including a **regression that reproduces the exact crash**: a `dbutils` whose `taskValues.get` raises `ValueError("Task key does not exist in run")` must **not** be called (`assert_not_called`).
- Added `test_migration_skips_retired_tables_no_spam`: with a Spark stub that raises `TABLE_OR_VIEW_NOT_FOUND` for any retired-table statement, no retired-table SQL is issued and no `[MIGRATION FAILED]`/`[MIGRATION INCOMPLETE]` is logged.

## Notes / discrepancies found during implementation
- **`run_finalize.py` is not the v2 publish task.** The task brief called `run_finalize.py` "the publish_and_audit path", but it's a legacy 6-task notebook not wired into the v2 DAG (the DAG's 5th task is `run_publish_and_audit.py`). My change keeps `run_finalize.py`'s handoff caller correct regardless; no edit was needed there. (`run_finalize.py` still has its own direct `taskValues` probes for `preflight`, out of scope for this fix.)
- **Only 2 of the "four" retired tables actually spam.** Of the four named in the brief, only `genie_eval_asi_results.mlflow_run_id` and `genie_opt_data_access_grants.grant_type` appear in `ADDITIVE_COLUMN_MIGRATIONS`; `genie_eval_question_regressions` and `genie_eval_gt_correction_candidates` are retired but have no migration entries, so they never spammed. The fix is table-membership-based, so it's robust regardless of count.

## Gates
- `uv run pytest` → **2 failed, 4148 passed** (17 skipped, 3 xfailed). Both failures are pre-existing on `gso/optimizer-v2` and unrelated to this change (`test_arbiter_approved_mining.py::...held_out_benchmarks_kwonly`, `test_unified_rca_prompt_alignment.py::...synthesis_contract_constant_exists`). Baseline before my change was identical (2 failed, 4144 passed); +4 = my net-new tests.
- `uv run ty check` → **292 diagnostics, unchanged from baseline.** The only diagnostics touching my files are pre-existing environmental `pyspark.sql` unresolved-imports. No new diagnostics.
- Lint: this package has no dedicated linter configured (no ruff in `pyproject.toml`/CI); `ty` is the static-analysis gate.

This pull request and its description were written by Isaac.