### PR TITLE
ci: deploy Pages job on databricks-solutions protected runner group

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,7 +41,9 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-solutions-protected-runner-group
+      labels: linux-ubuntu-latest
     # Pages write scope is confined to this job only.
     permissions:
       pages: write


### PR DESCRIPTION
## Problem

The `Deploy Docs` workflow builds the Docusaurus site fine, but the **deploy** job fails with:

> HttpError: ... the `databricks-solutions` organization has an IP allow list enabled, and your IP address is not permitted to access this resource. (status: 403)

`actions/deploy-pages` calls the GitHub Pages deployment API from the runner. The org enforces an IP allow list that excludes generic GitHub-hosted runners, so the call is rejected.

## Fix

Move **only the deploy job** to the org's allowlisted protected runner group (`databricks-solutions-protected-runner-group`), which sits on an allowlisted network. This is the documented internal pattern (mirrors `databrickslabs/geobrix`'s Pages workflow). The build job stays on `ubuntu-latest` since it only needs the public npm registry, not the IP-restricted Pages API.

## Validation

The `github-pages` environment only permits deploys from `main`, so the runner-group change can only be fully exercised once merged. The build job has already succeeded on the branch run.

This pull request and its description were written by Isaac.