### PR TITLE
[gso] Reject empty Genie config snapshots

### DIFF
--- a/packages/genie-space-optimizer/src/genie_space_optimizer/backend/routes/spaces.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/backend/routes/spaces.py
@@ -702,7 +702,11 @@ def do_start_optimization(
     optimization job.  Uses OBO for Genie domain inference, SP for job
     submission.  User identity comes from forwarded headers.
     """
-    from genie_space_optimizer.common.genie_client import fetch_space_config
+    from genie_space_optimizer.common.genie_client import (
+        fetch_space_config,
+        space_config_data_source_counts,
+        space_config_has_data_sources,
+    )
     from genie_space_optimizer.optimization.state import (
         create_run,
         ensure_optimization_tables,
@@ -833,10 +837,29 @@ def do_start_optimization(
 
     space_snapshot: dict = {}
     _snap_errors: list[str] = []
-    for label, cli in [("OBO/user", ws), ("SP", sp_ws)]:
+    for label, cli in [("SP", sp_ws), ("OBO/user", ws)]:
         try:
-            space_snapshot = fetch_space_config(cli, space_id)
-            logger.info("Captured space snapshot via %s client for %s", label, space_id)
+            candidate_snapshot = fetch_space_config(cli, space_id)
+            counts = space_config_data_source_counts(candidate_snapshot)
+            if not space_config_has_data_sources(candidate_snapshot):
+                msg = (
+                    f"{label}: exported serialized_space has no data sources "
+                    f"(tables={counts['tables']}, metric_views={counts['metric_views']}, "
+                    f"functions={counts['functions']})"
+                )
+                _snap_errors.append(msg)
+                logger.error("Rejecting empty Genie space snapshot for %s: %s", space_id, msg)
+                continue
+            space_snapshot = candidate_snapshot
+            logger.info(
+                "Captured space snapshot via %s client for %s "
+                "(tables=%d, metric_views=%d, functions=%d)",
+                label,
+                space_id,
+                counts["tables"],
+                counts["metric_views"],
+                counts["functions"],
+            )
             break
         except PermissionDenied as exc:
             _snap_errors.append(f"{label}: {exc}")

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/common/genie_client.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/common/genie_client.py
@@ -39,6 +39,60 @@ logger = logging.getLogger(__name__)
 # ── Space Discovery & Config ───────────────────────────────────────────
 
 
+class MissingSerializedSpaceError(RuntimeError):
+    """Raised when Genie returns a space without an exportable config."""
+
+
+_MISSING = object()
+
+
+def _space_from_config(config: dict | None) -> dict:
+    """Return the parsed serialized space from a fetch result or snapshot."""
+    if not isinstance(config, dict):
+        return {}
+
+    parsed = config.get("_parsed_space")
+    if isinstance(parsed, dict):
+        return parsed
+
+    ss = config.get("serialized_space")
+    if isinstance(ss, str):
+        try:
+            loaded = json.loads(ss)
+        except json.JSONDecodeError:
+            return {}
+        return loaded if isinstance(loaded, dict) else {}
+    if isinstance(ss, dict):
+        return ss
+
+    if any(key in config for key in ("data_sources", "instructions", "config")):
+        return config
+    return {}
+
+
+def space_config_data_source_counts(config: dict | None) -> dict[str, int]:
+    """Return counts for exported Genie data-source collections."""
+    parsed = _space_from_config(config)
+    ds = parsed.get("data_sources") if isinstance(parsed, dict) else None
+    if not isinstance(ds, dict):
+        return {"tables": 0, "metric_views": 0, "functions": 0}
+    counts: dict[str, int] = {}
+    for key in ("tables", "metric_views", "functions"):
+        values = ds.get(key)
+        counts[key] = len(values) if isinstance(values, list) else 0
+    return counts
+
+
+def space_config_has_data_sources(config: dict | None) -> bool:
+    """Return True when a config has at least one table, MV, or TVF."""
+    return any(space_config_data_source_counts(config).values())
+
+
+def space_config_has_tables(config: dict | None) -> bool:
+    """Return True when a config snapshot has at least one table entry."""
+    return space_config_data_source_counts(config).get("tables", 0) > 0
+
+
 def list_spaces(w: WorkspaceClient) -> list[dict[str, str]]:
     """List available Genie Spaces via SDK, paginating through all pages.
 
@@ -316,9 +370,31 @@ def fetch_space_config(w: WorkspaceClient, space_id: str) -> dict:
         )
     config = cast(dict[str, Any], raw_config)
 
-    ss = config.get("serialized_space", {})
+    ss = config.get("serialized_space", _MISSING)
+    if ss is _MISSING or ss is None or ss == "":
+        logger.error(
+            "Genie space %s response omitted serialized_space despite "
+            "include_serialized_space=true; response keys=%s",
+            space_id,
+            sorted(config.keys()),
+        )
+        raise MissingSerializedSpaceError(
+            f"Genie Space {space_id} response omitted serialized_space; "
+            "the caller must retry with a client that can export the space config."
+        )
     if isinstance(ss, str):
         ss = json.loads(ss)
+    if not isinstance(ss, dict) or not ss:
+        logger.error(
+            "Genie space %s response had empty/invalid serialized_space "
+            "despite include_serialized_space=true; type=%s",
+            space_id,
+            type(ss).__name__,
+        )
+        raise MissingSerializedSpaceError(
+            f"Genie Space {space_id} response had empty serialized_space; "
+            "the caller must reject this snapshot."
+        )
     config["_parsed_space"] = ss
 
     ds = ss.get("data_sources", {})

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/integration/trigger.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/integration/trigger.py
@@ -35,6 +35,61 @@ _ACTIVE_RUN_STATUSES = frozenset({"QUEUED", "IN_PROGRESS"})
 _SUPPORTED_APPLY_MODES = {"genie_config", "uc_artifact", "both"}
 
 
+def _capture_config_snapshot(
+    *,
+    space_id: str,
+    ws: WorkspaceClient,
+    sp_ws: WorkspaceClient,
+) -> dict:
+    """Capture a non-empty Genie serialized_space snapshot, SP first."""
+    from genie_space_optimizer.common.genie_client import (
+        fetch_space_config,
+        space_config_data_source_counts,
+        space_config_has_data_sources,
+    )
+
+    space_snapshot: dict = {}
+    snap_errors: list[str] = []
+    for label, cli in [("SP", sp_ws), ("OBO/user", ws)]:
+        try:
+            candidate = fetch_space_config(cli, space_id)
+        except Exception as exc:
+            snap_errors.append(f"{label}: {exc}")
+            logger.info("Snapshot via %s failed for %s: %s", label, space_id, exc)
+            continue
+
+        counts = space_config_data_source_counts(candidate)
+        if not space_config_has_data_sources(candidate):
+            msg = (
+                f"{label}: exported serialized_space has no data sources "
+                f"(tables={counts['tables']}, metric_views={counts['metric_views']}, "
+                f"functions={counts['functions']})"
+            )
+            snap_errors.append(msg)
+            logger.error("Rejecting empty Genie space snapshot for %s: %s", space_id, msg)
+            continue
+
+        space_snapshot = candidate
+        logger.info(
+            "Captured space snapshot via %s client for %s "
+            "(tables=%d, metric_views=%d, functions=%d)",
+            label,
+            space_id,
+            counts["tables"],
+            counts["metric_views"],
+            counts["functions"],
+        )
+        break
+
+    if not space_snapshot:
+        combined = "; ".join(snap_errors)
+        raise RuntimeError(
+            f"Cannot export non-empty Genie Space config for {space_id}. "
+            f"Errors: {combined}"
+        )
+    return space_snapshot
+
+
 def trigger_optimization(
     space_id: str,
     ws: WorkspaceClient,
@@ -74,7 +129,6 @@ def trigger_optimization(
     """
     from genie_space_optimizer.common.config import DEFAULT_LEVER_ORDER
     from genie_space_optimizer.common.genie_client import (
-        fetch_space_config,
         sp_can_manage_space,
         user_can_edit_space,
     )
@@ -140,23 +194,7 @@ def trigger_optimization(
 
     run_id = str(uuid.uuid4())
 
-    space_snapshot: dict = {}
-    snap_errors: list[str] = []
-    for label, cli in [("OBO/user", ws), ("SP", sp_ws)]:
-        try:
-            space_snapshot = fetch_space_config(cli, space_id)
-            logger.info("Captured space snapshot via %s client for %s", label, space_id)
-            break
-        except Exception as exc:
-            snap_errors.append(f"{label}: {exc}")
-            logger.info("Snapshot via %s failed for %s: %s", label, space_id, exc)
-
-    if not space_snapshot:
-        combined = "; ".join(snap_errors)
-        raise RuntimeError(
-            f"Cannot export Genie Space config for {space_id}. "
-            f"Errors: {combined}"
-        )
+    space_snapshot = _capture_config_snapshot(space_id=space_id, ws=ws, sp_ws=sp_ws)
 
     title = str(space_snapshot.get("title", "") or "")
     domain = (

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/harness.py
@@ -5134,6 +5134,7 @@ def _run_space_metadata_enrichment(
     from genie_space_optimizer.common.genie_client import (
         fetch_space_config,
         patch_space_config,
+        space_config_has_data_sources,
         update_space_description,
     )
     from genie_space_optimizer.optimization.optimizer import (
@@ -5153,6 +5154,7 @@ def _run_space_metadata_enrichment(
         "questions_generated": False,
         "questions_count": 0,
         "questions_skipped_empty_base": False,
+        "metadata_skipped_stale_empty_snapshot": False,
     }
 
     if not needs_description and not needs_questions:
@@ -5163,6 +5165,41 @@ def _run_space_metadata_enrichment(
         _sm_lines.append(_bar("-"))
         print("\n".join(_sm_lines))
         return result
+
+    working_has_data_sources = (
+        space_config_has_data_sources(config)
+        or space_config_has_data_sources({"_parsed_space": metadata_snapshot})
+    )
+    live_config_for_questions: dict | None = None
+    if not working_has_data_sources:
+        try:
+            live_config_for_questions = fetch_space_config(w, space_id)
+        except Exception:
+            logger.warning(
+                "Space metadata enrichment: could not verify live config for "
+                "%s while working snapshot had no data sources; skipping to "
+                "avoid writing empty-space metadata",
+                space_id,
+                exc_info=True,
+            )
+            result["metadata_skipped_stale_empty_snapshot"] = True
+            return result
+
+        if space_config_has_data_sources(live_config_for_questions):
+            result["metadata_skipped_stale_empty_snapshot"] = True
+            logger.warning(
+                "Space metadata enrichment: working snapshot for %s has no "
+                "data sources but live space is populated; skipping "
+                "description and sample-question generation to avoid "
+                "publishing stale empty-space metadata",
+                space_id,
+            )
+            _sm_lines = [_section("SPACE METADATA ENRICHMENT", "-")]
+            _sm_lines.append(_kv("Description", "skipped (stale empty snapshot)"))
+            _sm_lines.append(_kv("Sample questions", "skipped (stale empty snapshot)"))
+            _sm_lines.append(_bar("-"))
+            print("\n".join(_sm_lines))
+            return result
 
     write_stage(
         spark, run_id, "SPACE_METADATA_ENRICHMENT", "STARTED",
@@ -5214,8 +5251,12 @@ def _run_space_metadata_enrichment(
                 # mutating it fabricated a partial ``{"config": {...}}`` object
                 # missing top-level ``version``/``data_sources`` that the strict
                 # validator (correctly) rejected before any HTTP call.
-                current = fetch_space_config(w, space_id).get("_parsed_space") or {}
-                if not current.get("data_sources") or current.get("version") is None:
+                current_config = live_config_for_questions or fetch_space_config(w, space_id)
+                current = current_config.get("_parsed_space") or {}
+                if (
+                    current.get("version") is None
+                    or not space_config_has_data_sources({"_parsed_space": current})
+                ):
                     result["questions_skipped_empty_base"] = True
                     logger.info(
                         "Space metadata enrichment: base config has no "
@@ -7801,7 +7842,11 @@ def _prepare_lever_loop(
 
     Returns the fully prepared config dict with ``_uc_columns`` populated.
     """
-    from genie_space_optimizer.common.genie_client import fetch_space_config
+    from genie_space_optimizer.common.genie_client import (
+        fetch_space_config,
+        space_config_data_source_counts,
+        space_config_has_tables,
+    )
     from genie_space_optimizer.common.uc_metadata import (
         extract_genie_space_table_refs,
         get_columns_for_tables_rest,
@@ -7812,8 +7857,22 @@ def _prepare_lever_loop(
     snapshot = run_data.get("config_snapshot", {})
     config: dict
     if isinstance(snapshot, dict) and snapshot:
-        config = snapshot
-        logger.info("Lever loop: using config snapshot from run row for %s", run_id)
+        if space_config_has_tables(snapshot):
+            config = snapshot
+            logger.info("Lever loop: using config snapshot from run row for %s", run_id)
+        else:
+            counts = space_config_data_source_counts(snapshot)
+            logger.warning(
+                "Lever loop: run-row config snapshot for %s has no tables "
+                "(tables=%d, metric_views=%d, functions=%d) — fetching live "
+                "config via job client before enrichment.",
+                run_id,
+                counts["tables"],
+                counts["metric_views"],
+                counts["functions"],
+            )
+            config = fetch_space_config(w, space_id)
+            logger.info("Lever loop: fetched live config for space %s", space_id)
     else:
         logger.warning(
             "No config snapshot found in run row for %s — fetching from API.",

--- a/packages/genie-space-optimizer/tests/unit/test_genie_client_fetch_space_config.py
+++ b/packages/genie-space-optimizer/tests/unit/test_genie_client_fetch_space_config.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from genie_space_optimizer.common.genie_client import (
+    MissingSerializedSpaceError,
+    fetch_space_config,
+)
+
+
+def _client_with_response(response: dict) -> MagicMock:
+    client = MagicMock()
+    client.api_client.do.return_value = response
+    return client
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"title": "No export"},
+        {"title": "None export", "serialized_space": None},
+        {"title": "Empty export", "serialized_space": {}},
+        {"title": "String empty export", "serialized_space": "{}"},
+    ],
+)
+def test_fetch_space_config_rejects_missing_or_empty_serialized_space(
+    response: dict,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = _client_with_response(response)
+
+    with caplog.at_level(logging.ERROR), pytest.raises(MissingSerializedSpaceError):
+        fetch_space_config(client, "space-1")
+
+    assert client.api_client.do.call_args.kwargs["query"] == {
+        "include_serialized_space": "true"
+    }
+    assert "serialized_space" in caplog.text
+
+
+def test_fetch_space_config_allows_genuine_empty_space_with_export() -> None:
+    client = _client_with_response(
+        {
+            "title": "Empty but exported",
+            "serialized_space": {
+                "version": 2,
+                "data_sources": {"tables": [], "metric_views": [], "functions": []},
+                "instructions": {"text_instructions": []},
+            },
+        }
+    )
+
+    config = fetch_space_config(client, "space-1")
+
+    assert config["_parsed_space"]["version"] == 2
+    assert config["_tables"] == []
+    assert config["_metric_views"] == []
+    assert config["_functions"] == []

--- a/packages/genie-space-optimizer/tests/unit/test_prepare_lever_loop_snapshot_refresh.py
+++ b/packages/genie-space-optimizer/tests/unit/test_prepare_lever_loop_snapshot_refresh.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from genie_space_optimizer.optimization import harness
+
+
+def _config(table_name: str | None, *, metric_cache: bool = True) -> dict:
+    tables = (
+        [{"identifier": f"cat.sch.{table_name}", "column_configs": []}]
+        if table_name
+        else []
+    )
+    cfg = {
+        "_parsed_space": {
+            "version": 2,
+            "data_sources": {
+                "tables": tables,
+                "metric_views": [],
+                "functions": [],
+            },
+            "instructions": {"text_instructions": []},
+        },
+    }
+    if metric_cache:
+        cfg["_metric_view_yaml"] = {"cached": {}}
+    return cfg
+
+
+def _stub_prepare_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(harness, "ENABLE_PROMPT_MATCHING_AUTO_APPLY", False)
+    monkeypatch.setattr(
+        "genie_space_optimizer.common.uc_metadata.extract_genie_space_table_refs",
+        lambda config: [
+            ("cat", "sch", t["identifier"].split(".")[-1])
+            for t in (
+                config.get("_parsed_space", {})
+                .get("data_sources", {})
+                .get("tables", [])
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "genie_space_optimizer.common.uc_metadata.get_columns_for_tables_rest",
+        lambda _w, refs: [{"table": ".".join(ref)} for ref in refs],
+    )
+    monkeypatch.setattr(
+        "genie_space_optimizer.common.asset_semantics.build_and_stamp_from_run",
+        lambda *a, **k: {},
+    )
+    monkeypatch.setattr(
+        "genie_space_optimizer.common.asset_semantics.format_semantics_block",
+        lambda _semantics: [],
+    )
+    monkeypatch.setattr(
+        "genie_space_optimizer.iq_scan.collect_rls_audit",
+        lambda *a, **k: {},
+    )
+
+
+def test_prepare_lever_loop_refetches_empty_cached_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    empty_snapshot = _config(None)
+    live_config = _config("orders")
+    fetch = MagicMock(return_value=live_config)
+
+    _stub_prepare_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        harness,
+        "load_run",
+        lambda *a, **k: {"config_snapshot": empty_snapshot},
+    )
+    monkeypatch.setattr(
+        "genie_space_optimizer.common.genie_client.fetch_space_config",
+        fetch,
+    )
+
+    config = harness._prepare_lever_loop(
+        w=MagicMock(),
+        spark=MagicMock(),
+        run_id="run-empty-snapshot",
+        space_id="space-1",
+        catalog="cat",
+        schema="sch",
+    )
+
+    fetch.assert_called_once()
+    assert config is live_config
+    assert (
+        config["_parsed_space"]["data_sources"]["tables"][0]["identifier"]
+        == "cat.sch.orders"
+    )
+    assert config["_uc_columns"] == [{"table": "cat.sch.orders"}]
+
+
+def test_prepare_lever_loop_uses_non_empty_cached_snapshot_without_refetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cached_snapshot = _config("cached_orders")
+    fetch = MagicMock(side_effect=AssertionError("should not refetch"))
+
+    _stub_prepare_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        harness,
+        "load_run",
+        lambda *a, **k: {"config_snapshot": cached_snapshot},
+    )
+    monkeypatch.setattr(
+        "genie_space_optimizer.common.genie_client.fetch_space_config",
+        fetch,
+    )
+
+    config = harness._prepare_lever_loop(
+        w=MagicMock(),
+        spark=MagicMock(),
+        run_id="run-cached-snapshot",
+        space_id="space-1",
+        catalog="cat",
+        schema="sch",
+    )
+
+    fetch.assert_not_called()
+    assert config is cached_snapshot
+    assert (
+        config["_parsed_space"]["data_sources"]["tables"][0]["identifier"]
+        == "cat.sch.cached_orders"
+    )
+    assert config["_uc_columns"] == [{"table": "cat.sch.cached_orders"}]

--- a/packages/genie-space-optimizer/tests/unit/test_space_metadata_enrichment_full_replacement.py
+++ b/packages/genie-space-optimizer/tests/unit/test_space_metadata_enrichment_full_replacement.py
@@ -109,7 +109,7 @@ class TestPopulatedBase:
         updated in place."""
         passed_in = {
             "description": "x" * 20,   # present → no description work
-            "_parsed_space": {},        # DEGENERATE — must NOT drive the PATCH
+            "_parsed_space": _authoritative_full_config()["_parsed_space"],
         }
         fetch_return = _authoritative_full_config()
 
@@ -147,7 +147,10 @@ class TestPopulatedBase:
             validate_serialized_space,
         )
 
-        passed_in = {"description": "x" * 20, "_parsed_space": {}}
+        passed_in = {
+            "description": "x" * 20,
+            "_parsed_space": _authoritative_full_config()["_parsed_space"],
+        }
         _, patch_mock, _, _ = _run(
             passed_in, fetch_return=_authoritative_full_config()
         )
@@ -164,12 +167,20 @@ class TestPopulatedBase:
 class TestEmptyBase:
     def test_skips_patch_logs_clean_info_never_raises(self):
         passed_in = {"description": "x" * 20, "_parsed_space": {}}
-        # Genuinely empty space: fetch returns no serialized_space content.
+        # Genuinely empty space: the API exports a serialized_space, but it has
+        # no data sources to ground sample questions.
         result, patch_mock, fetch_mock, logger_mock = _run(
-            passed_in, fetch_return={"_parsed_space": {}}
+            passed_in,
+            fetch_return={
+                "_parsed_space": {
+                    "version": 2,
+                    "data_sources": {"tables": [], "metric_views": [], "functions": []},
+                },
+            },
         )
 
-        # Re-fetched but did NOT PATCH — no partial object constructed.
+        # Re-fetched for the stale-snapshot guard and reused for the empty-base
+        # questions guard, but did NOT PATCH.
         assert fetch_mock.call_count == 1
         patch_mock.assert_not_called()
 
@@ -192,7 +203,7 @@ class TestEmptyBase:
         """A base with a ``version`` but no ``data_sources`` is still an
         empty/degenerate space and must be skipped, not PATCHed with a
         payload the API would reject."""
-        passed_in = {"description": "x" * 20, "_parsed_space": {}}
+        passed_in = {"description": "x" * 20, "_parsed_space": {"version": 2}}
         result, patch_mock, _, _ = _run(
             passed_in, fetch_return={"_parsed_space": {"version": 2}}
         )
@@ -202,7 +213,10 @@ class TestEmptyBase:
     def test_missing_version_is_treated_as_empty(self):
         """A base with ``data_sources`` but no ``version`` is skipped —
         PATCHing without echoing ``version`` would trip the validator."""
-        passed_in = {"description": "x" * 20, "_parsed_space": {}}
+        passed_in = {
+            "description": "x" * 20,
+            "_parsed_space": {"data_sources": {"tables": []}},
+        }
         result, patch_mock, _, _ = _run(
             passed_in,
             fetch_return={
@@ -211,6 +225,53 @@ class TestEmptyBase:
         )
         patch_mock.assert_not_called()
         assert result["questions_skipped_empty_base"] is True
+
+
+class TestStaleEmptyWorkingSnapshot:
+    def test_populated_live_space_skips_empty_snapshot_metadata_writes(self):
+        """If the working snapshot is empty but live is populated, do not
+        generate from the empty context or PATCH either metadata field."""
+        passed_in = {"description": "", "_parsed_space": {}}
+        fetch_mock = MagicMock(
+            name="fetch_space_config",
+            return_value=_authoritative_full_config(),
+        )
+        gen_desc = MagicMock(name="_generate_space_description", return_value="empty space")
+        gen_questions = MagicMock(
+            name="_generate_sample_questions",
+            return_value=[{"id": _SQ_ID, "question": ["What data is available?"]}],
+        )
+        update_desc = MagicMock(name="update_space_description")
+        patch_config = MagicMock(name="patch_space_config")
+
+        with (
+            patch.object(_genie_client_mod, "fetch_space_config", fetch_mock),
+            patch.object(_genie_client_mod, "update_space_description", update_desc),
+            patch.object(_genie_client_mod, "patch_space_config", patch_config),
+            patch.object(_optimizer_mod, "_generate_space_description", gen_desc),
+            patch.object(_optimizer_mod, "_generate_sample_questions", gen_questions),
+            patch.object(harness, "write_stage", MagicMock()),
+            patch.object(harness, "write_patch", MagicMock()),
+        ):
+            result = harness._run_space_metadata_enrichment(
+                MagicMock(name="w"),
+                MagicMock(name="spark"),
+                "run-1",
+                _SPACE_ID,
+                passed_in,
+                {"data_sources": {"tables": []}},
+                "cat",
+                "sch",
+            )
+
+        assert result["metadata_skipped_stale_empty_snapshot"] is True
+        assert result["description_generated"] is False
+        assert result["questions_generated"] is False
+        fetch_mock.assert_called_once()
+        gen_desc.assert_not_called()
+        gen_questions.assert_not_called()
+        update_desc.assert_not_called()
+        patch_config.assert_not_called()
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -222,13 +283,15 @@ class TestSourceWiring:
     def test_builds_patch_from_authoritative_fetch_not_passed_in_parsed(self):
         src = inspect.getsource(harness._run_space_metadata_enrichment)
         # Re-fetches the authoritative serialized_space.
-        assert 'fetch_space_config(w, space_id).get("_parsed_space")' in src
+        assert "fetch_space_config(w, space_id)" in src
         # Deep-copies before mutating (no aliasing of the fetched object).
         assert "copy.deepcopy(current)" in src
-        # Empty-base guard present on BOTH required top-level fields.
-        assert 'current.get("data_sources")' in src
+        # Empty-base guard present on BOTH required top-level fields, and it
+        # treats data_sources with no assets as empty.
+        assert "space_config_has_data_sources" in src
         assert 'current.get("version") is None' in src
         assert "questions_skipped_empty_base" in src
+        assert "metadata_skipped_stale_empty_snapshot" in src
         # The old antipattern — mutating and PATCHing the passed-in parsed
         # object — must be gone.
         assert "patch_space_config(w, space_id, parsed)" not in src

--- a/packages/genie-space-optimizer/tests/unit/test_trigger_snapshot_capture.py
+++ b/packages/genie-space-optimizer/tests/unit/test_trigger_snapshot_capture.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+import genie_space_optimizer.common.genie_client as _genie_client
+from genie_space_optimizer.integration.config import IntegrationConfig
+from genie_space_optimizer.integration import trigger
+
+
+def _snapshot(table_count: int, *, title: str = "Revenue Space") -> dict:
+    return {
+        "title": title,
+        "_parsed_space": {
+            "version": 2,
+            "data_sources": {
+                "tables": [
+                    {"identifier": f"cat.sch.table_{idx}"}
+                    for idx in range(table_count)
+                ],
+                "metric_views": [],
+                "functions": [],
+            },
+            "instructions": {"text_instructions": []},
+        },
+    }
+
+
+def _client(label: str) -> MagicMock:
+    client = MagicMock(name=label)
+    client.config.host = "https://workspace.example"
+    client.get_workspace_id.return_value = 123
+    return client
+
+
+def _patch_trigger_happy_path(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    create_run = MagicMock(name="wh_create_run")
+    monkeypatch.setattr(trigger, "wh_ensure_optimization_tables", lambda *a, **k: None)
+    monkeypatch.setattr(trigger, "sql_warehouse_query", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(trigger, "wh_reconcile_active_runs", lambda *a, **k: False)
+    monkeypatch.setattr(trigger, "wh_create_run", create_run)
+    monkeypatch.setattr(trigger, "sql_warehouse_execute", lambda *a, **k: None)
+    monkeypatch.setattr(_genie_client, "user_can_edit_space", lambda *a, **k: True)
+    monkeypatch.setattr(_genie_client, "sp_can_manage_space", lambda *a, **k: True)
+    monkeypatch.setattr(
+        "genie_space_optimizer.common.sp_permissions.get_sp_principal_aliases",
+        lambda _sp_ws: {"sp"},
+    )
+    monkeypatch.setattr(
+        "genie_space_optimizer.backend.job_launcher.submit_optimization",
+        lambda *a, **k: (987, 654),
+    )
+    return create_run
+
+
+def test_trigger_capture_uses_sp_first_and_persists_sp_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ws = _client("obo")
+    sp_ws = _client("sp")
+    sp_snapshot = _snapshot(9)
+    obo_snapshot = _snapshot(0, title="Filtered OBO Export")
+    calls: list[str] = []
+
+    def fake_fetch(client: MagicMock, _space_id: str) -> dict:
+        calls.append(client._mock_name)
+        return sp_snapshot if client is sp_ws else obo_snapshot
+
+    create_run = _patch_trigger_happy_path(monkeypatch)
+    monkeypatch.setattr(_genie_client, "fetch_space_config", fake_fetch)
+
+    result = trigger.trigger_optimization(
+        "space-1",
+        ws,
+        sp_ws,
+        IntegrationConfig(
+            catalog="cat",
+            schema_name="sch",
+            warehouse_id="wh",
+            job_id=654,
+        ),
+        user_email="user@example.com",
+    )
+
+    assert result.status == "IN_PROGRESS"
+    assert calls == ["sp"]
+    assert create_run.call_args.kwargs["config_snapshot"] is sp_snapshot
+    persisted_tables = create_run.call_args.kwargs["config_snapshot"][
+        "_parsed_space"
+    ]["data_sources"]["tables"]
+    assert len(persisted_tables) == 9
+
+
+def test_trigger_capture_rejects_empty_snapshots_and_never_persists_them(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ws = _client("obo")
+    sp_ws = _client("sp")
+    empty_snapshot = _snapshot(0)
+    calls: list[str] = []
+
+    def fake_fetch(client: MagicMock, _space_id: str) -> dict:
+        calls.append(client._mock_name)
+        return empty_snapshot
+
+    create_run = _patch_trigger_happy_path(monkeypatch)
+    monkeypatch.setattr(_genie_client, "fetch_space_config", fake_fetch)
+
+    with caplog.at_level(logging.ERROR), pytest.raises(RuntimeError, match="non-empty"):
+        trigger.trigger_optimization(
+            "space-1",
+            ws,
+            sp_ws,
+            IntegrationConfig(
+                catalog="cat",
+                schema_name="sch",
+                warehouse_id="wh",
+                job_id=654,
+            ),
+            user_email="user@example.com",
+        )
+
+    assert calls == ["sp", "obo"]
+    create_run.assert_not_called()
+    assert "Rejecting empty Genie space snapshot" in caplog.text


### PR DESCRIPTION
## Summary

Fixes stale/empty Genie `serialized_space` snapshots reaching the optimizer by making the service-principal export path primary and rejecting missing or empty exports before they become run state. This prevents an OBO response without serialized config from being persisted and later used to generate empty-space descriptions or generic sample questions for populated Genie Spaces.

- Layer 1: trigger-time capture is SP-first in `integration/trigger.py` and the app route trigger path; snapshots with zero tables, metric views, and functions are rejected and fail before `config_snapshot` is persisted.
- Layer 2: `fetch_space_config` now raises `MissingSerializedSpaceError` when a 200 response omits `serialized_space` or returns an empty export, and shared data-source helpers give callers a consistent emptiness check.
- Layer 3: `_prepare_lever_loop` re-fetches live config through the job client when the cached run-row snapshot has no `data_sources.tables`; non-empty cached snapshots are still used as-is.
- Layer 4: `_run_space_metadata_enrichment` skips description and sample-question generation when the working snapshot is empty but the live space is populated, and the #260 sample-question empty-base guard now treats exported-but-empty data sources as empty.
- Caller audit: fallback loops (`settings`, backend access probe, trigger capture) still catch fetch failures and can try SP; soft snapshot/postflight paths already catch fetch exceptions; mutating and refresh paths now fail closed instead of fabricating `{}`; the questions path explicitly skips genuine empty spaces.

Track 1 note: this PR does not touch `patch_space_config` or the `harness.py:6773` region called out for the sibling PR.

## Test Plan

- [x] Focused Python regressions: `18 passed`.
- [x] Full GSO package pytest from package root: `4166 passed, 2 failed, 17 skipped, 3 xfailed, 23 warnings`. The failures are the known base failures in `test_arbiter_approved_mining.py` and `test_unified_rca_prompt_alignment.py`.
- [x] GSO UI package tests: `22 passed` across 2 files.
- [x] `uv lock --check`: passed.
- [x] `npm ci --dry-run --ignore-scripts`: passed.
- [x] `py_compile` for changed Python files and `git diff --check`: passed.
- [ ] Package typecheck `ty check`: failed with `268 diagnostics`, in existing broad package areas (`_spark`, SQLModel/read-through typing, prompt registry ignores, optimizer typing, etc.). No new snapshot-guard diagnostics were surfaced in the output.
- [ ] Package lint: no ruff executable/config and no GSO UI lint script are present in this package.

## Verification Commands

```bash
PYTHONPATH=$PWD/src:$PWD/../.. /Users/david.huang/Projects/databricks-genie-workbench/.venv/bin/python -m pytest tests/unit/test_genie_client_fetch_space_config.py tests/unit/test_trigger_snapshot_capture.py tests/unit/test_prepare_lever_loop_snapshot_refresh.py tests/unit/test_space_metadata_enrichment_full_replacement.py -q
PYTHONPATH=$PWD/src:$PWD/../.. /Users/david.huang/Projects/databricks-genie-workbench/.venv/bin/python -m pytest tests -q
npm test -- --run
uv lock --check
npm ci --dry-run --ignore-scripts
PYTHONPATH=$PWD/src:$PWD/../.. /Users/david.huang/Projects/databricks-genie-workbench/.venv/bin/python -m ty check
```
