### PR TITLE
Fix GSO enrichment PATCHes rejected for bare-string array fields

### DIFF
--- a/packages/genie-space-optimizer/src/genie_space_optimizer/common/genie_client.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/common/genie_client.py
@@ -804,10 +804,18 @@ def patch_space_config(
     structure before sending.  Retries on transient HTTP errors (429, 5xx).
     Returns the raw API response.
     """
-    from .genie_schema import validate_serialized_space
+    from .genie_schema import normalize_array_fields, validate_serialized_space
 
     clean = strip_non_exportable_fields(config)
     clean = sort_genie_config(clean)
+    # Coerce every array-typed leaf field (description / synonyms / content /
+    # …) to ``list[str]`` IN PLACE before validation AND serialization. The
+    # Genie API rejects a bare string here with "Expected an array for
+    # <field>"; the schema's model-level coercion never reaches this dict
+    # (see normalize_array_fields). This is the single choke point every
+    # PATCH flows through, so it also neutralizes a bare string left on a
+    # shared metadata_snapshot by an upstream enrichment step.
+    clean = normalize_array_fields(clean)
 
     ok, errors = validate_serialized_space(clean, strict=True)
     if not ok:

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/common/genie_schema.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/common/genie_schema.py
@@ -564,6 +564,138 @@ class SerializedSpace(BaseModel):
         return self
 
 
+# ── Array-typed field normalization ──────────────────────────────────
+#
+# The Genie API contract requires a fixed set of leaf fields to be
+# ``list[str]`` (see the "Array/List[str] Fields" section of the
+# validation-rules reference at the top of this module). A bare string in
+# any of them makes the API reject the whole PATCH with
+# ``Invalid serialized_space: Expected an array for <field>``.
+#
+# The Pydantic models above carry ``_coerce_str_to_list`` ``before``
+# validators that wrap bare strings, but ``validate_serialized_space``
+# throws the coerced model away — it returns only ``(ok, errors)``. So the
+# coercion never reaches the dict that ``patch_space_config`` serializes.
+# ``_iter_array_field_slots`` is the single source of truth for *which*
+# leaf fields are array-typed; both ``normalize_array_fields`` (writes the
+# coercion back into the outgoing dict) and the strict-mode shape check
+# (flags a divergence so it can't silently recur) walk it.
+
+
+def _iter_array_field_slots(config: dict):
+    """Yield ``(container_dict, key, dotted_path)`` for every known
+    array-typed leaf field slot in *config*.
+
+    Mirrors the ``list[str]`` fields declared on the models above and the
+    Databricks validation rules. Slots are yielded whether or not the key
+    is present so callers can decide what to do; callers must check the
+    current value themselves.
+    """
+    if not isinstance(config, dict):
+        return
+
+    def _rows(items: Any):
+        return enumerate(items) if isinstance(items, list) else ()
+
+    # config.sample_questions[].question
+    cfg = config.get("config")
+    if isinstance(cfg, dict):
+        for i, sq in _rows(cfg.get("sample_questions")):
+            if isinstance(sq, dict):
+                yield sq, "question", f"config.sample_questions[{i}].question"
+
+    # data_sources.{tables,metric_views}[].description (+ column_configs)
+    ds = config.get("data_sources")
+    if isinstance(ds, dict):
+        for source_key in ("tables", "metric_views"):
+            for i, tbl in _rows(ds.get(source_key)):
+                if not isinstance(tbl, dict):
+                    continue
+                base = f"data_sources.{source_key}[{i}]"
+                yield tbl, "description", f"{base}.description"
+                for j, cc in _rows(tbl.get("column_configs")):
+                    if isinstance(cc, dict):
+                        cbase = f"{base}.column_configs[{j}]"
+                        yield cc, "description", f"{cbase}.description"
+                        yield cc, "synonyms", f"{cbase}.synonyms"
+
+    # instructions.*
+    inst = config.get("instructions")
+    if isinstance(inst, dict):
+        for i, ti in _rows(inst.get("text_instructions")):
+            if isinstance(ti, dict):
+                yield ti, "content", f"instructions.text_instructions[{i}].content"
+        for i, eq in _rows(inst.get("example_question_sqls")):
+            if not isinstance(eq, dict):
+                continue
+            ebase = f"instructions.example_question_sqls[{i}]"
+            yield eq, "question", f"{ebase}.question"
+            yield eq, "sql", f"{ebase}.sql"
+            yield eq, "usage_guidance", f"{ebase}.usage_guidance"
+            for j, p in _rows(eq.get("parameters")):
+                if not isinstance(p, dict):
+                    continue
+                pbase = f"{ebase}.parameters[{j}]"
+                yield p, "description", f"{pbase}.description"
+                dv = p.get("default_value")
+                if isinstance(dv, dict):
+                    yield dv, "values", f"{pbase}.default_value.values"
+        for i, js in _rows(inst.get("join_specs")):
+            if isinstance(js, dict):
+                jbase = f"instructions.join_specs[{i}]"
+                yield js, "sql", f"{jbase}.sql"
+                yield js, "comment", f"{jbase}.comment"
+                yield js, "instruction", f"{jbase}.instruction"
+        snippets = inst.get("sql_snippets")
+        if isinstance(snippets, dict):
+            for snippet_key in ("filters", "expressions", "measures"):
+                for i, snip in _rows(snippets.get(snippet_key)):
+                    if isinstance(snip, dict):
+                        sbase = f"instructions.sql_snippets.{snippet_key}[{i}]"
+                        yield snip, "sql", f"{sbase}.sql"
+                        yield snip, "synonyms", f"{sbase}.synonyms"
+                        yield snip, "comment", f"{sbase}.comment"
+                        yield snip, "instruction", f"{sbase}.instruction"
+
+    # benchmarks.questions[].question (+ answer[].content)
+    bm = config.get("benchmarks")
+    if isinstance(bm, dict):
+        for i, bq in _rows(bm.get("questions")):
+            if not isinstance(bq, dict):
+                continue
+            bbase = f"benchmarks.questions[{i}]"
+            yield bq, "question", f"{bbase}.question"
+            for j, ans in _rows(bq.get("answer")):
+                if isinstance(ans, dict):
+                    yield ans, "content", f"{bbase}.answer[{j}].content"
+
+
+def normalize_array_fields(config: dict) -> dict:
+    """Coerce every bare-string value in an array-typed field to a
+    single-element ``list[str]``, IN PLACE, and return *config*.
+
+    This is the systemic choke-point fix: ``patch_space_config`` calls it
+    on the exact dict it is about to ``json.dumps`` so a bare string in
+    ``description`` / ``synonyms`` / ``content`` (etc.) — including a
+    legacy one already present in a fetched ``serialized_space`` — is
+    normalized before the PATCH is sent.
+
+    It is deliberately NOT implemented as
+    ``SerializedSpace(**config).model_dump()``: a wholesale model round-trip
+    would inject unset field defaults and can drop keys the model does not
+    declare. ``serialized_space`` is a FULL-REPLACEMENT PATCH, so no field
+    may be lost or added. This walker only rewrites known array-typed leaf
+    slots and leaves every other key exactly as-is.
+    """
+    if not isinstance(config, dict):
+        return config
+    for container, key, _path in _iter_array_field_slots(config):
+        value = container.get(key)
+        if isinstance(value, str):
+            container[key] = [value]
+    return config
+
+
 # ── Strict validation helpers ────────────────────────────────────────
 
 
@@ -896,6 +1028,21 @@ def _strict_validate(config: dict) -> list[str]:
             errors.append(
                 f"benchmarks.questions['{q_text}...']: "
                 f"answer format must be 'SQL', got '{answers[0].get('format')}'"
+            )
+
+    # ── Array-typed field shapes ─────────────────────────────────
+    # The API rejects a bare string in any array-typed leaf field with
+    # ``Expected an array for <field>``. The lenient model layer above
+    # silently coerces these (and then discards the coerced model), so
+    # this is the ONLY place the divergence surfaces as a local error.
+    # ``patch_space_config`` normalizes the payload with
+    # ``normalize_array_fields`` BEFORE calling this, so a correctly-built
+    # PATCH never trips it; a caller that skips normalization gets a clear
+    # error instead of an opaque server rejection.
+    for container, key, path in _iter_array_field_slots(config):
+        if isinstance(container.get(key), str):
+            errors.append(
+                f"{path}: must be an array of strings, got a bare string"
             )
 
     # ── Size / length limits ─────────────────────────────────────

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/applier.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/applier.py
@@ -4241,6 +4241,7 @@ def apply_patch_set(
         count_sql_snippets,
         MAX_INSTRUCTION_SLOTS,
         MAX_SQL_SNIPPETS,
+        normalize_array_fields,
         validate_serialized_space,
     )
 
@@ -4308,6 +4309,12 @@ def apply_patch_set(
     # it guarantees we cannot regress by adding a future runtime key
     # that `is_runtime_key` misses.
     validation_target = strip_non_exportable_fields(copy.deepcopy(config))
+    # Validate the payload we ACTUALLY send: patch_space_config coerces
+    # array-typed fields (description / synonyms / content …) to list[str]
+    # before serializing, so normalize here too. Otherwise a legacy bare
+    # string on the fetched snapshot would trip strict validation here and
+    # block a PATCH that patch_space_config would have sent successfully.
+    normalize_array_fields(validation_target)
     config_ok, validation_errors = validate_serialized_space(
         validation_target, strict=True,
     )

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
@@ -6758,10 +6758,17 @@ def _apply_instruction_table_descriptions(
         existing_text = _desc_as_text(existing_value)
         if desc_append.lower() in existing_text.lower():
             continue  # idempotent — already present
-        # Preserve the input shape: list-shaped descriptions stay
-        # ``list[str]`` (the Genie API contract), string-shaped stay str.
-        # Writing back a Python ``repr`` of a list (the prior bug) caused
-        # PATCH to reject with "Expected an array for description".
+        # The Genie API stores table / metric-view ``description`` as
+        # ``list[str]`` and rejects a bare string with "Expected an array
+        # for description". ALWAYS write back ``list[str]``:
+        #   * list-shaped existing → append the span as a new element;
+        #   * string-shaped or EMPTY existing → merge into one string
+        #     (preserving the append/merge semantics) and wrap it in a
+        #     single-element list.
+        # The empty-base branch is the origin of the #260 follow-up bug:
+        # a table/MV with no prior description took the ``else`` path and
+        # assigned the bare ``new_desc`` string, poisoning the shared
+        # ``metadata_snapshot`` that the two later PATCHes re-serialize.
         if isinstance(existing_value, list):
             tbl["description"] = list(existing_value) + [desc_append]
         else:
@@ -6770,7 +6777,7 @@ def _apply_instruction_table_descriptions(
                 + ("\n" if existing_text and not existing_text.endswith("\n") else "")
                 + desc_append
             ).strip()
-            tbl["description"] = new_desc
+            tbl["description"] = [new_desc]
         updated_ids.append(tbl.get("identifier", tbl.get("name", "?")))
         applied += 1
 

--- a/packages/genie-space-optimizer/tests/unit/test_apply_instruction_table_descriptions.py
+++ b/packages/genie-space-optimizer/tests/unit/test_apply_instruction_table_descriptions.py
@@ -1,24 +1,30 @@
 """Unit tests for ``_apply_instruction_table_descriptions``.
 
-Covers Fix 1 from the *Lever Loop Iteration 3 Fixes* plan: the function
-must preserve the original shape of the ``description`` field on a table
-or metric view. Genie's serialized space stores ``description`` as
-``list[str]`` for tables / metric views; older code wrote a Python
-``repr`` of the list back as a string, which caused the API to reject
-the PATCH with ``Expected an array for description but found
-"['PURPOSE:…']"``.
+Genie's serialized space stores a table / metric-view ``description`` as
+``list[str]`` and the API rejects a bare string with ``Expected an array
+for description``. The function must therefore ALWAYS write back
+``list[str]``, regardless of the shape of the existing value:
 
-The tests cover:
+  * Empty description (``""`` / absent) → the append text wrapped in a
+    one-element ``list[str]``. This empty-base branch was the origin of
+    the #260 follow-up bug: the old ``else`` path assigned the bare
+    ``new_desc`` string, poisoning the shared ``metadata_snapshot`` that
+    later PATCHes re-serialize (see ``TestPoisonedSharedSnapshot``).
+  * String description → merged into one string, wrapped in ``list[str]``.
+  * List description → the append text added as a new list element.
+  * Idempotency → re-running with the same span is a no-op (the existing
+    value, whatever its shape, is left untouched).
 
-  * Empty description (``""``) → string concatenation, returns string.
-  * String description → string concatenation, returns string.
-  * List description → list append, returns list (preserves API
-    contract).
-  * Idempotency → re-running with the same span is a no-op.
-  * Result shape matches input shape across both write paths.
+An earlier variant of the bug wrote a Python ``repr`` of the list back as
+a string (``"['PURPOSE:…']"``); the list-append path guards against that
+too.
 """
 
 from __future__ import annotations
+
+import copy
+import json
+from unittest.mock import MagicMock
 
 from genie_space_optimizer.optimization import harness as harness_mod
 
@@ -65,11 +71,15 @@ def _stub_side_effects(monkeypatch) -> None:
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# Empty description
+# Empty description — the empty-base branch (origin of the #260 follow-up)
 # ═══════════════════════════════════════════════════════════════════════
 
 
-def test_empty_description_appends_string(monkeypatch):
+def test_empty_description_writes_single_element_list(monkeypatch):
+    """Empty-base regression: a table with NO existing description must get
+    a ``list[str]`` — not the bare ``new_desc`` string the old ``else``
+    branch assigned (which the Genie API rejects with ``Expected an array
+    for description``)."""
     _stub_side_effects(monkeypatch)
     snapshot = _snapshot_with_table(description="")
     candidates = [_candidate("cat.sch.t1", "PURPOSE: track sales")]
@@ -82,16 +92,38 @@ def test_empty_description_appends_string(monkeypatch):
 
     assert applied == 1
     desc = snapshot["data_sources"]["tables"][0]["description"]
-    assert isinstance(desc, str)
-    assert desc == "PURPOSE: track sales"
+    assert isinstance(desc, list), (
+        f"empty-base description must be list[str], got {type(desc).__name__}: {desc!r}"
+    )
+    assert desc == ["PURPOSE: track sales"]
+
+
+def test_absent_description_writes_single_element_list(monkeypatch):
+    """Same empty-base contract when the ``description`` key is entirely
+    absent (the exact live shape for a freshly-added metric view)."""
+    _stub_side_effects(monkeypatch)
+    snapshot = _snapshot_with_table(description=None)  # key omitted
+    candidates = [_candidate("cat.sch.t1", "PURPOSE: track sales")]
+
+    applied = harness_mod._apply_instruction_table_descriptions(
+        w=None, spark=None, run_id="r1", space_id="s1",
+        candidates=candidates, metadata_snapshot=snapshot,
+        catalog="c", schema="s",
+    )
+
+    assert applied == 1
+    desc = snapshot["data_sources"]["tables"][0]["description"]
+    assert desc == ["PURPOSE: track sales"]
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# String description
+# String description — legacy string base is normalized to list[str]
 # ═══════════════════════════════════════════════════════════════════════
 
 
-def test_string_description_concatenates_and_stays_string(monkeypatch):
+def test_string_description_merges_into_list(monkeypatch):
+    """A legacy bare-string description is merged with the append text and
+    written back as ``list[str]`` (the API contract) — never a bare string."""
     _stub_side_effects(monkeypatch)
     snapshot = _snapshot_with_table(description="Existing prose.")
     candidates = [_candidate("cat.sch.t1", "PURPOSE: track sales")]
@@ -104,9 +136,10 @@ def test_string_description_concatenates_and_stays_string(monkeypatch):
 
     assert applied == 1
     desc = snapshot["data_sources"]["tables"][0]["description"]
-    assert isinstance(desc, str)
-    assert "Existing prose." in desc
-    assert "PURPOSE: track sales" in desc
+    assert isinstance(desc, list)
+    merged = "\n".join(desc)
+    assert "Existing prose." in merged
+    assert "PURPOSE: track sales" in merged
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -253,3 +286,175 @@ def test_short_name_lookup_still_resolves_table(monkeypatch):
     desc = snapshot["data_sources"]["tables"][0]["description"]
     assert isinstance(desc, list)
     assert "NEW LINE" in desc
+
+
+def test_empty_description_metric_view_writes_list(monkeypatch):
+    """The exact failing shape from the #260 follow-up: a metric view with
+    NO prior description (``mv_banking_transactions``). It must receive a
+    ``list[str]`` — the old ``else`` branch wrote the bare append string,
+    which the API rejected with ``Expected an array for description``."""
+    _stub_side_effects(monkeypatch)
+    snapshot = _snapshot_with_table(
+        identifier="cat.sch.mv_banking_transactions",
+        description=None,
+        is_metric_view=True,
+    )
+    append = (
+        "Prefer this materialized view for aggregate questions over dates "
+        "or periods when it covers the requested dimensions."
+    )
+    candidates = [_candidate("cat.sch.mv_banking_transactions", append)]
+
+    applied = harness_mod._apply_instruction_table_descriptions(
+        w=None, spark=None, run_id="r1", space_id="s1",
+        candidates=candidates, metadata_snapshot=snapshot,
+        catalog="c", schema="s",
+    )
+
+    assert applied == 1
+    desc = snapshot["data_sources"]["metric_views"][0]["description"]
+    assert isinstance(desc, list), (
+        f"empty-base MV description must be list[str], got {type(desc).__name__}"
+    )
+    assert desc == [append]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Poisoned-shared-dict regression — the whole #260 follow-up failure mode
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _shared_snapshot() -> dict:
+    """A strict-valid snapshot with a metric view that has NO description
+    and one table with one column — the shape the three-in-sequence
+    enrichment PATCHes all mutate in place."""
+    return {
+        "version": 2,
+        "data_sources": {
+            "tables": [
+                {
+                    "identifier": "cat.sch.transactions",
+                    "name": "transactions",
+                    "column_configs": [{"column_name": "amount"}],
+                },
+            ],
+            "metric_views": [
+                {
+                    "identifier": "cat.sch.mv_banking_transactions",
+                    "name": "mv_banking_transactions",
+                    "column_configs": [],
+                    # NB: NO ``description`` — the empty-base case.
+                },
+            ],
+        },
+        "instructions": {"join_specs": []},
+    }
+
+
+def _capturing_w():
+    """A WorkspaceClient double whose ``api_client.do`` records the parsed
+    ``serialized_space`` of every PATCH body it is handed."""
+    w = MagicMock(name="w")
+    sent: list[dict] = []
+
+    def _do(method, path, body=None):
+        assert method == "PATCH"
+        sent.append(json.loads(body["serialized_space"]))
+        return {}
+
+    w.api_client.do.side_effect = _do
+    return w, sent
+
+
+class TestPoisonedSharedSnapshot:
+    """Root cause: three enrichment steps share ONE ``metadata_snapshot``
+    and none re-fetches. A bare-string description written by step 1
+    poisoned it for steps 2 and 3, whose PATCHes (which only write arrays
+    themselves) were rejected too. Here the REAL ``patch_space_config``
+    choke point is exercised (only ``w.api_client.do`` is mocked), so the
+    test proves both the per-site fix (step 1 writes a list) and the
+    systemic coercion (choke point) keep every one of the three PATCH
+    payloads array-shaped."""
+
+    def test_all_three_patches_carry_array_descriptions(self, monkeypatch):
+        monkeypatch.setattr(harness_mod, "write_stage", lambda *a, **k: None)
+        w, sent = _capturing_w()
+        shared = _shared_snapshot()
+        space_id = "01f1756be5bf1db8895263c014de28c4"
+
+        # Step 1 (ORIGIN): append a description to the description-less MV.
+        mv_append = (
+            "Prefer this materialized view for aggregate questions over "
+            "dates or periods when it covers the requested dimensions; fall "
+            "back to the raw transactions table only when needed dimensions "
+            "are absent."
+        )
+        desc_applied = harness_mod._apply_instruction_table_descriptions(
+            w=w, spark=MagicMock(), run_id="r1", space_id=space_id,
+            candidates=[_candidate("cat.sch.mv_banking_transactions", mv_append)],
+            metadata_snapshot=shared, catalog="c", schema="s",
+        )
+        assert desc_applied == 1
+
+        # Step 2 (VICTIM): add a column synonym on the table. This PATCH
+        # only writes arrays itself, yet re-serializes the whole shared
+        # snapshot — including the MV description from step 1.
+        syn_applied = harness_mod._apply_instruction_column_synonyms(
+            w=w, spark=MagicMock(), run_id="r1", space_id=space_id,
+            candidates=[
+                {
+                    "table_identifier": "cat.sch.transactions",
+                    "column_name": "amount",
+                    "synonyms": ["value", "txn amount"],
+                }
+            ],
+            metadata_snapshot=shared, catalog="c", schema="s",
+        )
+        assert syn_applied == 1
+
+        # Step 3 (VICTIM): the prose-rewrite step re-sends the same shared
+        # snapshot verbatim via the same choke point.
+        from genie_space_optimizer.common.genie_client import patch_space_config
+        patch_space_config(w, space_id, shared)
+
+        # All three PATCHes reached the API layer...
+        assert len(sent) == 3, f"expected 3 PATCHes, got {len(sent)}"
+
+        # ...and NONE would be rejected: every table/MV description in every
+        # payload is an array (never a bare string).
+        for i, payload in enumerate(sent):
+            ds = payload["data_sources"]
+            for source_key in ("tables", "metric_views"):
+                for tbl in ds.get(source_key, []):
+                    desc = tbl.get("description")
+                    assert desc is None or isinstance(desc, list), (
+                        f"PATCH #{i} {source_key} {tbl.get('identifier')!r} "
+                        f"description is a bare string: {desc!r}"
+                    )
+            # The exact field the live API named in the rejection.
+            mv = ds["metric_views"][0]
+            assert mv["description"] == [mv_append]
+
+    def test_strict_validator_accepts_every_sent_payload(self, monkeypatch):
+        """The bare-string class is gone from the sent payloads: strict
+        validation raises no ``must be an array`` error for any of the
+        three PATCHes."""
+        from genie_space_optimizer.common.genie_schema import (
+            validate_serialized_space,
+        )
+
+        monkeypatch.setattr(harness_mod, "write_stage", lambda *a, **k: None)
+        w, sent = _capturing_w()
+        shared = _shared_snapshot()
+        space_id = "01f1756be5bf1db8895263c014de28c4"
+
+        harness_mod._apply_instruction_table_descriptions(
+            w=w, spark=MagicMock(), run_id="r1", space_id=space_id,
+            candidates=[_candidate("cat.sch.mv_banking_transactions", "AGG view")],
+            metadata_snapshot=shared, catalog="c", schema="s",
+        )
+        for payload in sent:
+            ok, errors = validate_serialized_space(copy.deepcopy(payload), strict=True)
+            array_errors = [e for e in errors if "must be an array" in e]
+            assert not array_errors, f"bare-string array field survived: {array_errors}"
+            assert ok, f"sent payload must be strict-valid; got: {errors}"

--- a/packages/genie-space-optimizer/tests/unit/test_patch_space_config_array_coercion.py
+++ b/packages/genie-space-optimizer/tests/unit/test_patch_space_config_array_coercion.py
@@ -1,0 +1,227 @@
+"""Systemic array-field coercion at the ``patch_space_config`` choke point.
+
+Root cause (#260 follow-up): the Genie API requires a fixed set of leaf
+fields (``description`` / ``synonyms`` / ``content`` / …) to be
+``list[str]`` and rejects a bare string with ``Invalid serialized_space:
+Expected an array for <field>``. ``validate_serialized_space`` runs the
+Pydantic ``_coerce_str_to_list`` validators but DISCARDS the coerced model
+(it returns only ``(ok, errors)``), so a bare string survived into the raw
+dict that ``patch_space_config`` serialized with ``json.dumps`` — local
+validation passed while the server rejected the PATCH.
+
+The fix normalizes the payload IN PLACE (``normalize_array_fields``) at the
+single choke point every PATCH flows through, right before validation and
+serialization. It must NOT wholesale-replace the payload with
+``SerializedSpace(...).model_dump()`` — ``serialized_space`` is a
+FULL-REPLACEMENT PATCH, so dropping an unmodeled field (or injecting unset
+model defaults) would corrupt the space.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from genie_space_optimizer.common.genie_client import patch_space_config
+from genie_space_optimizer.common.genie_schema import (
+    normalize_array_fields,
+    validate_serialized_space,
+)
+
+_SPACE_ID = "01f1756be5bf1db8895263c014de28c4"
+_ID = "a" * 32
+
+
+def _send(config: dict) -> dict:
+    """Run ``patch_space_config`` with only the HTTP layer mocked; return
+    the parsed ``serialized_space`` that was actually put on the wire."""
+    w = MagicMock(name="w")
+    captured: dict = {}
+
+    def _do(method, path, body=None):
+        assert method == "PATCH"
+        assert path == f"/api/2.0/genie/spaces/{_SPACE_ID}"
+        captured["sent"] = json.loads(body["serialized_space"])
+        return {}
+
+    w.api_client.do.side_effect = _do
+    patch_space_config(w, _SPACE_ID, config)
+    return captured["sent"]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Systemic coercion — bare strings across the field class become arrays
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestSystemicCoercion:
+    def test_bare_description_synonyms_content_become_arrays_in_wire_payload(self):
+        config = {
+            "version": 2,
+            "config": {
+                "sample_questions": [{"id": _ID, "question": "What is revenue?"}],
+            },
+            "data_sources": {
+                "tables": [
+                    {
+                        "identifier": "cat.sch.transactions",
+                        "description": "Raw transactions.",  # bare string
+                        "column_configs": [
+                            {
+                                "column_name": "amount",
+                                "description": "Txn amount.",  # bare string
+                                "synonyms": "value",           # bare string
+                            }
+                        ],
+                    }
+                ],
+                "metric_views": [
+                    {
+                        "identifier": "cat.sch.mv_agg",
+                        "description": "Aggregate view.",  # bare string
+                    }
+                ],
+            },
+            "instructions": {
+                "text_instructions": [
+                    {"id": _ID, "content": "Always filter by region."}  # bare string
+                ],
+            },
+        }
+
+        sent = _send(config)
+
+        tbl = sent["data_sources"]["tables"][0]
+        assert tbl["description"] == ["Raw transactions."]
+        assert tbl["column_configs"][0]["description"] == ["Txn amount."]
+        assert tbl["column_configs"][0]["synonyms"] == ["value"]
+        assert sent["data_sources"]["metric_views"][0]["description"] == [
+            "Aggregate view."
+        ]
+        assert sent["instructions"]["text_instructions"][0]["content"] == [
+            "Always filter by region."
+        ]
+        assert sent["config"]["sample_questions"][0]["question"] == [
+            "What is revenue?"
+        ]
+
+    def test_existing_arrays_are_left_unchanged(self):
+        """Coercion is idempotent: correctly-shaped arrays pass through
+        byte-for-byte (no double-wrapping)."""
+        config = {
+            "version": 2,
+            "data_sources": {
+                "tables": [
+                    {
+                        "identifier": "cat.sch.t",
+                        "description": ["line one", "line two"],
+                    }
+                ],
+                "metric_views": [],
+            },
+        }
+        sent = _send(config)
+        assert sent["data_sources"]["tables"][0]["description"] == [
+            "line one",
+            "line two",
+        ]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# No-field-loss guard — full-replacement PATCH keeps unmodeled fields
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestNoFieldLoss:
+    def test_unmodeled_nested_field_survives_serialization(self):
+        """A field the Pydantic model does not declare must reach the wire
+        unchanged — the coercion is an in-place walk, not a model round-trip
+        that would silently drop it."""
+        config = {
+            "version": 2,
+            "data_sources": {
+                "tables": [
+                    {
+                        "identifier": "cat.sch.t",
+                        "description": "bare",  # forces the coercion path
+                        # Not in TableDataSource — must be preserved verbatim.
+                        "future_api_field": {"nested": [1, 2, 3], "flag": True},
+                    }
+                ],
+                "metric_views": [],
+            },
+        }
+        sent = _send(config)
+        tbl = sent["data_sources"]["tables"][0]
+        assert tbl["description"] == ["bare"]
+        assert tbl["future_api_field"] == {"nested": [1, 2, 3], "flag": True}
+
+    def test_no_unset_model_defaults_are_injected(self):
+        """A ``model_dump`` round-trip would inject ``description: null`` /
+        ``column_configs: null`` on a table that declared neither, and
+        top-level ``config``/``instructions``/``benchmarks`` nulls. The
+        in-place walker must inject nothing — the sent table carries ONLY
+        the keys it started with."""
+        config = {
+            "version": 2,
+            "data_sources": {
+                "tables": [{"identifier": "cat.sch.t", "only_field": "keep-me"}],
+                "metric_views": [],
+            },
+        }
+        sent = _send(config)
+        tbl = sent["data_sources"]["tables"][0]
+        assert tbl == {"identifier": "cat.sch.t", "only_field": "keep-me"}
+        assert "description" not in tbl
+        assert "column_configs" not in tbl
+        # No null-valued top-level keys the model would have added.
+        assert set(sent.keys()) == {"version", "data_sources"}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Strict-mode tripwire — a bare string in an array field is flagged
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestStrictShapeGuard:
+    def test_strict_flags_bare_string_in_array_field(self):
+        """The divergence that shipped the bug (local validate passed, server
+        rejected) can no longer recur silently: strict validation of a raw,
+        un-normalized config names the offending field."""
+        config = {
+            "version": 2,
+            "data_sources": {
+                "tables": [{"identifier": "cat.sch.t", "description": "bare"}],
+                "metric_views": [],
+            },
+        }
+        ok, errors = validate_serialized_space(config, strict=True)
+        assert not ok
+        joined = "\n".join(errors)
+        assert "data_sources.tables[0].description" in joined
+        assert "must be an array of strings" in joined
+
+    def test_strict_passes_after_normalization(self):
+        config = {
+            "version": 2,
+            "data_sources": {
+                "tables": [{"identifier": "cat.sch.t", "description": "bare"}],
+                "metric_views": [],
+            },
+        }
+        normalize_array_fields(config)
+        ok, errors = validate_serialized_space(config, strict=True)
+        assert ok, errors
+
+    def test_lenient_mode_stays_permissive_about_bare_strings(self):
+        """Reads of API configs use lenient mode and must not error on a
+        legacy bare string (the model layer coerces it there)."""
+        config = {
+            "version": 2,
+            "data_sources": {
+                "tables": [{"identifier": "cat.sch.t", "description": "bare"}],
+                "metric_views": [],
+            },
+        }
+        ok, _ = validate_serialized_space(config, strict=False)
+        assert ok


### PR DESCRIPTION
## Problem

Notebook `03_optimize` cell-8 enrichment PATCHes failed against the live Genie API with:

> `InvalidParameterValue: Invalid serialized_space: Expected an array for description but found "Prefer this materialized view ..."`

The Genie `serialized_space` contract requires table / metric-view / column `description` (and `synonyms`, `text_instructions[].content`, `sample_questions[].question`, etc.) to be `list[str]`, **never a bare string** ([validation rules](https://docs.databricks.com/aws/en/genie/conversation-api#validation-rules-for-serialized_space)).

## Root cause

1. **Per-site origin** — `optimization/harness.py::_apply_instruction_table_descriptions`. When a table/MV had **no existing description**, the `else` branch assigned the computed `new_desc` as a **bare string**.
2. **Blast radius** — `_apply_instruction_table_descriptions`, `_apply_instruction_column_synonyms`, and the prose-mining rewrite all mutate the **same** `metadata_snapshot` in place and none re-fetches. The bare string from step 1 poisoned the two later PATCHes (which only write arrays themselves), so **all three** were rejected.
3. **Why local validation missed it** — `validate_serialized_space` runs the Pydantic `_coerce_str_to_list` validators but **discards** the coerced model (returns only `(ok, errors)`). `patch_space_config` then `json.dumps`-ed the raw dict with the bare string intact — local validation passed while the server rejected.

## Fix

**Part 1 — per-site (`harness.py`)**: the empty/string `else` branch now wraps the merged `new_desc` in a single-element list (`[new_desc]`), matching the list branch. Append/merge semantics preserved.

**Part 2 — systemic choke-point (`patch_space_config`)**: new `normalize_array_fields()` coerces every known array-typed leaf field to `list[str]` **in place** on the exact dict about to be serialized, right before validation. Implemented as a targeted in-place walk over a single source of truth (`_iter_array_field_slots`), **not** a `SerializedSpace(...).model_dump()` round-trip — so no unmodeled field is dropped and no unset model default is injected (serialized_space is a full-replacement PATCH). `_strict_validate` now also **flags** a bare string in an array field so the divergence can't silently recur, and `applier.apply_patch_set` normalizes its pre-send validation target to match what `patch_space_config` actually sends.

All three enrichment PATCHes route through `patch_space_config`, so coercing there neutralizes any bare string — including a legacy one already present on a fetched snapshot.

## Tests (hostile — assert real shape)

- **Empty-base description** (table + metric view): after `_apply_instruction_table_descriptions`, `description` is `list[str]` containing the append text.
- **Poisoned-shared-dict regression**: the three-in-sequence flow on a shared `metadata_snapshot`, exercising the **real** `patch_space_config` choke point (only HTTP mocked) — every table/MV description in every one of the three sent payloads is an array; strict validation raises no "must be an array" error.
- **Systemic coercion**: a serialized_space with bare `description` / `synonyms` / `content` → the serialized wire body has them as arrays.
- **No-field-loss guard**: an unmodeled nested field survives serialization unchanged, and no unset model defaults (`description: null`, `column_configs: null`, top-level nulls) are injected — proving Part 2 is not a `model_dump`.

## Gates

- `uv run pytest`: **4167 passed, 2 failed, 17 skipped, 3 xfailed**. The 2 failures (`test_arbiter_approved_mining.py::...test_signature_has_held_out_benchmarks_kwonly` and `test_unified_rca_prompt_alignment.py::test_leak_safe_example_synthesis_contract_constant_exists`) are **pre-existing on `gso/optimizer-v2`** and unrelated to this diff (verified against baseline: 4156 passed + same 2 failures). +11 = my new tests.
- `uv run ty check`: **292 diagnostics, unchanged from baseline**; touched files added zero new diagnostics.

This pull request and its description were written by Isaac.