### PR TITLE
Guard GSO against empty Genie snapshots

### DIFF
--- a/packages/genie-space-optimizer/src/genie_space_optimizer/common/genie_client.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/common/genie_client.py
@@ -358,6 +358,10 @@ def fetch_space_config(w: WorkspaceClient, space_id: str) -> dict:
     Returns the raw API response augmented with convenience keys:
     ``_parsed_space``, ``_tables``, ``_metric_views``, ``_functions``,
     ``_instructions``.
+
+    Raises:
+        MissingSerializedSpaceError: if Genie returns a 200 response without
+            the requested ``serialized_space`` export, or with an empty export.
     """
     raw_config = w.api_client.do(
         "GET",
@@ -383,6 +387,14 @@ def fetch_space_config(w: WorkspaceClient, space_id: str) -> dict:
             "the caller must retry with a client that can export the space config."
         )
     if isinstance(ss, str):
+        if not ss.strip():
+            logger.error(
+                "Genie Space %s response returned empty serialized_space string",
+                space_id,
+            )
+            raise MissingSerializedSpaceError(
+                f"Genie Space {space_id} response returned empty serialized_space"
+            )
         ss = json.loads(ss)
     if not isinstance(ss, dict) or not ss:
         logger.error(

--- a/packages/genie-space-optimizer/tests/unit/test_empty_snapshot_guards.py
+++ b/packages/genie-space-optimizer/tests/unit/test_empty_snapshot_guards.py
@@ -1,0 +1,116 @@
+"""Regression guards for stale/empty Genie Space snapshots."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _snapshot(identifier: str | None) -> dict:
+    tables = [{"identifier": identifier, "column_configs": []}] if identifier else []
+    return {
+        "_parsed_space": {
+            "version": 2,
+            "data_sources": {
+                "tables": tables,
+                "metric_views": [],
+                "functions": [],
+            },
+            "config": {"sample_questions": []},
+            "instructions": {"text_instructions": []},
+        },
+    }
+
+
+def _patch_prepare_deps(monkeypatch, fetch_mock: MagicMock) -> None:
+    from genie_space_optimizer.optimization import harness as _harness
+
+    monkeypatch.setattr(
+        "genie_space_optimizer.common.genie_client.fetch_space_config",
+        fetch_mock,
+    )
+
+    def extract_refs(config: dict) -> list[tuple[str, str, str]]:
+        parsed = config.get("_parsed_space", config)
+        data_sources = parsed.get("data_sources", {}) if isinstance(parsed, dict) else {}
+        refs: list[tuple[str, str, str]] = []
+        for table in data_sources.get("tables", []) or []:
+            identifier = table.get("identifier", "")
+            parts = identifier.split(".")
+            if len(parts) == 3:
+                refs.append((parts[0], parts[1], parts[2]))
+        return refs
+
+    monkeypatch.setattr(
+        "genie_space_optimizer.common.uc_metadata.extract_genie_space_table_refs",
+        extract_refs,
+    )
+    monkeypatch.setattr(
+        "genie_space_optimizer.common.uc_metadata.get_columns_for_tables_rest",
+        lambda w, refs: [{"table_full_name": ".".join(refs[0]), "name": "id"}] if refs else [],
+    )
+    monkeypatch.setattr(
+        "genie_space_optimizer.common.metric_view_catalog."
+        "detect_metric_views_via_catalog_with_outcomes",
+        lambda *a, **k: (set(), {}, {}),
+    )
+    monkeypatch.setattr(_harness, "ENABLE_PROMPT_MATCHING_AUTO_APPLY", False)
+    monkeypatch.setattr(
+        "genie_space_optimizer.iq_scan.collect_rls_audit",
+        lambda *a, **k: {},
+    )
+
+
+def test_prepare_lever_loop_refetches_empty_cached_snapshot(monkeypatch) -> None:
+    from genie_space_optimizer.optimization import harness as _harness
+
+    empty_cached = _snapshot(None)
+    live_populated = _snapshot("cat.sch.live_table")
+    fetch_mock = MagicMock(name="fetch_space_config", return_value=live_populated)
+
+    monkeypatch.setattr(
+        _harness,
+        "load_run",
+        lambda *a, **k: {"config_snapshot": empty_cached},
+    )
+    _patch_prepare_deps(monkeypatch, fetch_mock)
+
+    config = _harness._prepare_lever_loop(
+        w=MagicMock(),
+        spark=MagicMock(),
+        run_id="run-empty",
+        space_id="space-1",
+        catalog="cat",
+        schema="sch",
+    )
+
+    fetch_mock.assert_called_once()
+    tables = config["_parsed_space"]["data_sources"]["tables"]
+    assert [t["identifier"] for t in tables] == ["cat.sch.live_table"]
+    assert config["_uc_columns"], "UC columns should be populated from live refs"
+
+
+def test_prepare_lever_loop_uses_non_empty_cached_snapshot_as_is(monkeypatch) -> None:
+    from genie_space_optimizer.optimization import harness as _harness
+
+    cached_populated = _snapshot("cat.sch.cached_table")
+    fetch_mock = MagicMock(name="fetch_space_config", return_value=_snapshot("cat.sch.live_table"))
+
+    monkeypatch.setattr(
+        _harness,
+        "load_run",
+        lambda *a, **k: {"config_snapshot": cached_populated},
+    )
+    _patch_prepare_deps(monkeypatch, fetch_mock)
+
+    config = _harness._prepare_lever_loop(
+        w=MagicMock(),
+        spark=MagicMock(),
+        run_id="run-cached",
+        space_id="space-1",
+        catalog="cat",
+        schema="sch",
+    )
+
+    fetch_mock.assert_not_called()
+    tables = config["_parsed_space"]["data_sources"]["tables"]
+    assert [t["identifier"] for t in tables] == ["cat.sch.cached_table"]

--- a/packages/genie-space-optimizer/tests/unit/test_fetch_space_config_serialized_space.py
+++ b/packages/genie-space-optimizer/tests/unit/test_fetch_space_config_serialized_space.py
@@ -1,0 +1,69 @@
+"""Tests for Genie serialized_space fetch semantics."""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from genie_space_optimizer.common.genie_client import (
+    MissingSerializedSpaceError,
+    fetch_space_config,
+)
+
+
+def _workspace_with_response(response: dict) -> MagicMock:
+    w = MagicMock()
+    w.api_client.do.return_value = response
+    return w
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"space_id": "space-1", "title": "No export"},
+        {"space_id": "space-1", "serialized_space": None},
+        {"space_id": "space-1", "serialized_space": ""},
+        {"space_id": "space-1", "serialized_space": "   "},
+        {"space_id": "space-1", "serialized_space": {}},
+        {"space_id": "space-1", "serialized_space": "{}"},
+    ],
+)
+def test_fetch_space_config_raises_on_missing_or_empty_serialized_space(
+    response: dict,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(
+        logging.ERROR,
+        logger="genie_space_optimizer.common.genie_client",
+    ):
+        with pytest.raises(MissingSerializedSpaceError):
+            fetch_space_config(_workspace_with_response(response), "space-1")
+
+    assert any("serialized_space" in record.getMessage() for record in caplog.records)
+
+
+def test_fetch_space_config_allows_present_but_genuinely_empty_data_sources() -> None:
+    serialized = {
+        "version": 2,
+        "data_sources": {"tables": [], "metric_views": [], "functions": []},
+        "config": {"sample_questions": []},
+        "instructions": {"text_instructions": []},
+    }
+    config = fetch_space_config(
+        _workspace_with_response(
+            {
+                "space_id": "space-1",
+                "title": "Empty but exported",
+                "serialized_space": json.dumps(serialized),
+            }
+        ),
+        "space-1",
+    )
+
+    assert config["_parsed_space"] == serialized
+    assert config["_tables"] == []
+    assert config["_metric_views"] == []
+    assert config["_functions"] == []

--- a/packages/genie-space-optimizer/tests/unit/test_space_metadata_enrichment_full_replacement.py
+++ b/packages/genie-space-optimizer/tests/unit/test_space_metadata_enrichment_full_replacement.py
@@ -65,7 +65,30 @@ def _authoritative_full_config() -> dict:
     }
 
 
-def _run(config: dict, *, fetch_return: dict, generate_return=_NEW_SQS):
+def _working_full_config() -> dict:
+    """Shape passed into ``_run_space_metadata_enrichment`` after the
+    lever-loop preparation path has a populated working snapshot."""
+    return {
+        "description": "x" * 20,
+        "_parsed_space": {
+            "version": 1,
+            "data_sources": {
+                "tables": [{"identifier": "cat.sch.stale_name"}],
+                "metric_views": [],
+            },
+            "config": {"sample_questions": []},
+            "instructions": {"text_instructions": []},
+        },
+    }
+
+
+def _run(
+    config: dict,
+    *,
+    fetch_return: dict,
+    generate_return=_NEW_SQS,
+    metadata_snapshot: dict | None = None,
+):
     """Invoke ``_run_space_metadata_enrichment`` with all I/O mocked out.
 
     Returns ``(result, patch_mock, fetch_mock, logger_mock)``.
@@ -74,6 +97,8 @@ def _run(config: dict, *, fetch_return: dict, generate_return=_NEW_SQS):
     fetch_mock = MagicMock(name="fetch_space_config", return_value=fetch_return)
     gen_mock = MagicMock(name="_generate_sample_questions", return_value=generate_return)
     logger_mock = MagicMock(name="logger")
+    if metadata_snapshot is None:
+        metadata_snapshot = config.get("_parsed_space", config)
 
     with (
         patch.object(_genie_client_mod, "patch_space_config", patch_mock),
@@ -89,7 +114,7 @@ def _run(config: dict, *, fetch_return: dict, generate_return=_NEW_SQS):
             "run-1",
             _SPACE_ID,
             config,
-            {"data_sources": {"tables": []}},
+            metadata_snapshot,
             "cat",
             "sch",
         )
@@ -103,14 +128,11 @@ def _run(config: dict, *, fetch_return: dict, generate_return=_NEW_SQS):
 
 class TestPopulatedBase:
     def test_patches_full_object_from_authoritative_fetch(self):
-        """Even when the PASSED-IN ``_parsed_space`` is degenerate, the
-        PATCH is built from the authoritative re-fetched config and carries
-        top-level ``version`` + ``data_sources`` with sample_questions
-        updated in place."""
-        passed_in = {
-            "description": "x" * 20,   # present → no description work
-            "_parsed_space": _authoritative_full_config()["_parsed_space"],
-        }
+        """When the working snapshot is populated, the PATCH is built from
+        the authoritative re-fetched config and carries top-level
+        ``version`` + ``data_sources`` with sample_questions updated in
+        place."""
+        passed_in = _working_full_config()
         fetch_return = _authoritative_full_config()
 
         result, patch_mock, fetch_mock, _ = _run(passed_in, fetch_return=fetch_return)
@@ -147,10 +169,7 @@ class TestPopulatedBase:
             validate_serialized_space,
         )
 
-        passed_in = {
-            "description": "x" * 20,
-            "_parsed_space": _authoritative_full_config()["_parsed_space"],
-        }
+        passed_in = _working_full_config()
         _, patch_mock, _, _ = _run(
             passed_in, fetch_return=_authoritative_full_config()
         )

--- a/packages/genie-space-optimizer/tests/unit/test_trigger_snapshot_capture.py
+++ b/packages/genie-space-optimizer/tests/unit/test_trigger_snapshot_capture.py
@@ -7,8 +7,8 @@ import pandas as pd
 import pytest
 
 import genie_space_optimizer.common.genie_client as _genie_client
-from genie_space_optimizer.integration.config import IntegrationConfig
 from genie_space_optimizer.integration import trigger
+from genie_space_optimizer.integration.config import IntegrationConfig
 
 
 def _snapshot(table_count: int, *, title: str = "Revenue Space") -> dict:
@@ -18,12 +18,13 @@ def _snapshot(table_count: int, *, title: str = "Revenue Space") -> dict:
             "version": 2,
             "data_sources": {
                 "tables": [
-                    {"identifier": f"cat.sch.table_{idx}"}
+                    {"identifier": f"cat.sch.table_{idx}", "column_configs": []}
                     for idx in range(table_count)
                 ],
                 "metric_views": [],
                 "functions": [],
             },
+            "config": {"sample_questions": []},
             "instructions": {"text_instructions": []},
         },
     }
@@ -56,6 +57,21 @@ def _patch_trigger_happy_path(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     return create_run
 
 
+def _trigger(ws: MagicMock, sp_ws: MagicMock):
+    return trigger.trigger_optimization(
+        "space-1",
+        ws,
+        sp_ws,
+        IntegrationConfig(
+            catalog="cat",
+            schema_name="sch",
+            warehouse_id="wh",
+            job_id=654,
+        ),
+        user_email="user@example.com",
+    )
+
+
 def test_trigger_capture_uses_sp_first_and_persists_sp_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -72,18 +88,7 @@ def test_trigger_capture_uses_sp_first_and_persists_sp_snapshot(
     create_run = _patch_trigger_happy_path(monkeypatch)
     monkeypatch.setattr(_genie_client, "fetch_space_config", fake_fetch)
 
-    result = trigger.trigger_optimization(
-        "space-1",
-        ws,
-        sp_ws,
-        IntegrationConfig(
-            catalog="cat",
-            schema_name="sch",
-            warehouse_id="wh",
-            job_id=654,
-        ),
-        user_email="user@example.com",
-    )
+    result = _trigger(ws, sp_ws)
 
     assert result.status == "IN_PROGRESS"
     assert calls == ["sp"]
@@ -92,6 +97,31 @@ def test_trigger_capture_uses_sp_first_and_persists_sp_snapshot(
         "_parsed_space"
     ]["data_sources"]["tables"]
     assert len(persisted_tables) == 9
+
+
+def test_trigger_capture_rejects_empty_sp_then_uses_non_empty_obo_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ws = _client("obo")
+    sp_ws = _client("sp")
+    sp_empty = _snapshot(0)
+    obo_populated = _snapshot(9)
+    calls: list[str] = []
+
+    def fake_fetch(client: MagicMock, _space_id: str) -> dict:
+        calls.append(client._mock_name)
+        return sp_empty if client is sp_ws else obo_populated
+
+    create_run = _patch_trigger_happy_path(monkeypatch)
+    monkeypatch.setattr(_genie_client, "fetch_space_config", fake_fetch)
+
+    result = _trigger(ws, sp_ws)
+
+    assert result.status == "IN_PROGRESS"
+    assert calls == ["sp", "obo"]
+    persisted = create_run.call_args.kwargs["config_snapshot"]
+    assert persisted is obo_populated
+    assert len(persisted["_parsed_space"]["data_sources"]["tables"]) == 9
 
 
 def test_trigger_capture_rejects_empty_snapshots_and_never_persists_them(
@@ -111,18 +141,7 @@ def test_trigger_capture_rejects_empty_snapshots_and_never_persists_them(
     monkeypatch.setattr(_genie_client, "fetch_space_config", fake_fetch)
 
     with caplog.at_level(logging.ERROR), pytest.raises(RuntimeError, match="non-empty"):
-        trigger.trigger_optimization(
-            "space-1",
-            ws,
-            sp_ws,
-            IntegrationConfig(
-                catalog="cat",
-                schema_name="sch",
-                warehouse_id="wh",
-                job_id=654,
-            ),
-            user_email="user@example.com",
-        )
+        _trigger(ws, sp_ws)
 
     assert calls == ["sp", "obo"]
     create_run.assert_not_called()


### PR DESCRIPTION
## Summary
- Hardens `fetch_space_config` so missing, null, empty object, empty string, and whitespace-only `serialized_space` responses raise `MissingSerializedSpaceError` instead of producing `_parsed_space={}`.
- Keeps the SP-first trigger snapshot path from the latest base and extends trigger coverage for SP-first persistence, empty-SP fallback, and both-empty fail-loud behavior.
- Adds hostile lever-loop tests proving empty cached snapshots re-fetch live config while non-empty snapshots are used as-is.
- Extends space metadata enrichment coverage so stale empty working snapshots cannot generate/patch empty-space descriptions or generic sample questions, while the #260 empty-base sample-question guard still holds.

## Four-layer behavior
1. Trigger capture is SP-first via `_capture_config_snapshot`; captures are rejected when exported data sources are empty and both-empty raises before `wh_create_run`.
2. `fetch_space_config` signals omitted/empty `serialized_space` loudly with `MissingSerializedSpaceError`; this PR adds whitespace-only export coverage.
3. `_prepare_lever_loop` rejects cached snapshots with no `data_sources.tables` and re-fetches live config through the job client; non-empty cached snapshots avoid needless re-fetch.
4. `_run_space_metadata_enrichment` verifies live config before generating metadata from an empty working snapshot and skips description/sample-question writes when live is populated; #260 full-replacement and genuine-empty guards remain intact.

## fetch_space_config caller audit
- `integration/trigger.py`: SP-first capture rejects missing/empty export and no-data-source snapshots before persisting.
- `optimization/harness.py::_prepare_lever_loop`: empty cached snapshot forces live re-fetch; fetch exceptions fail loud before enrichment.
- `optimization/harness.py::_refresh_config_preserving_mv_state`: still treats fetch failure as a stage failure rather than silently continuing with empty config.
- `optimization/harness.py::_run_space_metadata_enrichment`: live verification prevents stale empty metadata writes; questions path reuses verified live config or fetches authoritatively, then keeps the #260 empty-base guard.
- Other fetch callers either already handle exceptions through existing stage/UI soft-fail blocks or should fail loud because an omitted serialized export is not a valid Genie config.

## Tests
- `uv run pytest tests/unit/test_fetch_space_config_serialized_space.py tests/unit/test_trigger_snapshot_capture.py tests/unit/test_empty_snapshot_guards.py tests/unit/test_space_metadata_enrichment_full_replacement.py`: 21 passed.
- `uv run pytest tests/unit`: 4093 passed, 2 failed, 1 skipped, 3 xfailed, 18 warnings. Failures match known pre-existing suites: `test_arbiter_approved_mining.py::TestRunEnrichmentSignature::test_signature_has_held_out_benchmarks_kwonly` and `test_unified_rca_prompt_alignment.py::test_leak_safe_example_synthesis_contract_constant_exists`.
- `uv run ty check`: failed with 292 diagnostics, pre-existing package-wide type issues such as optional `pyspark.sql` / `databricks.connect` imports and unrelated existing type errors.
- `git diff --check`: passed.

## Notes
- Rebasing onto current `gso/optimizer-v2` brought in sibling/Track 1 overlap from PR #262; this PR keeps the remaining delta scoped to fetch hardening and hostile regression coverage.
- No notebook files touched.
