### PR TITLE
Rename Genie Spaces to Genie Agents in documentation

### DIFF
--- a/docs/docs/features/auto-optimize.md
+++ b/docs/docs/features/auto-optimize.md
@@ -5,7 +5,7 @@ description: "Benchmark-driven optimization: a 6-task pipeline, 5 levers, 3 gate
 
 # Auto-Optimize (GSO)
 
-Auto-Optimize is a benchmark-driven optimization pipeline that measures Genie Space accuracy, diagnoses failures, and iteratively applies metadata patches until quality thresholds are met. It is powered by the Genie Space Optimizer (GSO) engine — a separate Python package at `packages/genie-space-optimizer/`.
+Auto-Optimize is a benchmark-driven optimization pipeline that measures Genie Agent accuracy, diagnoses failures, and iteratively applies metadata patches until quality thresholds are met. It is powered by the Genie Space Optimizer (GSO) engine — a separate Python package at `packages/genie-space-optimizer/`.
 
 ## Overview
 
@@ -33,7 +33,7 @@ flowchart LR
 | 3 | **Enrichment** | Gather optimization context | Proactive metadata enrichment — profile tables, analyze query patterns, identify improvement opportunities |
 | 4 | **Lever Loop** | Iterative optimization | The core loop: RCA-ground failures → cluster → pick one action group (cluster + lever) → generate patches → safety gates → apply → re-evaluate → accept or roll back |
 | 5 | **Finalize** | Consolidate results | Merge accepted patches, validate final configuration, compute final accuracy |
-| 6 | **Deploy** | Apply to space | Optionally apply the optimized configuration to the live Genie Space |
+| 6 | **Deploy** | Apply to agent | Optionally apply the optimized configuration to the live Genie Agent |
 
 ## The Levers
 
@@ -41,19 +41,19 @@ Levers are the categories of metadata change the optimizer can apply. **Lever 0 
 
 | Lever | Name | Target | Examples |
 |-------|------|--------|----------|
-| **0** | Proactive Enrichment *(always-on)* | UC metadata the space doesn't yet inline | Table/column descriptions, glossary terms, UC tags — non-behavioral context only |
+| **0** | Proactive Enrichment *(always-on)* | UC metadata the agent doesn't yet inline | Table/column descriptions, glossary terms, UC tags — non-behavioral context only |
 | **1** | Tables & Columns | Table allowlist + per-column metadata | Add a table, add column synonyms/aliases, mark deprecated columns |
 | **2** | Metric Views | Governed metric definitions | Add or refine a metric view for a common aggregation |
 | **3** | Table-Valued Functions | Parameterized SQL patterns | Register a TVF for a recurring query shape |
 | **4** | Join Specifications | Table relationships | Add or correct a join spec / preferred join key |
-| **5** | Genie Space Instructions | Natural-language guidance | Add a domain term, routing rule, or guardrail to the instructions block |
+| **5** | Genie Agent Instructions | Natural-language guidance | Add a domain term, routing rule, or guardrail to the instructions block |
 | **6** | SQL Expressions | Example SQL library | Add a worked example, replace a stale one |
 
 The lever loop's **strategist** analyzes current failure patterns and selects the lever most likely to address them.
 
 ## The Lever Loop
 
-The heart of Auto-Optimize is an evidence-grounded iteration — **measure, diagnose, intervene, prove, learn** — that never changes the space on a hunch:
+The heart of Auto-Optimize is an evidence-grounded iteration — **measure, diagnose, intervene, prove, learn** — that never changes the Genie Agent on a hunch:
 
 ```mermaid
 flowchart LR
@@ -68,12 +68,12 @@ flowchart LR
 2. **Cluster** — failures sharing a root cause are grouped so one patch can fix a whole theme.
 3. **Intervene** — the strategist commits to exactly **one** action group per iteration (a cluster paired with a lever). One change at a time keeps cause and effect attributable.
 4. **Gate + apply** — proposed patches run the safety gates (below); survivors are applied to a candidate config, with a pre-iteration snapshot kept for rollback.
-5. **Prove** — the train benchmark is re-evaluated through the patched space with the same judge panel.
+5. **Prove** — the train benchmark is re-evaluated through the patched agent with the same judge panel.
 6. **Accept / learn** — the acceptance rule (below) keeps or rolls back the change, and a reflection entry records what worked so the strategist won't repeat a dead end.
 
 ## Acceptance: did the score actually improve?
 
-Each iteration is kept or discarded by a single explicit rule (`decide_acceptance`): the **post-arbiter accuracy** of the patched space must beat the carried baseline by at least a gain floor.
+Each iteration is kept or discarded by a single explicit rule (`decide_acceptance`): the **post-arbiter accuracy** of the patched agent must beat the carried baseline by at least a gain floor.
 
 ```
 accept if  candidate_accuracy ≥ baseline_accuracy + min_gain_pp
@@ -130,7 +130,7 @@ A candidate that scores well on the questions it was tuned against might simply 
 
 - **Held-out generalization** — at preflight the benchmark is split, reserving ~15% (`HELD_OUT_RATIO = 0.15`) of questions that the lever loop **never sees**. Finalize evaluates the candidate against this held-out set; a large train-vs-held-out gap flags overfitting.
 - **Repeatability** — the candidate is re-run to confirm the score is stable rather than a lucky draw from LLM-graded variance.
-- **Champion promotion** — each accepted iteration is snapshotted as an MLflow **LoggedModel**; the best is promoted to the **`champion`** alias (`promote_best_model`). The Deploy task applies that champion config to the live space.
+- **Champion promotion** — each accepted iteration is snapshotted as an MLflow **LoggedModel**; the best is promoted to the **`champion`** alias (`promote_best_model`). The Deploy task applies that champion config to the live agent.
 
 ## Convergence
 

--- a/docs/docs/features/create-agent.md
+++ b/docs/docs/features/create-agent.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
-description: "Multi-turn, tool-calling LLM agent that builds Genie Spaces from requirements."
+description: "Multi-turn, tool-calling LLM agent that builds Genie Agents from requirements."
 ---
 
 # Create Agent
 
-The Create Agent is a multi-turn, tool-calling LLM agent that walks users from business requirements to a fully configured and deployed Genie Space. It handles data discovery, profiling, plan generation, config assembly, validation, and space creation — all through a conversational interface.
+The Create Agent is a multi-turn, tool-calling LLM agent that walks users from business requirements to a fully configured and deployed Genie Agent. It handles data discovery, profiling, plan generation, config assembly, validation, and agent creation — all through a conversational interface.
 
 ## How It Works
 
@@ -13,7 +13,7 @@ The agent follows a structured progression through six steps. Each step focuses 
 
 ```mermaid
 flowchart LR
-    req["Requirements<br/>what does the space<br/>need to do?"] --> ds["Data Sources<br/>which tables and<br/>schemas?"]
+    req["Requirements<br/>what does the agent<br/>need to do?"] --> ds["Data Sources<br/>which tables and<br/>schemas?"]
     ds --> insp["Inspection<br/>profile columns ·<br/>assess quality"]
     insp --> plan["Plan<br/>generate and present<br/>the plan"]
     plan --> cfg["Config Create<br/>build · validate ·<br/>deploy"]
@@ -28,8 +28,8 @@ flowchart LR
 | `data_sources` | Discovering Data | Agent browses Unity Catalog (catalogs → schemas → tables) to find relevant tables |
 | `inspection` | Inspecting Tables | Agent profiles columns, assesses data quality, and checks table usage patterns |
 | `plan` | Building Plan | Agent generates a structured plan with tables, questions, example SQLs, benchmarks |
-| `config_create` | Creating Space | Agent builds the `serialized_space` config, validates it, and creates the Genie Space |
-| `post_creation` | Done | Agent provides a summary, the space URL, and suggests next steps (e.g., run IQ Scan) |
+| `config_create` | Creating Agent | Agent builds the `serialized_space` config, validates it, and creates the Genie Agent |
+| `post_creation` | Done | Agent provides a summary, the agent URL, and suggests next steps (e.g., run IQ Scan) |
 
 Step detection is automatic — the agent infers the current step from conversation history using `detect_step()` in `backend/prompts_create/`.
 
@@ -68,7 +68,7 @@ The agent has access to 17 tools organized into six categories:
 | `get_config_schema` | Return the Genie Space JSON schema reference |
 | `generate_config` | Build a `serialized_space` config from the plan |
 | `validate_config` | Validate a config against the Genie API schema (errors + warnings) |
-| `update_config` | Modify an existing space's config |
+| `update_config` | Modify an existing agent's config |
 
 ### Plan
 
@@ -91,7 +91,7 @@ When the agent calls `generate_plan`, the request is routed to `backend/services
 | Section | Content Generated |
 |---------|-------------------|
 | `tables` | Table selection, descriptions, column configs |
-| `questions` | Sample questions for the space |
+| `questions` | Sample questions for the agent |
 | `example_sqls` | Example question-SQL pairs with usage guidance |
 | `benchmarks` | Benchmark question-answer pairs for accuracy measurement |
 | `analytics` | Join specs, measures, filters, expressions |
@@ -104,7 +104,7 @@ When the user reviews the plan in the UI and clicks "Create" (sending `action: "
 
 1. Calls `generate_config` to build the `serialized_space` from the plan
 2. Calls `validate_config` to check for errors
-3. Calls `create_space` (or `update_space` if modifying an existing space)
+3. Calls `create_space` (or `update_space` if modifying an existing agent)
 
 This avoids unnecessary LLM inference and completes in seconds.
 
@@ -130,8 +130,8 @@ The create agent uses SSE (Server-Sent Events) to stream progress to the fronten
 | `tool_result` | Tool execution result |
 | `message_delta` | Incremental text from the LLM (streamed token-by-token) |
 | `message` | Complete message from the agent |
-| `created` | Genie Space was created (includes space ID and URL) |
-| `updated` | Existing space was updated |
+| `created` | Genie Agent was created (includes space ID and URL) |
+| `updated` | Existing agent was updated |
 | `heartbeat` | Keep-alive ping (every 15s to prevent proxy timeout) |
 | `error` | Something went wrong |
 | `done` | Stream complete (may include `needs_continuation: true`) |
@@ -162,5 +162,5 @@ Agent sessions are persisted across page refreshes:
 
 ## Related Documentation
 
-- [IQ Scanner](/docs/features/iq-scanner) — run after creating a space to assess quality
+- [IQ Scanner](/docs/features/iq-scanner) — run after creating an agent to assess quality
 - [Architecture Overview](/docs/getting-started/architecture-overview) — how the create agent fits in the app

--- a/docs/docs/features/iq-scanner.md
+++ b/docs/docs/features/iq-scanner.md
@@ -5,13 +5,13 @@ description: "Deterministic 12-check quality scoring with three maturity tiers."
 
 # IQ Scanner
 
-The IQ Scanner is a **deterministic, rule-based** quality assessment engine for Genie Space configurations. It evaluates 12 binary checks, assigns a maturity tier, and produces actionable findings with recommended next steps.
+The IQ Scanner is a **deterministic, rule-based** quality assessment engine for Genie Agent configurations. It evaluates 12 binary checks, assigns a maturity tier, and produces actionable findings with recommended next steps.
 
 Unlike the LLM-based analysis tools, the scanner runs instantly with no LLM calls — it inspects the `serialized_space` JSON directly.
 
 ### Unity Catalog Enrichment
 
-Before scoring, `scan_space()` fetches table and column descriptions from Unity Catalog via `WorkspaceClient.tables.get()` and merges them into the space config. This means checks 2 (table descriptions) and 3 (column descriptions) reflect metadata that exists in UC even if not inlined in the Genie Space config. Existing inline descriptions are never overwritten. If UC metadata is unavailable (permissions, network), the scan continues with config-only data.
+Before scoring, `scan_space()` fetches table and column descriptions from Unity Catalog via `WorkspaceClient.tables.get()` and merges them into the agent config. This means checks 2 (table descriptions) and 3 (column descriptions) reflect metadata that exists in UC even if not inlined in the Genie Agent config. Existing inline descriptions are never overwritten. If UC metadata is unavailable (permissions, network), the scan continues with config-only data.
 
 ## Scoring Model
 
@@ -39,7 +39,7 @@ The first 10 checks evaluate configuration quality. The last 2 checks evaluate o
 | 2 | **Table descriptions** | ≥80% of tables have descriptions | Finding + next step to add descriptions |
 | 3 | **Column descriptions** | ≥50% of columns have descriptions | Finding + next step to add descriptions |
 | 4 | **Text instructions** | Present and >50 characters total | Finding to add business context instructions |
-| 5 | **Join specifications** | At least 1 join spec (for multi-source spaces) | Finding to add join specs |
+| 5 | **Join specifications** | At least 1 join spec (for multi-source agents) | Finding to add join specs |
 | 6 | **Data source count 1–12** | Between 1 and 12 tables + metric views | Finding to reduce data sources or use multi-room architecture |
 | 7 | **8+ example SQLs** | At least 8 example question-SQL pairs | Finding to add more examples |
 | 8 | **SQL snippets** | At least 1 function, expression, measure, or filter | Finding to add SQL snippets |
@@ -104,7 +104,7 @@ Beyond the 12 scored checks, the scanner emits additional warnings for edge case
 | Example SQLs 8–14 | "10-15 is the sweet spot for largest accuracy jump" |
 | Missing `usage_guidance` on >50% of example SQLs | "Add descriptions of when each example should be applied" |
 | Missing measures or filters in SQL snippets | "Add missing SQL snippet types for better coverage" |
-| Entity matching columns > 100 | "Approaching 120/space limit" |
+| Entity matching columns > 100 | "Approaching 120/agent limit" |
 | Row-level security on tables with entity matching | "Entity matching is silently disabled for these" |
 
 ## Integration with Auto-Optimize

--- a/docs/docs/getting-started/architecture-overview.md
+++ b/docs/docs/getting-started/architecture-overview.md
@@ -91,7 +91,7 @@ See [Appendix A: API Reference](/docs/reference/api) for the complete endpoint l
 | Auth | `services/auth.py` | OBO `ContextVar` management, SP singleton, `WorkspaceClient` factory |
 | Genie Client | `services/genie_client.py` | Genie API: fetch space, list spaces, SP fallback on scope error |
 | Scanner | `services/scanner.py` | Rule-based IQ scoring (12 checks, 3 maturity tiers) |
-| Create Agent | `services/create_agent.py` | Multi-turn tool-calling LLM agent for space creation |
+| Create Agent | `services/create_agent.py` | Multi-turn tool-calling LLM agent for agent creation |
 | Create Agent Tools | `services/create_agent_tools.py` | Tool definitions: UC discovery, SQL, config generation |
 | Create Agent Session | `services/create_agent_session.py` | Session persistence (L1 in-memory + L2 Lakebase) |
 | Plan Builder | `services/plan_builder.py` | Parallel LLM plan generation across 5 sections |
@@ -116,10 +116,10 @@ The frontend is a React 19 + TypeScript + Tailwind CSS v4 application built with
 
 | View | Component | Description |
 |------|-----------|-------------|
-| `list` | `SpaceList` | Browse and search Genie Spaces with IQ scores |
+| `list` | `SpaceList` | Browse and search Genie Agents with IQ scores |
 | `detail` | `SpaceDetail` | Space detail with tabs: Score, Optimize, History |
 | `admin` | `AdminDashboard` | Org-wide stats, leaderboard, alerts |
-| `create` | `CreateAgentChat` | Conversational agent for building new spaces |
+| `create` | `CreateAgentChat` | Conversational agent for building new Genie Agents |
 
 ### Component Organization
 

--- a/docs/docs/getting-started/deployment-guide.md
+++ b/docs/docs/getting-started/deployment-guide.md
@@ -21,7 +21,7 @@ A Databricks workspace with:
 - Apps enabled
 - A SQL Warehouse (Serverless recommended)
 - A Unity Catalog with CREATE SCHEMA permission
-- Lakebase Autoscaling available (optional but recommended for persistent scan history, starred spaces, and agent sessions)
+- Lakebase Autoscaling available (optional but recommended for persistent scan history, starred agents, and agent sessions)
 - MLflow Prompt Registry enabled (required for Auto-Optimize judge prompts)
 - Databricks Foundation Model APIs enabled for the curated Create Agent and Auto-Optimize model list
 
@@ -84,7 +84,7 @@ Open `notebooks/install.py`, attach a **Serverless** compute session (**environm
 | `lakebase_project_name` | Conditional | Lakebase project name for `create` or `existing`; defaults to `<app-name>-lakebase` for `create`. Leave blank when `lakebase_mode` is `skip` |
 
 :::note
-The notebook user must hold the [installer permissions](/docs/platform/authentication). The notebook automatically grants visible Genie Spaces to the app service principal, so the user needs `CAN_MANAGE` on each visible space they want the app to manage.
+The notebook user must hold the [installer permissions](/docs/platform/authentication). The notebook automatically grants visible Genie Agents to the app service principal, so the user needs `CAN_MANAGE` on each visible agent they want the app to manage.
 :::
 
 <!-- TODO(screenshot): the installer notebook open in the workspace with widgets visible -->
@@ -101,7 +101,7 @@ The installer uses the shared `scripts.deploy_lib` Python library and notebook-n
 5. Creates or updates the GSO optimization job (`<app-name>-gso-optimization-job`) via the SDK/Jobs API
 6. Renders a patched `app.yaml` into the generated source folder and patches app OAuth scopes and resources
 7. Deploys the app from the generated source folder
-8. Grants the app SP access to visible Genie Spaces
+8. Grants the app SP access to visible Genie Agents
 
 The Git folder is never modified — the generated workspace folder is deployment output; do not edit it by hand.
 
@@ -148,11 +148,11 @@ The installer will:
 8. Write `.env.deploy` with your configuration (including the default LLM endpoint)
 9. Run `scripts/deploy.sh` to build and deploy the app
 10. Resolve the app's service principal
-11. Optionally grant the SP access to your existing Genie Spaces
+11. Optionally grant the SP access to your existing Genie Agents
 
 ## Lakebase (automated)
 
-Lakebase provides persistent storage for scan history, starred spaces, and agent sessions. Without it, the app uses in-memory storage (data lost on restart).
+Lakebase provides persistent storage for scan history, starred agents, and agent sessions. Without it, the app uses in-memory storage (data lost on restart).
 
 **Lakebase setup is fully automated by both install paths:**
 - Creates a Lakebase Autoscaling project via the SDK
@@ -206,7 +206,7 @@ This applies to **Method 2 (local terminal)**. The notebook installer runs the e
 It does **not** remove:
 - Lakebase data (the `genie` schema in `databricks_postgres`)
 - Unity Catalog schema/tables (`<catalog>.genie_space_optimizer` and its tables)
-- Genie Space SP permissions granted during install
+- Genie Agent SP permissions granted during install
 - MLflow experiments created during install
 - Synced tables (if manually created)
 

--- a/docs/docs/getting-started/introduction.md
+++ b/docs/docs/getting-started/introduction.md
@@ -7,31 +7,31 @@ description: "What Genie Workbench is, who it's for, key concepts, and the five-
 
 ## What is Genie Workbench?
 
-Genie Workbench is a developer tool for Databricks Genie Spaces — the natural-language-to-SQL interface for business users. It addresses the gap between creating a Genie Space and having one that reliably produces correct SQL: most spaces start with incomplete metadata, missing instructions, and no benchmarks, leading to poor user experiences.
+Genie Workbench is a developer tool for Databricks Genie Agents — the natural-language-to-SQL interface for business users. It addresses the gap between creating a Genie Agent and having one that reliably produces correct SQL: most agents start with incomplete metadata, missing instructions, and no benchmarks, leading to poor user experiences.
 
 Genie Workbench provides five capabilities that form a continuous improvement loop:
 
-1. **Create** — An AI agent that walks you from business requirements through data discovery, inspection, and plan generation to a fully configured Genie Space.
-2. **Score** — A rule-based IQ Scanner that evaluates space quality across 12 checks and assigns a maturity tier.
+1. **Create** — An AI agent that walks you from business requirements through data discovery, inspection, and plan generation to a fully configured Genie Agent.
+2. **Score** — A rule-based IQ Scanner that evaluates agent quality across 12 checks and assigns a maturity tier.
 3. **Fix** — An AI agent that reads scan findings and generates targeted JSON patches to fix configuration gaps.
-4. **Optimize** — A benchmark-driven pipeline (Auto-Optimize / GSO) that measures real accuracy, diagnoses failures, and iteratively improves the space configuration.
+4. **Optimize** — A benchmark-driven pipeline (Auto-Optimize / GSO) that measures real accuracy, diagnoses failures, and iteratively improves the agent configuration.
 5. **Track** — Persistent history of every scan, optimization run, and configuration change, stored in Lakebase.
 
 ## Target Audience
 
-- **Genie Space developers** building and maintaining spaces for their organizations
-- **Data platform teams** managing quality across multiple Genie Spaces
+- **Genie Agent developers** building and maintaining agents for their organizations
+- **Data platform teams** managing quality across multiple Genie Agents
 - **Workspace administrators** deploying and operating the Workbench app
 
 ## Key Concepts
 
 | Term | Definition |
 |------|-----------|
-| **Genie Space** | A Databricks resource that lets business users ask data questions in natural language. Configured with tables, instructions, example SQL, and benchmarks. |
-| **`serialized_space`** | The JSON configuration of a Genie Space, accessed via the Genie Conversation API. Contains `data_sources`, `instructions`, `config`, and `benchmarks` sections. |
-| **IQ Score** | A 0–12 score based on 12 binary checks. Each check evaluates one aspect of space configuration quality. |
+| **Genie Agent** | A Databricks resource (formerly "Genie Space") that lets business users ask data questions in natural language. Configured with tables, instructions, example SQL, and benchmarks. |
+| **`serialized_space`** | The JSON configuration of a Genie Agent, accessed via the Genie Conversation API. Contains `data_sources`, `instructions`, `config`, and `benchmarks` sections. |
+| **IQ Score** | A 0–12 score based on 12 binary checks. Each check evaluates one aspect of agent configuration quality. |
 | **Maturity Tier** | One of three labels derived from the IQ Score: **Not Ready**, **Ready to Optimize**, or **Trusted**. |
-| **Finding** | A specific configuration gap identified by the IQ Scanner (e.g., "No join specifications for multi-table space"), paired with a recommended next step. |
+| **Finding** | A specific configuration gap identified by the IQ Scanner (e.g., "No join specifications for multi-table agent"), paired with a recommended next step. |
 | **Benchmark** | A question-answer pair used to measure Genie accuracy. The expected SQL is compared against Genie's generated SQL by specialized judges. |
 | **Lever** | An optimization strategy category in Auto-Optimize. Five lever types: tables/columns, metric views, TVFs, join specs, and instructions/example SQL. |
 | **Patch** | A targeted change to the `serialized_space` configuration, represented as a `field_path` + `new_value` pair. |
@@ -41,7 +41,7 @@ Genie Workbench provides five capabilities that form a continuous improvement lo
 
 ## Feature Workflow
 
-The features form a lifecycle that can be entered at any point and repeated as the space evolves:
+The features form a lifecycle that can be entered at any point and repeated as the Genie Agent evolves:
 
 ```mermaid
 flowchart LR
@@ -51,8 +51,8 @@ flowchart LR
     Track -. "re-scan · continuous improvement" .-> Score
 ```
 
-- **Create Agent** builds a new space from scratch (or updates an existing one).
-- **IQ Scanner** evaluates the space and produces findings with recommended next steps.
+- **Create Agent** builds a new agent from scratch (or updates an existing one).
+- **IQ Scanner** evaluates the agent and produces findings with recommended next steps.
 - **Auto-Optimize** runs a deeper benchmark-driven pipeline for accuracy improvement.
 - **Track** persists all results to Lakebase so you can see progress over time.
 - The cycle repeats: after optimization, re-scan to see the updated score.

--- a/docs/docs/platform/authentication.md
+++ b/docs/docs/platform/authentication.md
@@ -43,9 +43,9 @@ For the Create Agent's Server-Sent Events endpoint, the `ContextVar` is **not** 
 
 Users can only interact with resources they have permission to access:
 - **Unity Catalog**: catalogs, schemas, tables visible to the user
-- **Genie Spaces**: only spaces the user can manage
+- **Genie Agents**: only agents the user can manage
 - **SQL Warehouse**: queries execute under the user's identity
-- **Space creation/modification**: spaces are created and patched as the user
+- **Genie Agent creation/modification**: agents are created and patched as the user
 
 ## Service Principal (SP)
 
@@ -67,7 +67,7 @@ def _is_scope_error(e: Exception) -> bool:
     return "scope" in msg or "insufficient_scope" in msg
 ```
 
-For this fallback to work, the SP must have **CAN_MANAGE** on each Genie Space.
+For this fallback to work, the SP must have **CAN_MANAGE** on each Genie Agent.
 
 #### 2. Optimization job execution
 
@@ -113,7 +113,7 @@ The `user_api_scopes` in `app.yaml` request these scopes for the user's OBO toke
 | Scope | Purpose |
 |-------|---------|
 | `sql` | Execute SQL queries via warehouses |
-| `dashboards.genie` | Access Genie Space API |
+| `dashboards.genie` | Access Genie Agent API |
 | `serving.serving-endpoints` | Call model serving endpoints (LLM) |
 | `catalog.catalogs:read` | Browse Unity Catalog catalogs |
 | `catalog.schemas:read` | Browse Unity Catalog schemas |
@@ -125,13 +125,13 @@ If the workspace or user's OAuth consent doesn't grant all scopes, the app degra
 
 ## SP Permissions Required
 
-### Per Genie Space
+### Per Genie Agent
 
 | Permission | Purpose |
 |-----------|---------|
 | `CAN_MANAGE` | API fallback when user token lacks Genie scope; applying optimization patches during the GSO pipeline |
 
-Grant via the Genie Space sharing UI or the installer (`scripts/install.sh` automates this).
+Grant via the Genie Agent sharing UI or the installer (`scripts/install.sh` automates this).
 
 ### Per referenced data schema
 
@@ -170,11 +170,11 @@ These are granted automatically by `scripts/grant_permissions.py` during deploym
 
 | Operation | Identity | Code Reference | Rationale |
 |-----------|----------|---------------|-----------|
-| Browse Genie Spaces, UC catalogs/schemas/tables | OBO (user) | `services/uc_client.py`, `routers/create.py` | User sees only what they have access to |
-| Genie API — fetch/list spaces | OBO → SP fallback | `services/genie_client.py` `_is_scope_error()` | User token may lack `dashboards.genie` scope |
-| Create Agent — tools, SQL, space creation | OBO (user) | `services/create_agent.py`, `services/create_agent_tools.py` | Space created under user identity |
+| Browse Genie Agents, UC catalogs/schemas/tables | OBO (user) | `services/uc_client.py`, `routers/create.py` | User sees only what they have access to |
+| Genie API — fetch/list agents | OBO → SP fallback | `services/genie_client.py` `_is_scope_error()` | User token may lack `dashboards.genie` scope |
+| Create Agent — tools, SQL, agent creation | OBO (user) | `services/create_agent.py`, `services/create_agent_tools.py` | Agent created under user identity |
 | Trigger optimization — permission check | OBO (user) | `integration/trigger.py` `user_can_edit_space()` | Verify user has CAN_EDIT/CAN_MANAGE |
-| Trigger optimization — SP entitlement check | SP | `integration/trigger.py` `sp_can_manage_space()` | Verify SP can manage the space |
+| Trigger optimization — SP entitlement check | SP | `integration/trigger.py` `sp_can_manage_space()` | Verify SP can manage the agent |
 | Optimization job submission | SP | `backend/job_launcher.py` `submit_optimization()` | `jobs.run_now()` requires SP |
 | Optimization job execution (6-task DAG) | SP (run_as) | `backend/job_launcher.py` `ensure_job_run_as()` | Lakeflow Jobs have no OBO mechanism |
 | GSO Delta table reads/writes | SP | `routers/auto_optimize.py` `_delta_query()` | Optimizer state tables owned by SP |
@@ -184,9 +184,9 @@ These are granted automatically by `scripts/grant_permissions.py` during deploym
 
 ## Security Considerations
 
-1. **Authorization before execution** — the user must have `CAN_EDIT` or `CAN_MANAGE` on the Genie Space before any optimization job is submitted. This check happens with the user's OBO token, not the SP.
+1. **Authorization before execution** — the user must have `CAN_EDIT` or `CAN_MANAGE` on the Genie Agent before any optimization job is submitted. This check happens with the user's OBO token, not the SP.
 
-2. **SP entitlement validated** — even if the user is authorized, the SP must also have `CAN_MANAGE` on the space. If the SP lacks access, the trigger is rejected with a clear error.
+2. **SP entitlement validated** — even if the user is authorized, the SP must also have `CAN_MANAGE` on the agent. If the SP lacks access, the trigger is rejected with a clear error.
 
 3. **Minimum-privilege SP** — the SP only needs read access to referenced data schemas (for benchmarking) and manage access to the GSO state schema. It does not need workspace-admin privileges.
 

--- a/docs/docs/platform/gsl-instruction-schema.md
+++ b/docs/docs/platform/gsl-instruction-schema.md
@@ -10,12 +10,12 @@ description: "Shared section vocabulary and format rules for text_instructions c
 Two agents write `text_instructions`:
 
 - **Create Agent** — generates the initial block when a user builds a
-  new space.
+  new Genie Agent.
 - **Optimizer (GSO)** — rewrites the block as part of
   benchmark-driven optimization.
 
 Historically each used a different authoring convention, so a Create
-Agent space with `## Terminology` headers could be stripped by an
+Agent output with `## Terminology` headers could be stripped by an
 optimizer that expected `PURPOSE:` ALL-CAPS headers. This doc is the
 shared vocabulary the Create Agent targets so the output is
 coherent end-to-end. The optimizer migrates to this schema in
@@ -28,7 +28,7 @@ sections** — do not leave an empty header.
 
 | # | Header | What goes here |
 |---|---|---|
-| 1 | `## PURPOSE` | One or two bullets stating the space's scope and audience. |
+| 1 | `## PURPOSE` | One or two bullets stating the Genie Agent's scope and audience. |
 | 2 | `## DISAMBIGUATION` | Clarification-question triggers: "When the user asks about X without specifying Y, ask them to clarify Y." Also, term-resolution rules: "'Q1' means calendar Q1 unless the user says 'fiscal Q1'." |
 | 3 | `## DATA QUALITY NOTES` | Caveats about the data the model needs to know: NULL handling, known bad rows, column semantics that aren't in the column description. |
 | 4 | `## CONSTRAINTS` | Hard guardrails: what never to show (PII columns, secrets), what not to do (cross-join, ignore a required filter). |
@@ -97,7 +97,7 @@ Genie cannot infer from the structured config.
 
 ### Create Agent
 
-Emits the section vocabulary above when generating a new space. Each
+Emits the section vocabulary above when generating a new Genie Agent. Each
 section is one or more bullets. Output shape stays
 `content: list[str]` during this near-term pass; migration to the
 canonical single-item `[full_text]` shape is tracked in #177

--- a/docs/docs/platform/operations.md
+++ b/docs/docs/platform/operations.md
@@ -16,8 +16,8 @@ The app creates the `genie` schema and all tables on first startup (the SP owns 
 | Table | Purpose |
 |-------|---------|
 | `scan_results` | IQ scan history: score, maturity, checks, findings, timestamps |
-| `starred_spaces` | User-starred spaces for quick access |
-| `seen_spaces` | Tracks which spaces the user has visited |
+| `starred_spaces` | User-starred agents for quick access |
+| `seen_spaces` | Tracks which agents the user has visited |
 | `optimization_runs` | Legacy optimization accuracy records (used by scanner checks 11–12) |
 | `agent_sessions` | Create agent session persistence (message history, step state) |
 
@@ -30,7 +30,7 @@ Lakebase credentials are auto-generated via the Databricks SDK (`postgres.genera
 If `LAKEBASE_HOST` is not configured (no Lakebase attached), the app falls back to **in-memory dictionaries**. The app remains fully functional but:
 
 - Scan results are lost on restart
-- Starred spaces are lost on restart
+- Starred Genie Agents are lost on restart
 - Agent sessions are lost on restart
 - The Admin Dashboard shows no historical data
 
@@ -129,12 +129,12 @@ databricks bundle deploy -t app --profile <profile>
 
 The `app` target uses `mode: development` for per-deployer Terraform state with `presets.name_prefix: ""` for clean job names.
 
-### Post-Deploy: Genie Space Access
+### Post-Deploy: Genie Agent Access
 
-After deploying, the app's SP needs access to Genie Spaces for API fallback and optimization:
+After deploying, the app's SP needs access to Genie Agents for API fallback and optimization:
 
-1. The installer grants SP access to your existing Genie Spaces
-2. For spaces created after install, share them with the SP (`CAN_MANAGE`)
+1. The installer grants SP access to your existing Genie Agents
+2. For agents created after install, share them with the SP (`CAN_MANAGE`)
 3. Grant SP `SELECT` on referenced schemas:
 
 ```sql

--- a/docs/docs/reference/environment-variables.md
+++ b/docs/docs/reference/environment-variables.md
@@ -29,11 +29,11 @@ These variables are defined in `app.yaml` and injected into the app runtime. Pla
 |----------|--------|-------------|
 | `SQL_WAREHOUSE_ID` | `valueFrom: sql-warehouse` | SQL Warehouse ID, pulled from the app resource named `sql-warehouse` |
 
-### Genie Space Configuration
+### Genie Agent Configuration
 
 | Variable | Value | Description |
 |----------|-------|-------------|
-| `GENIE_TARGET_DIRECTORY` | `/Shared/` | Where new Genie Spaces are created. Override to a specific folder if needed |
+| `GENIE_TARGET_DIRECTORY` | `/Shared/` | Where new Genie Agents are created. Override to a specific folder if needed |
 
 ### Local Development
 

--- a/docs/docs/reference/troubleshooting.md
+++ b/docs/docs/reference/troubleshooting.md
@@ -25,11 +25,11 @@ description: "Common issues, causes, and fixes."
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| "You need CAN_EDIT or CAN_MANAGE permission" on optimize trigger | User lacks permission on the Genie Space | Share the space with the user (CAN_EDIT or CAN_MANAGE) |
-| "The service principal does not have CAN_MANAGE" | SP not shared on the Genie Space | Share the space with the app's SP (CAN_MANAGE) |
+| "You need CAN_EDIT or CAN_MANAGE permission" on optimize trigger | User lacks permission on the Genie Agent | Share the agent with the user (CAN_EDIT or CAN_MANAGE) |
+| "The service principal does not have CAN_MANAGE" | SP not shared on the Genie Agent | Share the agent with the app's SP (CAN_MANAGE) |
 | "OBO token lacks genie scope, retrying with service principal" (in logs) | User token missing `dashboards.genie` scope | This is handled automatically via SP fallback — no action needed unless SP also fails |
 | Optimization job fails with catalog/schema access errors | SP lacks UC permissions on referenced data | Grant `SELECT` on referenced schemas to the SP |
-| "Permission denied" on scan | User lacks access to the Genie Space | Share the space with the user |
+| "Permission denied" on scan | User lacks access to the Genie Agent | Share the agent with the user |
 
 ## Lakebase Issues
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -47,7 +47,7 @@ const DOC_NAV = [
 
 const config: Config = {
   title: 'Genie Workbench',
-  tagline: 'Create, score, and optimize Databricks Genie Spaces',
+  tagline: 'Create, score, and optimize Databricks Genie Agents',
   favicon: 'img/favicon.svg',
 
   // Production URL for GitHub Pages: https://databricks-solutions.github.io/databricks-genie-workbench/
@@ -125,7 +125,7 @@ const config: Config = {
       {
         siteTitle: 'Genie Workbench',
         siteDescription:
-          'Developer tool for creating, scoring, and optimizing Databricks Genie Spaces.',
+          'Developer tool for creating, scoring, and optimizing Databricks Genie Agents.',
       },
     ],
   ],

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -8,12 +8,12 @@ import Button from '@site/src/components/Button';
 const CAPABILITIES = [
   {
     title: 'Create',
-    body: 'A multi-turn AI agent walks you from business requirements to a fully configured Genie Space.',
+    body: 'A multi-turn AI agent walks you from business requirements to a fully configured Genie Agent.',
     to: '/docs/features/create-agent',
   },
   {
     title: 'Score',
-    body: 'The rule-based IQ Scanner grades space quality across 12 checks and assigns a maturity tier.',
+    body: 'The rule-based IQ Scanner grades Genie Agent quality across 12 checks and assigns a maturity tier.',
     to: '/docs/features/iq-scanner',
   },
   {
@@ -37,8 +37,8 @@ const STATS = [
 
 const PERSONAS = [
   {
-    title: 'Genie Space developer',
-    body: 'Build and refine spaces. Start with the Create Agent and the IQ Scanner.',
+    title: 'Genie Agent developer',
+    body: 'Build and refine Genie Agents. Start with the Create Agent and the IQ Scanner.',
     to: '/docs/getting-started/introduction',
   },
   {
@@ -122,7 +122,7 @@ function Capabilities() {
       <Eyebrow>The continuous-improvement loop</Eyebrow>
       <h2 className="mt-1 text-3xl font-normal">Five capabilities, one workflow</h2>
       <p className="mt-2 max-w-2xl text-slate-600 dark:text-slate-400">
-        Enter the loop at any point and repeat as the space evolves — after
+        Enter the loop at any point and repeat as the Genie Agent evolves — after
         optimizing, re-scan to see the updated score.
       </p>
       <div className="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
Closes #313

## Summary

<!-- Describe the change in your own words. -->

Changing Genie Spaces or Spaces references to Genie Agent wording. 

## What changed

<!-- List the docs/areas you updated. -->

13 Markdown files edited. 

## Rationale

<!-- Why this change (branding alignment, etc.). -->

In an effort to align to Databricks Branding. 

## Out of scope / preserved

<!-- Note anything intentionally left unchanged (e.g. serialized_space, GSO name, API terms, archives). -->

The Genie Spaces references in the actual source code.

## Testing

<!-- How you validated (e.g. npm run typecheck / npm run build in docs/, dev server). -->

 npm run build in docs in local server. 

## Notes for reviewers

<!-- Anything else. -->
