### PR TITLE
security: harden CI supply chain (SHA-pin actions, scope permissions, add Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot version updates.
+#
+# Python (pip/uv) version updates are intentionally NOT configured here: the
+# project's dependency policy (AGENTS.md "Dependency Security Policy") requires
+# regenerating requirements.txt via `uv export` alongside any Python bump,
+# which Dependabot cannot do. Python vulnerability coverage comes from
+# Dependabot security alerts, with bumps applied manually per that policy.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /docs
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/genie-space-optimizer
+    schedule:
+      interval: weekly

--- a/.github/workflows/genie-space-optimizer-replay.yml
+++ b/.github/workflows/genie-space-optimizer-replay.yml
@@ -6,7 +6,11 @@ on:
       - "packages/genie-space-optimizer/src/**"
       - "packages/genie-space-optimizer/tests/**"
       - "packages/genie-space-optimizer/pyproject.toml"
-      - "packages/genie-space-optimizer/uv.lock"
+      - "uv.lock"
+
+# This workflow executes PR-controlled test code; never grant it more than read.
+permissions:
+  contents: read
 
 jobs:
   replay:
@@ -16,8 +20,13 @@ jobs:
       run:
         working-directory: packages/genie-space-optimizer
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # PR-controlled test code runs below; don't leave the token in .git/config.
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.10.2"
       - run: uv sync --frozen
       - name: Run replay tests
         run: uv run pytest tests/replay -v --maxfail=1


### PR DESCRIPTION
## Summary

Hardens the repo's GitHub Actions supply chain, from a SIRT-format supply-chain audit. This re-lands the **zero-runtime-risk subset** of the closed-unmerged #270, with the two action SHAs **independently re-verified against their release tags via the GitHub API**.

**All findings here are latent until GitHub Actions is re-enabled on the repo** (Actions is currently disabled). Nothing in this PR touches the app runtime, dependencies, or deploy path — it is CI/governance only, so it is safe to merge without a Databricks deploy.

## Changes

| Change | Finding addressed |
|---|---|
| Pin `actions/checkout` → `@de0fac2e…` (v6.0.2) and `astral-sh/setup-uv` → `@11f9893b…` (v8.3.2) in `genie-space-optimizer-replay.yml`; pin uv tool to `0.10.2` | **HIGH** — actions were pinned to mutable tags (`@v4`/`@v3`), vulnerable to tag mutation / upstream retagging |
| Add top-level `permissions: contents: read` to `genie-space-optimizer-replay.yml`; set `persist-credentials: false` | **HIGH** — the workflow ran with the default token scope while executing PR-author-controlled test code |
| Add `.github/dependabot.yml` (github-actions + `/frontend`, `/docs`, `/packages/genie-space-optimizer` npm) | **MEDIUM** — no automated dependency-update / vuln-patch flow |
| Fix the `paths:` filter from the nonexistent `packages/genie-space-optimizer/uv.lock` → root `uv.lock` | **INFO** — the workspace uses a single root lock, so the old filter never matched and lock bumps didn't trigger the gate |
| Remove the empty, misnamed `CODEOWNERS.txt` | **MEDIUM** (partial) — GitHub never reads that filename for ownership |

Python is intentionally omitted from Dependabot: the dependency policy (`AGENTS.md` → Dependency Security Policy) requires regenerating `requirements.txt` via `uv export` alongside any Python bump, which Dependabot can't do — Python is covered by Dependabot **security alerts** with manual bumps instead.

## Why this workflow is sensitive
`genie-space-optimizer-replay.yml` runs `uv run pytest tests/replay` on the PR merge ref — i.e. **PR-author-controlled code**. For a public repo this is acceptable *provided* actions are SHA-pinned and the token is least-privilege (both now true). Because the repo has **no secrets, variables, or deploy keys** and the default token is already `read`, the blast radius of malicious PR code is low (runner abuse / cache poisoning, not credential theft).

## Verification
- Both workflow files and `dependabot.yml` parse as valid YAML; asserted `permissions.contents == read`, both `uses:` are 40-char SHA pins, and no `@vN` tag refs remain.
- Action SHAs confirmed via `gh api` to be the commit objects for tags `v6.0.2` / `v8.3.2`.
- The workflow itself cannot be exercised in CI here — **Actions is disabled repo-wide**; runtime validation happens only after an admin re-enables it.

## Follow-ups NOT in this PR

**Admin / settings (cannot live in a PR):**
- [ ] Enable Actions on the repo (blocked on the org Actions allowlist — needs an org admin)
- [ ] Turn on org *Require actions pinned to a full-length commit SHA*
- [ ] Require approval to run fork-PR workflows for all outside / first-time contributors
- [ ] Add "GSO Lever Loop Replay" as a required status check on the `main` ruleset (id `13791172`) once Actions is enabled
- [ ] Add a tag-protection ruleset for `v*` release tags
- [ ] Switch GitHub Pages `build_type` to `workflow` (retire the legacy `main:/docs` builder)

**Deferred file changes (separate PRs):**
- [ ] `deploy-docs.yml` (reviewed Actions-based Pages deploy) — coupled to the Pages build-type switch above
- [ ] Pin `databricks-connect` exactly in `packages/genie-space-optimizer/databricks.yml` (currently appends `>=15.0.0` to the built wheel reqs) — deploy-only-testable; correct fix mirrors the env-marker split in `packages/genie-space-optimizer/pyproject.toml`

This pull request and its description were written by Isaac.