### PR TITLE
Build the GSO wheel with uv build instead of pip build isolation

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -37,7 +37,7 @@ sync:
 artifacts:
   default:
     build: |
-      rm -f .build/genie_space_optimizer-*.whl && cd packages/genie-space-optimizer && uv run --with build python -m build --wheel -o ../../.build/ && cd ../.. && cp .build/genie_space_optimizer-*.whl .build/genie_space_optimizer-0.0.0-py3-none-any.whl
+      rm -f .build/genie_space_optimizer-*.whl && cd packages/genie-space-optimizer && uv build --wheel -o ../../.build/ && cd ../.. && cp .build/genie_space_optimizer-*.whl .build/genie_space_optimizer-0.0.0-py3-none-any.whl
 
 # ---------------------------------------------------------------------------
 # Resources


### PR DESCRIPTION
Closes #267

The bundle artifact command used `uv run --with build python -m build --wheel`, whose isolated pip environment ignores uv's index configuration — in environments that route Python packages through a private index/proxy, resolving the build requirements (`uv-dynamic-versioning`) fails and `databricks bundle deploy` aborts. Switching to `uv build --wheel` produces the same wheel, honors uv's index config, and skips the extra pip isolation round-trip.

**Tested:** with this change `databricks bundle deploy` built and deployed the wheel successfully in a private-index environment, and the deployed app + GSO job work. `uv build --wheel` output is equivalent on a vanilla-PyPI machine.

This pull request and its description were written by Isaac.