### PR TITLE
Fix proactive sample_questions enrichment to PATCH a full serialized_space

### DIFF
--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
@@ -5132,6 +5132,7 @@ def _run_space_metadata_enrichment(
     the top-level ``description`` or ``config.sample_questions`` are absent.
     """
     from genie_space_optimizer.common.genie_client import (
+        fetch_space_config,
         patch_space_config,
         update_space_description,
     )
@@ -5151,6 +5152,7 @@ def _run_space_metadata_enrichment(
         "description_generated": False,
         "questions_generated": False,
         "questions_count": 0,
+        "questions_skipped_empty_base": False,
     }
 
     if not needs_description and not needs_questions:
@@ -5201,33 +5203,54 @@ def _run_space_metadata_enrichment(
         if needs_questions:
             new_sqs = _generate_sample_questions(metadata_snapshot, effective_desc, w)
             if new_sqs:
-                cfg_block = parsed.setdefault("config", {})
-                cfg_block["sample_questions"] = new_sqs
-                try:
-                    patch_space_config(w, space_id, parsed)
-                    result["questions_generated"] = True
-                    result["questions_count"] = len(new_sqs)
-                    for idx, sq in enumerate(new_sqs):
-                        q_text = sq.get("question", [""])[0] if sq.get("question") else ""
-                        write_patch(
-                            spark, run_id, 0, 0, idx + 1,
-                            {
-                                "patch_type": "proactive_sample_question",
-                                "scope": "genie_config",
-                                "risk_level": "low",
-                                "target_object": f"config.sample_questions[{idx}]",
-                                "patch": {"question": q_text[:100]},
-                                "command": None,
-                                "rollback": None,
-                                "proposal_id": "space_metadata_enrichment",
-                            },
-                            catalog, schema,
-                        )
-                except Exception:
-                    logger.warning(
-                        "Space metadata enrichment: sample_questions PATCH failed",
-                        exc_info=True,
+                # A Genie ``serialized_space`` update is FULL-REPLACEMENT: to
+                # change only ``config.sample_questions`` we must GET the whole
+                # current object, mutate it in place, and PATCH it back —
+                # echoing the existing top-level ``version`` and preserving
+                # ``data_sources`` (see the Update Genie Space API validation
+                # rules and ``validate_serialized_space``). Build the PATCH from
+                # the AUTHORITATIVE re-fetched config rather than the passed-in
+                # ``_parsed_space``: the latter can be empty/degenerate, and
+                # mutating it fabricated a partial ``{"config": {...}}`` object
+                # missing top-level ``version``/``data_sources`` that the strict
+                # validator (correctly) rejected before any HTTP call.
+                current = fetch_space_config(w, space_id).get("_parsed_space") or {}
+                if not current.get("data_sources") or current.get("version") is None:
+                    result["questions_skipped_empty_base"] = True
+                    logger.info(
+                        "Space metadata enrichment: base config has no "
+                        "data_sources/version (empty space) — skipping "
+                        "sample_questions PATCH for %s",
+                        space_id,
                     )
+                else:
+                    target = copy.deepcopy(current)
+                    target.setdefault("config", {})["sample_questions"] = new_sqs
+                    try:
+                        patch_space_config(w, space_id, target)
+                        result["questions_generated"] = True
+                        result["questions_count"] = len(new_sqs)
+                        for idx, sq in enumerate(new_sqs):
+                            q_text = sq.get("question", [""])[0] if sq.get("question") else ""
+                            write_patch(
+                                spark, run_id, 0, 0, idx + 1,
+                                {
+                                    "patch_type": "proactive_sample_question",
+                                    "scope": "genie_config",
+                                    "risk_level": "low",
+                                    "target_object": f"config.sample_questions[{idx}]",
+                                    "patch": {"question": q_text[:100]},
+                                    "command": None,
+                                    "rollback": None,
+                                    "proposal_id": "space_metadata_enrichment",
+                                },
+                                catalog, schema,
+                            )
+                    except Exception:
+                        logger.warning(
+                            "Space metadata enrichment: sample_questions PATCH failed",
+                            exc_info=True,
+                        )
 
         _desc_status = (
             f"generated ({len(desc_text)} chars)"
@@ -5237,7 +5260,14 @@ def _run_space_metadata_enrichment(
         _sq_status = (
             f"generated ({len(new_sqs)} questions)"
             if result['questions_generated']
-            else ("already present" if not needs_questions else "FAILED")
+            else (
+                "already present" if not needs_questions
+                else (
+                    "skipped (empty space — no data_sources/version)"
+                    if result['questions_skipped_empty_base']
+                    else "FAILED"
+                )
+            )
         )
         _sm_lines = [_section("SPACE METADATA ENRICHMENT", "-")]
         _sm_lines.append(_kv("Description", _desc_status))

--- a/packages/genie-space-optimizer/tests/unit/test_space_metadata_enrichment_full_replacement.py
+++ b/packages/genie-space-optimizer/tests/unit/test_space_metadata_enrichment_full_replacement.py
@@ -1,0 +1,275 @@
+"""Proactive sample_questions enrichment must build a FULL, valid
+``serialized_space`` from the AUTHORITATIVE re-fetched config.
+
+Root cause (v2 E2E, notebook 03_optimize Stage 2.5 proactive
+enrichment):
+:func:`genie_space_optimizer.optimization.harness._run_space_metadata_enrichment`
+mutated whatever the passed-in ``config['_parsed_space']`` held and
+shipped THAT as the entire ``serialized_space`` via
+``patch_space_config`` — it never re-fetched/merged. When the base was
+empty/degenerate, ``parsed.setdefault('config', {})['sample_questions']``
+fabricated a partial object ``{'config': {'sample_questions': [...]}}``
+missing the mandatory top-level ``data_sources`` and ``version``. The
+strict validator inside ``patch_space_config`` correctly rejected the
+partial object BEFORE any HTTP call
+(``serialized_space must contain 'data_sources'`` +
+``version: required field is missing``). Non-fatal — the loop
+continued — but it emitted a scary ERROR + traceback and silently
+skipped sample-question enrichment.
+
+A Genie ``serialized_space`` update is FULL-REPLACEMENT (see the Update
+Genie Space API validation rules): to change only sample_questions the
+whole object must be GET → mutate → PATCH, echoing the existing
+``version`` and preserving ``data_sources``. ``fetch_space_config``
+already requests ``include_serialized_space=true``, so the fix re-fetches
+the authoritative config, mutates ``config.sample_questions`` on a deep
+copy, and PATCHes the full object. When the base has no
+``data_sources``/``version`` it logs a clean INFO skip instead of
+fabricating a partial PATCH.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from unittest.mock import MagicMock, patch
+
+import genie_space_optimizer.common.genie_client as _genie_client_mod
+import genie_space_optimizer.optimization.optimizer as _optimizer_mod
+from genie_space_optimizer.optimization import harness
+
+# A valid 32-char lowercase hex sample-question id.
+_SQ_ID = "a" * 32
+_NEW_SQS = [{"id": _SQ_ID, "question": ["What is total revenue?"]}]
+
+# The exact fabricated shape the old bug produced from a degenerate base.
+_PARTIAL_FABRICATED = {"config": {"sample_questions": _NEW_SQS}}
+
+_SPACE_ID = "01f1756be5bf1db8895263c014de28c4"
+
+
+def _authoritative_full_config() -> dict:
+    """Shape ``fetch_space_config`` returns for a populated space: a full
+    ``serialized_space`` under ``_parsed_space`` (version + data_sources +
+    config + instructions)."""
+    return {
+        "_parsed_space": {
+            "version": 2,
+            "data_sources": {
+                "tables": [{"identifier": "cat.sch.fact_sales"}],
+                "metric_views": [],
+            },
+            "config": {"sample_questions": []},
+            "instructions": {"text_instructions": []},
+        },
+    }
+
+
+def _run(config: dict, *, fetch_return: dict, generate_return=_NEW_SQS):
+    """Invoke ``_run_space_metadata_enrichment`` with all I/O mocked out.
+
+    Returns ``(result, patch_mock, fetch_mock, logger_mock)``.
+    """
+    patch_mock = MagicMock(name="patch_space_config", return_value={})
+    fetch_mock = MagicMock(name="fetch_space_config", return_value=fetch_return)
+    gen_mock = MagicMock(name="_generate_sample_questions", return_value=generate_return)
+    logger_mock = MagicMock(name="logger")
+
+    with (
+        patch.object(_genie_client_mod, "patch_space_config", patch_mock),
+        patch.object(_genie_client_mod, "fetch_space_config", fetch_mock),
+        patch.object(_optimizer_mod, "_generate_sample_questions", gen_mock),
+        patch.object(harness, "write_stage", MagicMock()),
+        patch.object(harness, "write_patch", MagicMock()),
+        patch.object(harness, "logger", logger_mock),
+    ):
+        result = harness._run_space_metadata_enrichment(
+            MagicMock(name="w"),
+            MagicMock(name="spark"),
+            "run-1",
+            _SPACE_ID,
+            config,
+            {"data_sources": {"tables": []}},
+            "cat",
+            "sch",
+        )
+    return result, patch_mock, fetch_mock, logger_mock
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Populated base — build a FULL serialized_space from the authoritative fetch
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPopulatedBase:
+    def test_patches_full_object_from_authoritative_fetch(self):
+        """Even when the PASSED-IN ``_parsed_space`` is degenerate, the
+        PATCH is built from the authoritative re-fetched config and carries
+        top-level ``version`` + ``data_sources`` with sample_questions
+        updated in place."""
+        passed_in = {
+            "description": "x" * 20,   # present → no description work
+            "_parsed_space": {},        # DEGENERATE — must NOT drive the PATCH
+        }
+        fetch_return = _authoritative_full_config()
+
+        result, patch_mock, fetch_mock, _ = _run(passed_in, fetch_return=fetch_return)
+
+        # Re-fetched the authoritative serialized_space exactly once.
+        assert fetch_mock.call_count == 1
+        # PATCHed exactly once, with the FULL object.
+        assert patch_mock.call_count == 1
+        _w, space_id, target = patch_mock.call_args.args
+        assert space_id == _SPACE_ID
+
+        # Top-level version echoed UNCHANGED and data_sources PRESERVED.
+        assert target["version"] == 2
+        assert target["data_sources"] == {
+            "tables": [{"identifier": "cat.sch.fact_sales"}],
+            "metric_views": [],
+        }
+        # sample_questions updated in place on config.
+        assert target["config"]["sample_questions"] == _NEW_SQS
+
+        # Deep copy — the fetched current object was NOT mutated.
+        assert fetch_return["_parsed_space"]["config"]["sample_questions"] == []
+
+        # Result reflects a real write, not a skip.
+        assert result["questions_generated"] is True
+        assert result["questions_count"] == 1
+        assert result["questions_skipped_empty_base"] is False
+
+    def test_patched_object_passes_strict_validation(self):
+        """The object handed to ``patch_space_config`` must itself be a
+        strict-valid ``serialized_space`` (this is precisely what the old
+        code failed to guarantee)."""
+        from genie_space_optimizer.common.genie_schema import (
+            validate_serialized_space,
+        )
+
+        passed_in = {"description": "x" * 20, "_parsed_space": {}}
+        _, patch_mock, _, _ = _run(
+            passed_in, fetch_return=_authoritative_full_config()
+        )
+        target = patch_mock.call_args.args[2]
+        ok, errors = validate_serialized_space(target, strict=True)
+        assert ok, f"enrichment PATCH payload must be strict-valid; got: {errors}"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Empty / degenerate base — clean skip, never fabricate a partial PATCH
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestEmptyBase:
+    def test_skips_patch_logs_clean_info_never_raises(self):
+        passed_in = {"description": "x" * 20, "_parsed_space": {}}
+        # Genuinely empty space: fetch returns no serialized_space content.
+        result, patch_mock, fetch_mock, logger_mock = _run(
+            passed_in, fetch_return={"_parsed_space": {}}
+        )
+
+        # Re-fetched but did NOT PATCH — no partial object constructed.
+        assert fetch_mock.call_count == 1
+        patch_mock.assert_not_called()
+
+        # Recorded as a clean skip, not a failure.
+        assert result["questions_generated"] is False
+        assert result["questions_count"] == 0
+        assert result["questions_skipped_empty_base"] is True
+
+        # Clean INFO skip — no WARNING/ERROR/traceback.
+        logger_mock.warning.assert_not_called()
+        logger_mock.error.assert_not_called()
+        logger_mock.exception.assert_not_called()
+        info_fmt = " ".join(
+            str(c.args[0]) for c in logger_mock.info.call_args_list if c.args
+        )
+        assert "empty space" in info_fmt
+        assert "skipping" in info_fmt
+
+    def test_missing_data_sources_key_is_treated_as_empty(self):
+        """A base with a ``version`` but no ``data_sources`` is still an
+        empty/degenerate space and must be skipped, not PATCHed with a
+        payload the API would reject."""
+        passed_in = {"description": "x" * 20, "_parsed_space": {}}
+        result, patch_mock, _, _ = _run(
+            passed_in, fetch_return={"_parsed_space": {"version": 2}}
+        )
+        patch_mock.assert_not_called()
+        assert result["questions_skipped_empty_base"] is True
+
+    def test_missing_version_is_treated_as_empty(self):
+        """A base with ``data_sources`` but no ``version`` is skipped —
+        PATCHing without echoing ``version`` would trip the validator."""
+        passed_in = {"description": "x" * 20, "_parsed_space": {}}
+        result, patch_mock, _, _ = _run(
+            passed_in,
+            fetch_return={
+                "_parsed_space": {"data_sources": {"tables": []}},
+            },
+        )
+        patch_mock.assert_not_called()
+        assert result["questions_skipped_empty_base"] is True
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Source-level guard — pin the fix wiring
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestSourceWiring:
+    def test_builds_patch_from_authoritative_fetch_not_passed_in_parsed(self):
+        src = inspect.getsource(harness._run_space_metadata_enrichment)
+        # Re-fetches the authoritative serialized_space.
+        assert 'fetch_space_config(w, space_id).get("_parsed_space")' in src
+        # Deep-copies before mutating (no aliasing of the fetched object).
+        assert "copy.deepcopy(current)" in src
+        # Empty-base guard present on BOTH required top-level fields.
+        assert 'current.get("data_sources")' in src
+        assert 'current.get("version") is None' in src
+        assert "questions_skipped_empty_base" in src
+        # The old antipattern — mutating and PATCHing the passed-in parsed
+        # object — must be gone.
+        assert "patch_space_config(w, space_id, parsed)" not in src
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# patch_space_config full-replacement contract — partial object rejected
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPatchSpaceConfigFullReplacement:
+    def test_rejects_partial_object_before_any_http(self):
+        """The exact fabricated shape the old bug produced must be rejected
+        by ``patch_space_config`` BEFORE any HTTP call."""
+        from genie_space_optimizer.common.genie_client import patch_space_config
+
+        w = MagicMock()
+        try:
+            patch_space_config(w, _SPACE_ID, dict(_PARTIAL_FABRICATED))
+        except ValueError as exc:
+            msg = str(exc)
+            assert "data_sources" in msg
+            assert "version" in msg
+        else:
+            raise AssertionError(
+                "expected ValueError for partial serialized_space"
+            )
+        # Validation short-circuits before the PATCH is sent.
+        w.api_client.do.assert_not_called()
+
+    def test_validator_reproduces_exact_partial_failure(self):
+        """Direct validator reproduction of the two error messages seen in
+        the failing E2E run."""
+        from genie_space_optimizer.common.genie_schema import (
+            validate_serialized_space,
+        )
+
+        ok, errors = validate_serialized_space(
+            dict(_PARTIAL_FABRICATED), strict=True
+        )
+        assert not ok
+        joined = "\n".join(errors)
+        assert "data_sources" in joined
+        assert "version: required field is missing" in joined


### PR DESCRIPTION
## Root cause

During the GSO v2 E2E (notebook `03_optimize`, Stage 2.5 proactive enrichment), the sample_questions metadata-enrichment PATCH failed validation:

```
'serialized_space must contain data_sources' + 'version: required field is missing'
```

for space `01f1756be5bf1db8895263c014de28c4`. It was **non-fatal** (caught; loop continues) but emitted a scary ERROR + traceback and silently skipped sample-question enrichment.

`_run_space_metadata_enrichment` (`optimization/harness.py`) mutated whatever the passed-in `config['_parsed_space']` held and shipped **that** as the entire `serialized_space` via `patch_space_config` — it never re-fetched/merged. When the base was empty/degenerate, `parsed.setdefault('config', {})['sample_questions'] = new_sqs` fabricated a partial `{'config': {'sample_questions': [...]}}` object missing the mandatory top-level `data_sources` and `version`. `patch_space_config` is a correct "send-exactly-this" full-replacement primitive; its strict validator (`common/genie_schema.py` — `data_sources` required via the pydantic model validator, `version ∈ {1,2}` required via `_strict_validate`) correctly rejected the partial object **before any HTTP call**, so nothing was corrupted.

A Genie `serialized_space` update is **full-replacement**: to change only `sample_questions` you must GET the current space with `include_serialized_space=true`, mutate `config.sample_questions` in place, and PATCH the whole object, echoing the existing `version`.

## STEP 0 conclusion — `fetch_space_config` is correct (no fetch defect)

`fetch_space_config` (`common/genie_client.py:308-312`) **does** request the full serialized space — it calls `GET /api/2.0/genie/spaces/{id}` with `query={"include_serialized_space": "true"}` and sets `config['_parsed_space'] = serialized_space` (or `{}`). So there is **no fetch defect**. That means space `01f175...` was a **genuinely empty space**, and the clean-skip branch is the right behavior. No change was needed to `fetch_space_config`.

## What changed

Confined to the `genie-space-optimizer` package. No notebooks touched.

In the shared body of `_run_space_metadata_enrichment` (covers both call sites — `harness.py:8297` in `_run_enrichment` and the inline clone), the sample_questions PATCH now:

1. **Builds the PATCH from the authoritative current config**, mirroring the sibling `_refresh_config_preserving_mv_state` re-fetch pattern:
   ```python
   current = fetch_space_config(w, space_id).get("_parsed_space") or {}
   if not current.get("data_sources") or current.get("version") is None:
       # clean INFO skip — empty space
   else:
       target = copy.deepcopy(current)
       target.setdefault("config", {})["sample_questions"] = new_sqs
       patch_space_config(w, space_id, target)  # full, valid serialized_space
   ```
   This guarantees the object handed to `patch_space_config` always carries top-level `version` + `data_sources` when we actually PATCH.
2. **Empty-base guard**: when `data_sources`/`version` are absent, logs a clean INFO (`... base config has no data_sources/version (empty space) — skipping sample_questions PATCH for <space_id>`) and skips — never fabricates a partial PATCH, never raises. The existing except-block behavior (run continues) is preserved.
3. Banner status now reads `skipped (empty space …)` instead of a misleading `FAILED`; adds a `questions_skipped_empty_base` result flag.

`patch_space_config`'s validation/replacement contract is **unchanged** (it is correct); its pre-PATCH `logger.error` for genuine caller bugs is retained, but the enrichment path no longer trips it under the empty-space condition.

## Tests (hostile, not smoke) — `tests/unit/test_space_metadata_enrichment_full_replacement.py`

- **Populated base**: even with a *degenerate passed-in* `_parsed_space`, the PATCH is built from the authoritative re-fetch and carries top-level `version` (echoed unchanged) + `data_sources` (preserved), with `sample_questions` updated in place; deep-copy verified (fetched object not mutated); payload is itself strict-valid.
- **Empty/degenerate base**: `patch_space_config` is **not** called, no raise, `questions_skipped_empty_base` is set, clean INFO logged (no WARNING/ERROR/exception). Also covers `version`-only and `data_sources`-only bases.
- **Source-level guard**: pins the re-fetch + deepcopy wiring and asserts the old `patch_space_config(w, space_id, parsed)` antipattern is gone.
- **Full-replacement contract**: `patch_space_config` rejects the exact fabricated partial object *before any HTTP call*; direct validator reproduction of both error strings.

## Gate results

- **Tests**: `uv run pytest tests/unit tests/replay` → **4127 passed**, 14 skipped, 3 xfailed. My 8 new tests pass. Two **pre-existing, unrelated** failures (verified present on base with my edit stashed):
  - `tests/unit/test_arbiter_approved_mining.py::TestRunEnrichmentSignature::test_signature_has_held_out_benchmarks_kwonly`
  - `tests/unit/test_unified_rca_prompt_alignment.py::test_leak_safe_example_synthesis_contract_constant_exists`
- **Typecheck**: `uv run ty check` → **292 diagnostics = the Phase-8 baseline** (0 net-new; base and branch both 292 total / 197 harness.py).
- **Lint**: the package configures no `ruff`; `ty` is the typecheck/lint gate (dev group = `ty`, `pytest`, `httpx`).

_This pull request and its description were written by Isaac._