### PR TITLE
Harden GitHub Actions supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot version updates.
+#
+# Python (pip/uv) version updates are intentionally NOT configured here: the
+# project's dependency policy (AGENTS.md "Dependency Security Policy") requires
+# regenerating requirements.txt via `uv export` alongside any Python bump,
+# which Dependabot cannot do. Python vulnerability coverage comes from
+# Dependabot security alerts, with bumps applied manually per that policy.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /docs
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/genie-space-optimizer
+    schedule:
+      interval: weekly

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,108 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/**
+      - .github/workflows/deploy-docs.yml
+  # Allow manual runs from the Actions tab.
+  workflow_dispatch:
+
+# Least-privilege defaults; the deploy job elevates what it needs.
+permissions:
+  contents: read
+  id-token: write # required to mint the JFrog OIDC token
+
+# Serialize deploys; don't cancel an in-flight publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Docusaurus
+    runs-on:
+      group: databricks-solutions-protected-runner-group
+      labels: linux-ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./docs
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ./docs/package-lock.json
+
+      - name: Configure npm for JFrog (OIDC)
+        run: |
+          set -euo pipefail
+
+          # Exchange the GitHub Actions OIDC token for a JFrog access token so
+          # npm can install from the org's internal registry. JFrog is for use
+          # from GitHub Actions only. The token is written only into ~/.npmrc —
+          # never into GITHUB_ENV — so it is not exposed to later steps'
+          # process environments.
+          ID_TOKEN=$(curl -sLS \
+            -H "User-Agent: actions/oidc-client" \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
+          echo "::add-mask::${ID_TOKEN}"
+
+          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
+            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
+            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
+          echo "::add-mask::${ACCESS_TOKEN}"
+
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+            echo "FAIL: Could not extract JFrog access token"
+            exit 1
+          fi
+
+          cat > ~/.npmrc << EOF
+          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
+          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${ACCESS_TOKEN}
+          always-auth=true
+          EOF
+
+          echo "npm configured to use JFrog registry"
+
+      - name: Install dependencies
+        # --ignore-scripts: dependency lifecycle scripts must never run in CI
+        # (they would execute third-party code with registry credentials on disk).
+        run: npm ci --ignore-scripts
+
+      - name: Build website
+        run: npx docusaurus build
+
+      - name: Upload Build Artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: ./docs/build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on:
+      group: databricks-solutions-protected-runner-group
+      labels: linux-ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,7 +33,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # Full history for docs last-update metadata; no pushes happen here,
+          # so don't leave the token in .git/config.
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -77,6 +80,9 @@ jobs:
       - name: Install dependencies
         # --ignore-scripts: dependency lifecycle scripts must never run in CI
         # (they would execute third-party code with registry credentials on disk).
+        # Residual risk: `docusaurus build` below still executes dependency JS at
+        # build time in a job holding id-token:write and the npmrc token; the
+        # mitigation is the exact-pinned, integrity-checked package-lock.json.
         run: npm ci --ignore-scripts
 
       - name: Build website

--- a/.github/workflows/genie-space-optimizer-replay.yml
+++ b/.github/workflows/genie-space-optimizer-replay.yml
@@ -21,6 +21,9 @@ jobs:
         working-directory: packages/genie-space-optimizer
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # PR-controlled test code runs below; don't leave the token in .git/config.
+          persist-credentials: false
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "0.10.2"

--- a/.github/workflows/genie-space-optimizer-replay.yml
+++ b/.github/workflows/genie-space-optimizer-replay.yml
@@ -6,7 +6,11 @@ on:
       - "packages/genie-space-optimizer/src/**"
       - "packages/genie-space-optimizer/tests/**"
       - "packages/genie-space-optimizer/pyproject.toml"
-      - "packages/genie-space-optimizer/uv.lock"
+      - "uv.lock"
+
+# This workflow executes PR-controlled test code; never grant it more than read.
+permissions:
+  contents: read
 
 jobs:
   replay:
@@ -16,8 +20,10 @@ jobs:
       run:
         working-directory: packages/genie-space-optimizer
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.10.2"
       - run: uv sync --frozen
       - name: Run replay tests
         run: uv run pytest tests/replay -v --maxfail=1


### PR DESCRIPTION
## Summary

Remediations from a supply-chain security analysis (SIRT prompt) of this repo's CI/CD surface, done ahead of re-enabling GitHub Actions. Each change maps to a finding:

| Finding | Change |
|---|---|
| Replay workflow ran with the repo-default **write** token while executing PR-controlled pytest code | Added `permissions: contents: read` to `genie-space-optimizer-replay.yml` (repo default has also been switched to read-only) |
| Actions were tag-pinned (`@v4`, `@v3`) — vulnerable to upstream tag mutation | SHA-pinned `actions/checkout` (v6.0.2, same SHA as `deploy-docs.yml`) and `astral-sh/setup-uv` (v8.3.2); also pinned the uv version itself (`0.10.2`) since setup-uv otherwise installs mutable "latest" |
| Stale `paths:` filter referenced `packages/genie-space-optimizer/uv.lock`, which doesn't exist (single root `uv.lock` by design) — dependency-only changes never triggered the replay tests | Filter now watches root `uv.lock` |
| `deploy-docs.yml` exposed the JFrog OIDC token to npm dependency lifecycle scripts via `GITHUB_ENV` | Token is now written only into `~/.npmrc`, and install runs `npm ci --ignore-scripts`. **Verified locally**: `npm ci --ignore-scripts && npm run build` in `docs/` succeeds and produces `build/index.html` |
| No Dependabot configuration | Added `.github/dependabot.yml`: weekly `github-actions` + npm (`frontend/`, `docs/`, `packages/genie-space-optimizer/`) version updates. Python version updates intentionally excluded — the repo's dependency policy requires regenerating `requirements.txt` via `uv export` with each bump; Python is covered by Dependabot security alerts (now enabled) with manual bumps |

`deploy-docs.yml` is committed for the first time here; it stays inert until Actions/Pages are re-enabled at the org level.

Repo settings applied alongside this PR (not part of the diff): default workflow token → read-only, fork-PR approval → all outside collaborators, secret scanning + push protection + non-provider patterns → enabled, Dependabot alerts + security updates → enabled. Still pending (needs repo admin UI): "Require actions to be pinned to a full-length commit SHA", and adding the replay job as a required status check once Actions is back on.

## Test plan

- [x] All three YAML files parse cleanly
- [x] Pinned SHAs verified against upstream tags (`actions/checkout` v6.0.2 = `de0fac2e…`, `astral-sh/setup-uv` v8.3.2 = `11f9893b…`)
- [x] `cd docs && npm ci --ignore-scripts && npm run build` succeeds (exit 0, `build/index.html` generated)
- [ ] Replay workflow run with read-only token — only verifiable after the org re-enables Actions

This pull request and its description were written by Isaac.