### PR TITLE
Surface benchmark candidate gaps from production Genie traffic

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -78,6 +78,7 @@ from backend.watch.routers import (
     watch_resources_router,
     watch_settings_router,
     watch_spaces_router,
+    watch_traffic_gaps_router,
     watch_usage_router,
 )
 from backend.watch.services.system_tables import warm_cost_overview_cache
@@ -217,6 +218,7 @@ app.include_router(auto_optimize_router)
 
 # GenieWatch (observability) — all routes under /api/watch/*
 app.include_router(watch_spaces_router)
+app.include_router(watch_traffic_gaps_router)
 app.include_router(watch_cost_router)
 app.include_router(watch_usage_router)
 app.include_router(watch_feedback_router)

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -114,6 +114,19 @@ def get_workspace_client() -> WorkspaceClient:
     return _get_default_client()
 
 
+def require_obo_workspace_client() -> WorkspaceClient:
+    """Return only the request's user-authorized client.
+
+    Unlike :func:`get_workspace_client`, this function never falls back to the
+    app service principal. Use it for reads whose visibility is explicitly
+    scoped to the current user's permissions.
+    """
+    obo = _obo_client.get()
+    if obo is None:
+        raise RuntimeError("This operation requires user authorization")
+    return obo
+
+
 def get_service_principal_client() -> WorkspaceClient:
     """Get the service principal client (bypasses OBO).
 

--- a/backend/tests/test_obo_auth.py
+++ b/backend/tests/test_obo_auth.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.services import auth
+
+
+def test_require_obo_client_never_falls_back_to_default(monkeypatch) -> None:
+    auth.clear_obo_user_token()
+    monkeypatch.setattr(
+        auth,
+        "_get_default_client",
+        lambda: (_ for _ in ()).throw(AssertionError("must not use app identity")),
+    )
+
+    with pytest.raises(RuntimeError, match="user authorization"):
+        auth.require_obo_workspace_client()
+
+
+def test_require_obo_client_returns_request_client() -> None:
+    marker = object()
+    token = auth._obo_client.set(marker)
+    try:
+        assert auth.require_obo_workspace_client() is marker
+    finally:
+        auth._obo_client.reset(token)

--- a/backend/tests/test_watch_traffic_gap_reader.py
+++ b/backend/tests/test_watch_traffic_gap_reader.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.watch.services.traffic_gap_reader import (
+    IncompleteTrafficRead,
+    read_traffic_gap_analysis,
+)
+
+
+SPACE_ID = "a" * 32
+
+
+class _ApiClient:
+    def __init__(self, responses: dict[tuple[str, str | None], dict]):
+        self.responses = responses
+        self.calls: list[tuple[str, dict]] = []
+
+    def do(self, *, method: str, path: str, query: dict):
+        assert method == "GET"
+        self.calls.append((path, query))
+        token = query.get("page_token")
+        return self.responses[(path, token)]
+
+
+class _Client:
+    def __init__(self, responses: dict[tuple[str, str | None], dict]):
+        self.api_client = _ApiClient(responses)
+
+        class Config:
+            host = "https://workspace.example"
+
+        self.config = Config()
+
+
+def _responses() -> dict[tuple[str, str | None], dict]:
+    space_path = f"/api/2.0/genie/spaces/{SPACE_ID}"
+    conversations_path = f"{space_path}/conversations"
+    messages_1_path = f"{conversations_path}/conv-1/messages"
+    messages_2_path = f"{conversations_path}/conv-2/messages"
+    return {
+        (space_path, None): {
+            "serialized_space": json.dumps(
+                {"benchmarks": {"questions": [{"question": ["Covered question"]}]}}
+            )
+        },
+        (conversations_path, None): {
+            "conversations": [{"id": "conv-1", "user": {"id": "u1"}}],
+            "next_page_token": "next",
+        },
+        (conversations_path, "next"): {
+            "conversations": [{"id": "conv-2", "user": {"id": "u2"}}]
+        },
+        (messages_1_path, None): {
+            "messages": [
+                {
+                    "content": "Missing question",
+                    "status": "FAILED",
+                    "created_timestamp": 1_754_003_200_000,
+                }
+            ]
+        },
+        (messages_2_path, None): {
+            "messages": [
+                {
+                    "content": "Covered question",
+                    "status": "FAILED",
+                    "feedback": {"rating": "NEGATIVE"},
+                    "created_timestamp": 1_754_003_300_000,
+                }
+            ]
+        },
+    }
+
+
+def test_reads_all_pages_with_manager_scope_and_returns_no_raw_text() -> None:
+    client = _Client(_responses())
+
+    result = read_traffic_gap_analysis(client=client, space_id=SPACE_ID)
+
+    assert result.scanned_message_count == 2
+    assert result.covered_family_count == 1
+    assert len(result.candidates) == 1
+    assert result.candidates[0].signals == ["failed"]
+    assert result.candidates[0].conversation_urls == [
+        f"https://workspace.example/genie/rooms/{SPACE_ID}/chats/conv-1"
+    ]
+    serialized = result.model_dump_json()
+    assert "Missing question" not in serialized
+    assert "Covered question" not in serialized
+    assert "u1" not in serialized
+    assert "u2" not in serialized
+
+    conversation_call = next(
+        query for path, query in client.api_client.calls if path.endswith("/conversations")
+    )
+    assert conversation_call["include_all"] == "true"
+    assert any(query.get("page_token") == "next" for _, query in client.api_client.calls)
+
+
+def test_repeated_page_token_fails_closed_without_partial_results() -> None:
+    responses = _responses()
+    conversations_path = f"/api/2.0/genie/spaces/{SPACE_ID}/conversations"
+    responses[(conversations_path, "next")]["next_page_token"] = "next"
+    client = _Client(responses)
+
+    with pytest.raises(IncompleteTrafficRead, match="repeated page token"):
+        read_traffic_gap_analysis(client=client, space_id=SPACE_ID)
+
+
+def test_missing_serialized_space_fails_closed() -> None:
+    responses = _responses()
+    space_path = f"/api/2.0/genie/spaces/{SPACE_ID}"
+    responses[(space_path, None)] = {}
+
+    with pytest.raises(IncompleteTrafficRead, match="serialized_space"):
+        read_traffic_gap_analysis(client=_Client(responses), space_id=SPACE_ID)
+
+
+def test_omitted_empty_collection_is_a_complete_empty_page() -> None:
+    responses = _responses()
+    conversations_path = f"/api/2.0/genie/spaces/{SPACE_ID}/conversations"
+    responses[(conversations_path, None)] = {}
+
+    result = read_traffic_gap_analysis(client=_Client(responses), space_id=SPACE_ID)
+
+    assert result.scanned_message_count == 0
+    assert result.candidates == []
+
+
+def test_omitted_collection_with_next_token_fails_closed() -> None:
+    responses = _responses()
+    conversations_path = f"/api/2.0/genie/spaces/{SPACE_ID}/conversations"
+    responses[(conversations_path, None)] = {"next_page_token": "next"}
+
+    with pytest.raises(IncompleteTrafficRead, match="missing page data"):
+        read_traffic_gap_analysis(client=_Client(responses), space_id=SPACE_ID)

--- a/backend/tests/test_watch_traffic_gap_reader.py
+++ b/backend/tests/test_watch_traffic_gap_reader.py
@@ -8,6 +8,7 @@ from backend.watch.services.traffic_gap_reader import (
     IncompleteTrafficRead,
     read_traffic_gap_analysis,
 )
+from backend.watch.services import traffic_gap_reader
 
 
 SPACE_ID = "a" * 32
@@ -136,4 +137,51 @@ def test_omitted_collection_with_next_token_fails_closed() -> None:
     responses[(conversations_path, None)] = {"next_page_token": "next"}
 
     with pytest.raises(IncompleteTrafficRead, match="missing page data"):
+        read_traffic_gap_analysis(client=_Client(responses), space_id=SPACE_ID)
+
+
+def test_malformed_message_content_fails_closed() -> None:
+    responses = _responses()
+    message_path = (
+        f"/api/2.0/genie/spaces/{SPACE_ID}/conversations/conv-1/messages"
+    )
+    responses[(message_path, None)]["messages"][0].pop("content")
+
+    with pytest.raises(IncompleteTrafficRead, match="message content"):
+        read_traffic_gap_analysis(client=_Client(responses), space_id=SPACE_ID)
+
+
+def test_global_cap_counts_nonterminal_api_messages(monkeypatch) -> None:
+    responses = _responses()
+    space_path = f"/api/2.0/genie/spaces/{SPACE_ID}"
+    conversations_path = f"{space_path}/conversations"
+    responses[(conversations_path, None)] = {
+        "conversations": [
+            {"id": "conv-1"},
+            {"id": "conv-2"},
+            {"id": "conv-3"},
+        ]
+    }
+    for conversation_id in ("conv-1", "conv-2", "conv-3"):
+        responses[(f"{conversations_path}/{conversation_id}/messages", None)] = {
+            "messages": [
+                {"content": "still running", "status": "SUBMITTED"}
+            ]
+        }
+    monkeypatch.setattr(traffic_gap_reader, "_MAX_MESSAGES", 2)
+
+    with pytest.raises(IncompleteTrafficRead, match="safety limit"):
+        read_traffic_gap_analysis(client=_Client(responses), space_id=SPACE_ID)
+
+
+def test_malformed_benchmark_question_fails_closed() -> None:
+    responses = _responses()
+    space_path = f"/api/2.0/genie/spaces/{SPACE_ID}"
+    responses[(space_path, None)] = {
+        "serialized_space": json.dumps(
+            {"benchmarks": {"questions": [{"id": "missing-question"}]}}
+        )
+    }
+
+    with pytest.raises(IncompleteTrafficRead, match="benchmark question"):
         read_traffic_gap_analysis(client=_Client(responses), space_id=SPACE_ID)

--- a/backend/tests/test_watch_traffic_gap_router.py
+++ b/backend/tests/test_watch_traffic_gap_router.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+from databricks.sdk.errors import PermissionDenied
+from fastapi import HTTPException
+
+from backend.watch.models import TrafficGapAnalysis
+from backend.watch.routers import traffic_gaps
+from backend.watch.services.traffic_gap_reader import IncompleteTrafficRead
+
+
+SPACE_ID = "b" * 32
+
+
+@pytest.mark.asyncio
+async def test_endpoint_requires_user_authorization(monkeypatch) -> None:
+    monkeypatch.setattr(
+        traffic_gaps,
+        "require_obo_workspace_client",
+        lambda: (_ for _ in ()).throw(RuntimeError("no user")),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await traffic_gaps.get_traffic_gaps(SPACE_ID)
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_endpoint_maps_manager_permission_failure_to_403(monkeypatch) -> None:
+    monkeypatch.setattr(traffic_gaps, "require_obo_workspace_client", object)
+    monkeypatch.setattr(
+        traffic_gaps,
+        "read_traffic_gap_analysis",
+        lambda **_kwargs: (_ for _ in ()).throw(PermissionDenied("denied")),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await traffic_gaps.get_traffic_gaps(SPACE_ID)
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_endpoint_returns_explicit_unavailable_for_incomplete_read(monkeypatch) -> None:
+    monkeypatch.setattr(traffic_gaps, "require_obo_workspace_client", object)
+    monkeypatch.setattr(
+        traffic_gaps,
+        "read_traffic_gap_analysis",
+        lambda **_kwargs: (_ for _ in ()).throw(IncompleteTrafficRead("bad page")),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await traffic_gaps.get_traffic_gaps(SPACE_ID)
+
+    assert exc.value.status_code == 503
+    assert "complete traffic" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_endpoint_returns_analysis(monkeypatch) -> None:
+    marker = TrafficGapAnalysis(
+        scanned_message_count=0,
+        family_count=0,
+        covered_family_count=0,
+    )
+    client = object()
+    monkeypatch.setattr(traffic_gaps, "require_obo_workspace_client", lambda: client)
+    monkeypatch.setattr(
+        traffic_gaps,
+        "read_traffic_gap_analysis",
+        lambda *, client, space_id: marker,
+    )
+
+    assert await traffic_gaps.get_traffic_gaps(SPACE_ID) is marker

--- a/backend/tests/test_watch_traffic_gaps.py
+++ b/backend/tests/test_watch_traffic_gaps.py
@@ -28,12 +28,16 @@ def _message(
 
 
 def test_normalization_groups_literal_variants_without_fuzzy_matching() -> None:
-    assert normalize_question("Revenue for 'EMEA' in 2025?") == normalize_question(
-        'revenue for "APAC" in 2024'
+    assert normalize_question("Revenue in 2025?") == normalize_question(
+        "revenue in 2024"
     )
     assert normalize_question("revenue by country") != normalize_question(
         "revenue for country"
     )
+    assert normalize_question('Show "gross margin" by region') != normalize_question(
+        'Show "net revenue" by region'
+    )
+    assert normalize_question("profit/loss") != normalize_question("profit-loss")
     assert "revenue" in normalize_question("What's revenue for John's region?")
 
 
@@ -41,12 +45,12 @@ def test_covered_family_is_not_returned() -> None:
     result = analyze_traffic_gaps(
         messages=[
             _message(
-                "Revenue for 'EMEA' in 2025",
+                "Revenue in 2025",
                 conversation_id="conv-1",
                 status="FAILED",
             )
         ],
-        benchmark_questions=["Revenue for 'APAC' in 2024"],
+        benchmark_questions=["Revenue in 2024"],
         conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
     )
 
@@ -146,3 +150,46 @@ def test_response_has_opaque_ids_no_raw_content_and_at_most_three_links() -> Non
     assert "Show orders" not in serialized
     assert "user-" not in serialized
     assert "normalized" not in serialized
+
+
+def test_evidence_links_prioritize_signal_bearing_conversations() -> None:
+    result = analyze_traffic_gaps(
+        messages=[
+            _message("Show orders for 2021", conversation_id="conv-1"),
+            _message("Show orders for 2022", conversation_id="conv-2"),
+            _message("Show orders for 2023", conversation_id="conv-3"),
+            _message(
+                "Show orders for 2024",
+                conversation_id="conv-4",
+                status="FAILED",
+            ),
+        ],
+        benchmark_questions=[],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+
+    assert result.candidates[0].conversation_urls[0] == "https://example/conv-4"
+
+
+def test_cross_user_evidence_links_include_two_users() -> None:
+    result = analyze_traffic_gaps(
+        messages=[
+            _message(
+                f"Show orders for {2021 + index}",
+                conversation_id=f"conv-{index}",
+                user_key="u1",
+            )
+            for index in range(3)
+        ]
+        + [
+            _message(
+                "Show orders for 2024",
+                conversation_id="conv-u2",
+                user_key="u2",
+            )
+        ],
+        benchmark_questions=[],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+
+    assert "https://example/conv-u2" in result.candidates[0].conversation_urls

--- a/backend/tests/test_watch_traffic_gaps.py
+++ b/backend/tests/test_watch_traffic_gaps.py
@@ -193,3 +193,32 @@ def test_cross_user_evidence_links_include_two_users() -> None:
     )
 
     assert "https://example/conv-u2" in result.candidates[0].conversation_urls
+
+
+def test_cross_user_evidence_reserves_a_link_when_failures_fill_budget() -> None:
+    result = analyze_traffic_gaps(
+        messages=[
+            _message(
+                f"Show orders for {2021 + index}",
+                conversation_id=f"failed-{index}",
+                user_key="u1",
+                status="FAILED",
+            )
+            for index in range(3)
+        ]
+        + [
+            _message(
+                "Show orders for 2024",
+                conversation_id="repeat-u2",
+                user_key="u2",
+            )
+        ],
+        benchmark_questions=[],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+
+    candidate = result.candidates[0]
+    assert candidate.signals == ["failed", "cross_user_repeat"]
+    assert "https://example/failed-0" in candidate.conversation_urls
+    assert "https://example/repeat-u2" in candidate.conversation_urls
+    assert len(candidate.conversation_urls) <= 3

--- a/backend/tests/test_watch_traffic_gaps.py
+++ b/backend/tests/test_watch_traffic_gaps.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from backend.watch.services.traffic_gaps import (
+    TrafficMessage,
+    analyze_traffic_gaps,
+    normalize_question,
+)
+
+
+def _message(
+    content: str,
+    *,
+    conversation_id: str,
+    user_key: str = "user-1",
+    status: str = "COMPLETED",
+    feedback: str | None = None,
+) -> TrafficMessage:
+    return TrafficMessage(
+        content=content,
+        conversation_id=conversation_id,
+        user_key=user_key,
+        status=status,
+        feedback=feedback,
+        created_at=datetime(2026, 8, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_normalization_groups_literal_variants_without_fuzzy_matching() -> None:
+    assert normalize_question("Revenue for 'EMEA' in 2025?") == normalize_question(
+        'revenue for "APAC" in 2024'
+    )
+    assert normalize_question("revenue by country") != normalize_question(
+        "revenue for country"
+    )
+    assert "revenue" in normalize_question("What's revenue for John's region?")
+
+
+def test_covered_family_is_not_returned() -> None:
+    result = analyze_traffic_gaps(
+        messages=[
+            _message(
+                "Revenue for 'EMEA' in 2025",
+                conversation_id="conv-1",
+                status="FAILED",
+            )
+        ],
+        benchmark_questions=["Revenue for 'APAC' in 2024"],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+
+    assert result.covered_family_count == 1
+    assert result.candidates == []
+
+
+def test_cross_user_repeat_is_actionable_but_single_user_repeat_is_not() -> None:
+    repeated = [
+        _message("Show churn for 2025", conversation_id="conv-1", user_key="u1"),
+        _message("Show churn for 2024", conversation_id="conv-2", user_key="u2"),
+    ]
+    result = analyze_traffic_gaps(
+        messages=repeated,
+        benchmark_questions=[],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+    assert len(result.candidates) == 1
+    assert result.candidates[0].signals == ["cross_user_repeat"]
+    assert result.candidates[0].distinct_user_count == 2
+
+    same_user = [
+        _message("Show churn for 2025", conversation_id="conv-1"),
+        _message("Show churn for 2024", conversation_id="conv-2"),
+    ]
+    result = analyze_traffic_gaps(
+        messages=same_user,
+        benchmark_questions=[],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+    assert result.candidates == []
+
+
+def test_failures_and_negative_feedback_are_actionable() -> None:
+    result = analyze_traffic_gaps(
+        messages=[
+            _message("Question one", conversation_id="conv-1", status="FAILED"),
+            _message(
+                "Question two",
+                conversation_id="conv-2",
+                feedback="NEGATIVE",
+            ),
+        ],
+        benchmark_questions=[],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+
+    assert [candidate.signals for candidate in result.candidates] == [
+        ["negative_feedback"],
+        ["failed"],
+    ]
+
+
+def test_in_flight_and_cancelled_messages_are_not_evidence() -> None:
+    result = analyze_traffic_gaps(
+        messages=[
+            _message(
+                "Show churn for 2025",
+                conversation_id="conv-1",
+                user_key="u1",
+                status="SUBMITTED",
+            ),
+            _message(
+                "Show churn for 2024",
+                conversation_id="conv-2",
+                user_key="u2",
+                status="CANCELLED",
+            ),
+        ],
+        benchmark_questions=[],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+
+    assert result.scanned_message_count == 0
+    assert result.candidates == []
+
+
+def test_response_has_opaque_ids_no_raw_content_and_at_most_three_links() -> None:
+    messages = [
+        _message(
+            f"Show orders for {2020 + index}",
+            conversation_id=f"conv-{index}",
+            user_key=f"user-{index}",
+        )
+        for index in range(5)
+    ]
+    result = analyze_traffic_gaps(
+        messages=messages,
+        benchmark_questions=[],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+
+    payload = result.model_dump(mode="json")
+    assert payload["candidates"][0]["candidate_id"] == "candidate-1"
+    assert len(payload["candidates"][0]["conversation_urls"]) == 3
+    serialized = result.model_dump_json()
+    assert "Show orders" not in serialized
+    assert "user-" not in serialized
+    assert "normalized" not in serialized

--- a/backend/tests/test_watch_traffic_gaps.py
+++ b/backend/tests/test_watch_traffic_gaps.py
@@ -38,6 +38,13 @@ def test_normalization_groups_literal_variants_without_fuzzy_matching() -> None:
         'Show "net revenue" by region'
     )
     assert normalize_question("profit/loss") != normalize_question("profit-loss")
+
+
+def test_normalization_ignores_surrounding_whitespace_around_punctuation() -> None:
+    canonical = normalize_question("Revenue?")
+    assert canonical == "revenue"
+    for variant in ("Revenue? ", "  Revenue?  ", "Revenue?\t", "Revenue!\n ", "Revenue . "):
+        assert normalize_question(variant) == canonical
     assert "revenue" in normalize_question("What's revenue for John's region?")
 
 
@@ -125,6 +132,54 @@ def test_in_flight_and_cancelled_messages_are_not_evidence() -> None:
     )
 
     assert result.scanned_message_count == 0
+    assert result.candidates == []
+
+
+def test_expired_query_results_count_as_completed_traffic_not_failures() -> None:
+    result = analyze_traffic_gaps(
+        messages=[
+            _message(
+                "Show refunds by region",
+                conversation_id="conv-1",
+                user_key="u1",
+                status="QUERY_RESULT_EXPIRED",
+            ),
+            _message(
+                "Show refunds by region",
+                conversation_id="conv-2",
+                user_key="u2",
+                status="QUERY_RESULT_EXPIRED",
+            ),
+        ],
+        benchmark_questions=[],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+
+    assert result.scanned_message_count == 2
+    assert result.family_count == 1
+    assert len(result.candidates) == 1
+    candidate = result.candidates[0]
+    assert candidate.signals == ["cross_user_repeat"]
+    assert candidate.occurrence_count == 2
+    assert candidate.failed_count == 0
+
+
+def test_expired_query_result_family_can_be_covered_by_a_benchmark() -> None:
+    result = analyze_traffic_gaps(
+        messages=[
+            _message(
+                "Show refunds by region",
+                conversation_id="conv-1",
+                user_key="u1",
+                status="QUERY_RESULT_EXPIRED",
+            ),
+        ],
+        benchmark_questions=["Show refunds by region"],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+
+    assert result.scanned_message_count == 1
+    assert result.covered_family_count == 1
     assert result.candidates == []
 
 

--- a/backend/tests/test_watch_traffic_gaps.py
+++ b/backend/tests/test_watch_traffic_gaps.py
@@ -222,3 +222,44 @@ def test_cross_user_evidence_reserves_a_link_when_failures_fill_budget() -> None
     assert "https://example/failed-0" in candidate.conversation_urls
     assert "https://example/repeat-u2" in candidate.conversation_urls
     assert len(candidate.conversation_urls) <= 3
+
+
+def test_cross_user_evidence_uses_two_known_users_not_unknown_signal_users() -> None:
+    result = analyze_traffic_gaps(
+        messages=[
+            _message(
+                "Show orders for 2020",
+                conversation_id="unknown-negative",
+                user_key="",
+                feedback="NEGATIVE",
+            ),
+            _message(
+                "Show orders for 2021",
+                conversation_id="unknown-failed",
+                user_key="",
+                status="FAILED",
+            ),
+            _message(
+                "Show orders for 2022",
+                conversation_id="known-u1",
+                user_key="u1",
+            ),
+            _message(
+                "Show orders for 2023",
+                conversation_id="known-u2",
+                user_key="u2",
+            ),
+        ],
+        benchmark_questions=[],
+        conversation_url=lambda conversation_id: f"https://example/{conversation_id}",
+    )
+
+    candidate = result.candidates[0]
+    assert candidate.signals == [
+        "negative_feedback",
+        "failed",
+        "cross_user_repeat",
+    ]
+    assert "https://example/known-u1" in candidate.conversation_urls
+    assert "https://example/known-u2" in candidate.conversation_urls
+    assert len(candidate.conversation_urls) <= 3

--- a/backend/watch/models.py
+++ b/backend/watch/models.py
@@ -159,6 +159,28 @@ class TopQuery(BaseModel):
     statement_text: Optional[str] = None
 
 
+# ─── Benchmark candidate gaps ─────────────────────────────────────────────
+
+
+class TrafficGapCandidate(BaseModel):
+    candidate_id: str
+    occurrence_count: int
+    distinct_user_count: int
+    failed_count: int
+    negative_feedback_count: int
+    signals: list[str] = Field(default_factory=list)
+    conversation_urls: list[str] = Field(default_factory=list, max_length=3)
+    first_seen_at: Optional[datetime] = None
+    last_seen_at: Optional[datetime] = None
+
+
+class TrafficGapAnalysis(BaseModel):
+    scanned_message_count: int
+    family_count: int
+    covered_family_count: int
+    candidates: list[TrafficGapCandidate] = Field(default_factory=list)
+
+
 # ─── Feedback tab (workspace-wide aggregation) ────────────────────────────
 
 

--- a/backend/watch/routers/__init__.py
+++ b/backend/watch/routers/__init__.py
@@ -6,6 +6,7 @@ from backend.watch.routers.feedback import router as watch_feedback_router
 from backend.watch.routers.resources import router as watch_resources_router
 from backend.watch.routers.settings import router as watch_settings_router
 from backend.watch.routers.spaces import router as watch_spaces_router
+from backend.watch.routers.traffic_gaps import router as watch_traffic_gaps_router
 from backend.watch.routers.usage import router as watch_usage_router
 
 __all__ = [
@@ -15,5 +16,6 @@ __all__ = [
     "watch_resources_router",
     "watch_settings_router",
     "watch_spaces_router",
+    "watch_traffic_gaps_router",
     "watch_usage_router",
 ]

--- a/backend/watch/routers/traffic_gaps.py
+++ b/backend/watch/routers/traffic_gaps.py
@@ -1,0 +1,56 @@
+"""Read-only benchmark candidate gaps from manager-visible Genie traffic."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from databricks.sdk.errors import DatabricksError, PermissionDenied
+from fastapi import APIRouter, HTTPException
+
+from backend.services.auth import require_obo_workspace_client
+from backend.watch._validators import validate_space_id
+from backend.watch.models import TrafficGapAnalysis
+from backend.watch.services.traffic_gap_reader import (
+    IncompleteTrafficRead,
+    read_traffic_gap_analysis,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/watch/spaces")
+
+
+@router.get("/{space_id}/traffic-gaps", response_model=TrafficGapAnalysis)
+async def get_traffic_gaps(space_id: str) -> TrafficGapAnalysis:
+    sid = validate_space_id(space_id)
+    try:
+        client = require_obo_workspace_client()
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=401,
+            detail="User authorization is required for traffic analysis.",
+        ) from exc
+
+    try:
+        return await asyncio.to_thread(
+            read_traffic_gap_analysis,
+            client=client,
+            space_id=sid,
+        )
+    except PermissionDenied as exc:
+        raise HTTPException(
+            status_code=403,
+            detail="CAN_MANAGE permission is required to analyze all conversations.",
+        ) from exc
+    except IncompleteTrafficRead as exc:
+        logger.info("Traffic analysis unavailable for %s: %s", sid, exc)
+        raise HTTPException(
+            status_code=503,
+            detail="The complete traffic corpus is unavailable; no partial analysis was returned.",
+        ) from exc
+    except DatabricksError as exc:
+        logger.warning("Traffic analysis API read failed for %s: %s", sid, type(exc).__name__)
+        raise HTTPException(
+            status_code=502,
+            detail="The Genie traffic API request failed.",
+        ) from exc

--- a/backend/watch/services/traffic_gap_reader.py
+++ b/backend/watch/services/traffic_gap_reader.py
@@ -106,9 +106,13 @@ def _benchmark_questions(config: dict[str, Any]) -> list[str]:
         if isinstance(value, str) and value.strip():
             out.append(value)
         elif isinstance(value, list):
-            if any(not isinstance(item, str) for item in value):
+            if not value or any(
+                not isinstance(item, str) or not item.strip() for item in value
+            ):
                 raise IncompleteTrafficRead("benchmark question has an invalid shape")
-            out.extend(item for item in value if item.strip())
+            out.extend(value)
+        else:
+            raise IncompleteTrafficRead("benchmark question has an invalid shape")
     return out
 
 
@@ -137,12 +141,15 @@ def _user_key(message: dict[str, Any], conversation: dict[str, Any]) -> str:
 
 
 def _feedback_rating(value: Any) -> str | None:
+    if value is None:
+        return None
     if isinstance(value, str):
         return value
     if isinstance(value, dict):
         rating = value.get("rating") or value.get("feedback_rating")
-        return str(rating) if rating is not None else None
-    return None
+        if isinstance(rating, str) and rating.strip():
+            return rating
+    raise IncompleteTrafficRead("message feedback has an invalid shape")
 
 
 def _conversation_url(host: str, space_id: str, conversation_id: str) -> str:
@@ -171,6 +178,7 @@ def read_traffic_gap_analysis(*, client: Any, space_id: str) -> TrafficGapAnalys
     )
 
     messages: list[TrafficMessage] = []
+    returned_message_count = 0
     for conversation in conversations:
         conversation_id = conversation.get("id") or conversation.get("conversation_id")
         if not conversation_id:
@@ -180,12 +188,13 @@ def read_traffic_gap_analysis(*, client: Any, space_id: str) -> TrafficGapAnalys
             client,
             path=f"{conversations_path}/{conversation_id}/messages",
             item_key="messages",
-            max_items=_MAX_MESSAGES - len(messages),
+            max_items=_MAX_MESSAGES - returned_message_count,
         )
+        returned_message_count += len(raw_messages)
         for message in raw_messages:
             content = message.get("content")
             if not isinstance(content, str) or not content.strip():
-                continue
+                raise IncompleteTrafficRead("message content has an invalid shape")
             messages.append(
                 TrafficMessage(
                     content=content,
@@ -198,7 +207,7 @@ def read_traffic_gap_analysis(*, client: Any, space_id: str) -> TrafficGapAnalys
                     ),
                 )
             )
-            if len(messages) > _MAX_MESSAGES:
+            if returned_message_count > _MAX_MESSAGES:
                 raise IncompleteTrafficRead("messages: safety limit exceeded")
 
     host = str(getattr(getattr(client, "config", None), "host", "") or "")

--- a/backend/watch/services/traffic_gap_reader.py
+++ b/backend/watch/services/traffic_gap_reader.py
@@ -1,0 +1,213 @@
+"""Transient, user-authorized reads for benchmark candidate-gap analysis."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import quote
+
+from backend.watch.models import TrafficGapAnalysis
+from backend.watch.services.traffic_gaps import (
+    TrafficMessage,
+    analyze_traffic_gaps,
+)
+
+_MAX_CONVERSATIONS = 1_000
+_MAX_MESSAGES = 10_000
+_MAX_PAGES = 500
+
+
+class IncompleteTrafficRead(RuntimeError):
+    """Raised when the complete manager-visible traffic set is unavailable."""
+
+
+def _get_space(client: Any, space_id: str) -> dict[str, Any]:
+    response = client.api_client.do(
+        method="GET",
+        path=f"/api/2.0/genie/spaces/{space_id}",
+        query={"include_serialized_space": "true"},
+    )
+    if not isinstance(response, dict) or not response.get("serialized_space"):
+        raise IncompleteTrafficRead("Genie did not return serialized_space")
+    return response
+
+
+def _paginate(
+    client: Any,
+    *,
+    path: str,
+    item_key: str,
+    query: dict[str, Any] | None = None,
+    max_items: int,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    page_token: str | None = None
+    seen_tokens: set[str] = set()
+    page_count = 0
+    while True:
+        if page_token:
+            if page_token in seen_tokens:
+                raise IncompleteTrafficRead(f"{item_key}: repeated page token")
+            seen_tokens.add(page_token)
+        page_count += 1
+        if page_count > _MAX_PAGES:
+            raise IncompleteTrafficRead(f"{item_key}: page limit exceeded")
+
+        params = {"page_size": 50, **(query or {})}
+        if page_token:
+            params["page_token"] = page_token
+        response = client.api_client.do(method="GET", path=path, query=params)
+        if not isinstance(response, dict):
+            raise IncompleteTrafficRead(f"{item_key}: invalid page response")
+        page_items = response.get(item_key)
+        if page_items is None and not response.get("next_page_token"):
+            page_items = []
+        if not isinstance(page_items, list):
+            raise IncompleteTrafficRead(f"{item_key}: missing page data")
+        if any(not isinstance(item, dict) for item in page_items):
+            raise IncompleteTrafficRead(f"{item_key}: invalid item data")
+        items.extend(page_items)
+        if len(items) > max_items:
+            raise IncompleteTrafficRead(f"{item_key}: safety limit exceeded")
+        page_token = response.get("next_page_token")
+        if not page_token:
+            return items
+
+
+def _parse_serialized_space(response: dict[str, Any]) -> dict[str, Any]:
+    raw = response.get("serialized_space")
+    if isinstance(raw, dict):
+        parsed = raw
+    elif isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise IncompleteTrafficRead("serialized_space is not valid JSON") from exc
+    else:
+        raise IncompleteTrafficRead("serialized_space has an invalid shape")
+    if not isinstance(parsed, dict):
+        raise IncompleteTrafficRead("serialized_space has an invalid shape")
+    return parsed
+
+
+def _benchmark_questions(config: dict[str, Any]) -> list[str]:
+    benchmarks = config.get("benchmarks") or {}
+    if not isinstance(benchmarks, dict):
+        raise IncompleteTrafficRead("benchmarks has an invalid shape")
+    questions = benchmarks.get("questions") or []
+    if not isinstance(questions, list):
+        raise IncompleteTrafficRead("benchmark questions have an invalid shape")
+    out: list[str] = []
+    for entry in questions:
+        if not isinstance(entry, dict):
+            raise IncompleteTrafficRead("benchmark question has an invalid shape")
+        value = entry.get("question")
+        if isinstance(value, str) and value.strip():
+            out.append(value)
+        elif isinstance(value, list):
+            if any(not isinstance(item, str) for item in value):
+                raise IncompleteTrafficRead("benchmark question has an invalid shape")
+            out.extend(item for item in value if item.strip())
+    return out
+
+
+def _timestamp(value: Any) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(float(value) / 1000, tz=timezone.utc)
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _user_key(message: dict[str, Any], conversation: dict[str, Any]) -> str:
+    for payload in (message.get("user"), conversation.get("user")):
+        if not isinstance(payload, dict):
+            continue
+        value = payload.get("id") or payload.get("user_id") or payload.get("user_name")
+        if value is not None:
+            return str(value)
+    value = message.get("user_id") or conversation.get("user_id")
+    return str(value) if value is not None else ""
+
+
+def _feedback_rating(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        rating = value.get("rating") or value.get("feedback_rating")
+        return str(rating) if rating is not None else None
+    return None
+
+
+def _conversation_url(host: str, space_id: str, conversation_id: str) -> str:
+    return (
+        f"{host.rstrip('/')}/genie/rooms/{quote(space_id, safe='')}"
+        f"/chats/{quote(conversation_id, safe='')}"
+    )
+
+
+def read_traffic_gap_analysis(*, client: Any, space_id: str) -> TrafficGapAnalysis:
+    """Read the full manager-visible corpus and analyze it entirely in memory.
+
+    Calling the conversation endpoint with ``include_all=true`` is both the
+    manager-permission enforcement point and the source of complete space-wide
+    traffic. Any page/shape/cap failure aborts the whole analysis.
+    """
+    space_path = f"/api/2.0/genie/spaces/{space_id}"
+    config = _parse_serialized_space(_get_space(client, space_id))
+    conversations_path = f"{space_path}/conversations"
+    conversations = _paginate(
+        client,
+        path=conversations_path,
+        item_key="conversations",
+        query={"include_all": "true"},
+        max_items=_MAX_CONVERSATIONS,
+    )
+
+    messages: list[TrafficMessage] = []
+    for conversation in conversations:
+        conversation_id = conversation.get("id") or conversation.get("conversation_id")
+        if not conversation_id:
+            raise IncompleteTrafficRead("conversation is missing its id")
+        conversation_id = str(conversation_id)
+        raw_messages = _paginate(
+            client,
+            path=f"{conversations_path}/{conversation_id}/messages",
+            item_key="messages",
+            max_items=_MAX_MESSAGES - len(messages),
+        )
+        for message in raw_messages:
+            content = message.get("content")
+            if not isinstance(content, str) or not content.strip():
+                continue
+            messages.append(
+                TrafficMessage(
+                    content=content,
+                    conversation_id=conversation_id,
+                    user_key=_user_key(message, conversation),
+                    status=str(message.get("status") or ""),
+                    feedback=_feedback_rating(message.get("feedback")),
+                    created_at=_timestamp(
+                        message.get("created_timestamp") or message.get("created_at")
+                    ),
+                )
+            )
+            if len(messages) > _MAX_MESSAGES:
+                raise IncompleteTrafficRead("messages: safety limit exceeded")
+
+    host = str(getattr(getattr(client, "config", None), "host", "") or "")
+    if not host:
+        raise IncompleteTrafficRead("workspace host is unavailable")
+    return analyze_traffic_gaps(
+        messages=messages,
+        benchmark_questions=_benchmark_questions(config),
+        conversation_url=lambda conversation_id: _conversation_url(
+            host, space_id, conversation_id
+        ),
+    )

--- a/backend/watch/services/traffic_gaps.py
+++ b/backend/watch/services/traffic_gaps.py
@@ -80,10 +80,10 @@ def _evidence_conversations(family: _Family, signals: list[str]) -> list[str]:
         if conversation_id and conversation_id not in selected and len(selected) < 3:
             selected.append(conversation_id)
 
-    for conversation_id in family.negative_feedback_conversations:
-        add(conversation_id)
-    for conversation_id in family.failed_conversations:
-        add(conversation_id)
+    if "negative_feedback" in signals and family.negative_feedback_conversations:
+        add(family.negative_feedback_conversations[0])
+    if "failed" in signals and family.failed_conversations:
+        add(family.failed_conversations[0])
 
     if "cross_user_repeat" in signals:
         represented_users = {
@@ -98,6 +98,10 @@ def _evidence_conversations(family: _Family, signals: list[str]) -> list[str]:
             if len(represented_users) >= 2 or len(selected) >= 3:
                 break
 
+    for conversation_id in family.negative_feedback_conversations:
+        add(conversation_id)
+    for conversation_id in family.failed_conversations:
+        add(conversation_id)
     for conversation_id in family.conversations:
         add(conversation_id)
     return selected

--- a/backend/watch/services/traffic_gaps.py
+++ b/backend/watch/services/traffic_gaps.py
@@ -20,6 +20,13 @@ _NUMBER_RE = re.compile(r"(?<!\w)[+-]?(?:\d[\d,]*)(?:\.\d+)?(?!\w)")
 _TRAILING_SENTENCE_PUNCTUATION_RE = re.compile(r"[?!.]+$")
 _SPACE_RE = re.compile(r"\s+")
 
+# Genie message statuses that represent finished processing. QUERY_RESULT_EXPIRED
+# means the message completed successfully but its stored SQL result has aged
+# out, so it is real traffic and must not be read as a failure.
+_COMPLETED_STATUSES = frozenset({"COMPLETED", "QUERY_RESULT_EXPIRED"})
+_FAILED_STATUSES = frozenset({"FAILED"})
+_TERMINAL_STATUSES = _COMPLETED_STATUSES | _FAILED_STATUSES
+
 
 @dataclass(frozen=True)
 class TrafficMessage:
@@ -55,8 +62,11 @@ def normalize_question(value: str) -> str:
     text = unicodedata.normalize("NFKC", str(value or "")).casefold()
     text = _ISO_DATE_RE.sub(" dateliteral ", text)
     text = _NUMBER_RE.sub(" numberliteral ", text)
+    # Collapse and trim whitespace before stripping trailing sentence
+    # punctuation, so "Revenue?" and "Revenue? " reach the same family key.
+    text = _SPACE_RE.sub(" ", text).strip()
     text = _TRAILING_SENTENCE_PUNCTUATION_RE.sub("", text)
-    return _SPACE_RE.sub(" ", text).strip()
+    return text.strip()
 
 
 def _is_negative_feedback(value: str | None) -> bool:
@@ -123,7 +133,7 @@ def analyze_traffic_gaps(
     scanned_message_count = 0
     for message in messages:
         status = str(message.status or "").strip().upper()
-        if status not in {"COMPLETED", "FAILED"}:
+        if status not in _TERMINAL_STATUSES:
             continue
         key = normalize_question(message.content)
         if not key:
@@ -139,7 +149,7 @@ def analyze_traffic_gaps(
             family.conversation_users.setdefault(
                 message.conversation_id, message.user_key
             )
-        if status == "FAILED":
+        if status in _FAILED_STATUSES:
             family.failed_count += 1
             if message.conversation_id not in family.failed_conversations:
                 family.failed_conversations.append(message.conversation_id)

--- a/backend/watch/services/traffic_gaps.py
+++ b/backend/watch/services/traffic_gaps.py
@@ -1,0 +1,161 @@
+"""Pure analysis for owner-reviewable benchmark candidate gaps.
+
+Raw question text and user identifiers are inputs only.  Neither is included
+in the result model, logged, or persisted by this module.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Iterable
+
+from backend.watch.models import TrafficGapAnalysis, TrafficGapCandidate
+
+_QUOTED_LITERAL_RE = re.compile(
+    r"(?:(?<!\w)'[^'\n]*'(?!\w)|(?<!\w)\"[^\"\n]*\"(?!\w))"
+)
+_ISO_DATE_RE = re.compile(r"\b\d{4}-\d{1,2}-\d{1,2}\b")
+_NUMBER_RE = re.compile(r"(?<!\w)[+-]?(?:\d[\d,]*)(?:\.\d+)?(?!\w)")
+_PUNCTUATION_RE = re.compile(r"[^\w\s]+", re.UNICODE)
+_SPACE_RE = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class TrafficMessage:
+    content: str
+    conversation_id: str
+    user_key: str
+    status: str = ""
+    feedback: str | None = None
+    created_at: datetime | None = None
+
+
+@dataclass
+class _Family:
+    users: set[str]
+    conversations: list[str]
+    occurrence_count: int = 0
+    failed_count: int = 0
+    negative_feedback_count: int = 0
+    first_seen_at: datetime | None = None
+    last_seen_at: datetime | None = None
+
+
+def normalize_question(value: str) -> str:
+    """Return a conservative template key used for exact family matching.
+
+    Only explicit quoted values, ISO dates, and numeric literals are abstracted.
+    The remaining words must match exactly after Unicode/case/punctuation
+    normalization; this is intentionally not semantic or fuzzy matching.
+    """
+    text = unicodedata.normalize("NFKC", str(value or "")).casefold()
+    text = _QUOTED_LITERAL_RE.sub(" stringliteral ", text)
+    text = _ISO_DATE_RE.sub(" dateliteral ", text)
+    text = _NUMBER_RE.sub(" numberliteral ", text)
+    text = _PUNCTUATION_RE.sub(" ", text)
+    return _SPACE_RE.sub(" ", text).strip()
+
+
+def _is_negative_feedback(value: str | None) -> bool:
+    normalized = str(value or "").strip().upper()
+    return normalized in {"NEGATIVE", "THUMBS_DOWN", "DISLIKE"}
+
+
+def _update_seen(family: _Family, created_at: datetime | None) -> None:
+    if created_at is None:
+        return
+    if family.first_seen_at is None or created_at < family.first_seen_at:
+        family.first_seen_at = created_at
+    if family.last_seen_at is None or created_at > family.last_seen_at:
+        family.last_seen_at = created_at
+
+
+def analyze_traffic_gaps(
+    *,
+    messages: Iterable[TrafficMessage],
+    benchmark_questions: Iterable[str],
+    conversation_url: Callable[[str], str],
+) -> TrafficGapAnalysis:
+    """Group traffic and return only uncovered, owner-actionable candidates."""
+    families: dict[str, _Family] = defaultdict(
+        lambda: _Family(users=set(), conversations=[])
+    )
+    scanned_message_count = 0
+    for message in messages:
+        status = str(message.status or "").strip().upper()
+        if status not in {"COMPLETED", "FAILED"}:
+            continue
+        key = normalize_question(message.content)
+        if not key:
+            continue
+        scanned_message_count += 1
+        family = families[key]
+        family.occurrence_count += 1
+        if message.user_key:
+            family.users.add(message.user_key)
+        if message.conversation_id and message.conversation_id not in family.conversations:
+            family.conversations.append(message.conversation_id)
+        if status == "FAILED":
+            family.failed_count += 1
+        if _is_negative_feedback(message.feedback):
+            family.negative_feedback_count += 1
+        _update_seen(family, message.created_at)
+
+    covered_keys = {
+        key
+        for question in benchmark_questions
+        if (key := normalize_question(question))
+    }
+    covered_family_count = sum(key in covered_keys for key in families)
+
+    ranked: list[tuple[str, _Family, list[str]]] = []
+    for key, family in families.items():
+        if key in covered_keys:
+            continue
+        signals: list[str] = []
+        if family.negative_feedback_count:
+            signals.append("negative_feedback")
+        if family.failed_count:
+            signals.append("failed")
+        if len(family.users) >= 2 and family.occurrence_count >= 2:
+            signals.append("cross_user_repeat")
+        if signals:
+            ranked.append((key, family, signals))
+
+    ranked.sort(
+        key=lambda item: (
+            -item[1].negative_feedback_count,
+            -item[1].failed_count,
+            -len(item[1].users),
+            -item[1].occurrence_count,
+            item[0],
+        )
+    )
+
+    candidates = [
+        TrafficGapCandidate(
+            candidate_id=f"candidate-{index}",
+            occurrence_count=family.occurrence_count,
+            distinct_user_count=len(family.users),
+            failed_count=family.failed_count,
+            negative_feedback_count=family.negative_feedback_count,
+            signals=signals,
+            conversation_urls=[
+                conversation_url(conversation_id)
+                for conversation_id in family.conversations[:3]
+            ],
+            first_seen_at=family.first_seen_at,
+            last_seen_at=family.last_seen_at,
+        )
+        for index, (_key, family, signals) in enumerate(ranked, start=1)
+    ]
+    return TrafficGapAnalysis(
+        scanned_message_count=scanned_message_count,
+        family_count=len(families),
+        covered_family_count=covered_family_count,
+        candidates=candidates,
+    )

--- a/backend/watch/services/traffic_gaps.py
+++ b/backend/watch/services/traffic_gaps.py
@@ -15,12 +15,9 @@ from typing import Callable, Iterable
 
 from backend.watch.models import TrafficGapAnalysis, TrafficGapCandidate
 
-_QUOTED_LITERAL_RE = re.compile(
-    r"(?:(?<!\w)'[^'\n]*'(?!\w)|(?<!\w)\"[^\"\n]*\"(?!\w))"
-)
 _ISO_DATE_RE = re.compile(r"\b\d{4}-\d{1,2}-\d{1,2}\b")
 _NUMBER_RE = re.compile(r"(?<!\w)[+-]?(?:\d[\d,]*)(?:\.\d+)?(?!\w)")
-_PUNCTUATION_RE = re.compile(r"[^\w\s]+", re.UNICODE)
+_TRAILING_SENTENCE_PUNCTUATION_RE = re.compile(r"[?!.]+$")
 _SPACE_RE = re.compile(r"\s+")
 
 
@@ -38,6 +35,9 @@ class TrafficMessage:
 class _Family:
     users: set[str]
     conversations: list[str]
+    conversation_users: dict[str, str]
+    failed_conversations: list[str]
+    negative_feedback_conversations: list[str]
     occurrence_count: int = 0
     failed_count: int = 0
     negative_feedback_count: int = 0
@@ -48,15 +48,14 @@ class _Family:
 def normalize_question(value: str) -> str:
     """Return a conservative template key used for exact family matching.
 
-    Only explicit quoted values, ISO dates, and numeric literals are abstracted.
-    The remaining words must match exactly after Unicode/case/punctuation
-    normalization; this is intentionally not semantic or fuzzy matching.
+    Only ISO dates and numeric literals are abstracted. Quoted business terms
+    and meaningful punctuation are preserved; this is intentionally not
+    semantic or fuzzy matching.
     """
     text = unicodedata.normalize("NFKC", str(value or "")).casefold()
-    text = _QUOTED_LITERAL_RE.sub(" stringliteral ", text)
     text = _ISO_DATE_RE.sub(" dateliteral ", text)
     text = _NUMBER_RE.sub(" numberliteral ", text)
-    text = _PUNCTUATION_RE.sub(" ", text)
+    text = _TRAILING_SENTENCE_PUNCTUATION_RE.sub("", text)
     return _SPACE_RE.sub(" ", text).strip()
 
 
@@ -74,6 +73,36 @@ def _update_seen(family: _Family, created_at: datetime | None) -> None:
         family.last_seen_at = created_at
 
 
+def _evidence_conversations(family: _Family, signals: list[str]) -> list[str]:
+    selected: list[str] = []
+
+    def add(conversation_id: str) -> None:
+        if conversation_id and conversation_id not in selected and len(selected) < 3:
+            selected.append(conversation_id)
+
+    for conversation_id in family.negative_feedback_conversations:
+        add(conversation_id)
+    for conversation_id in family.failed_conversations:
+        add(conversation_id)
+
+    if "cross_user_repeat" in signals:
+        represented_users = {
+            family.conversation_users.get(conversation_id, "")
+            for conversation_id in selected
+        }
+        for conversation_id in family.conversations:
+            user_key = family.conversation_users.get(conversation_id, "")
+            if user_key and user_key not in represented_users:
+                add(conversation_id)
+                represented_users.add(user_key)
+            if len(represented_users) >= 2 or len(selected) >= 3:
+                break
+
+    for conversation_id in family.conversations:
+        add(conversation_id)
+    return selected
+
+
 def analyze_traffic_gaps(
     *,
     messages: Iterable[TrafficMessage],
@@ -82,7 +111,13 @@ def analyze_traffic_gaps(
 ) -> TrafficGapAnalysis:
     """Group traffic and return only uncovered, owner-actionable candidates."""
     families: dict[str, _Family] = defaultdict(
-        lambda: _Family(users=set(), conversations=[])
+        lambda: _Family(
+            users=set(),
+            conversations=[],
+            conversation_users={},
+            failed_conversations=[],
+            negative_feedback_conversations=[],
+        )
     )
     scanned_message_count = 0
     for message in messages:
@@ -99,10 +134,18 @@ def analyze_traffic_gaps(
             family.users.add(message.user_key)
         if message.conversation_id and message.conversation_id not in family.conversations:
             family.conversations.append(message.conversation_id)
+        if message.conversation_id and message.user_key:
+            family.conversation_users.setdefault(
+                message.conversation_id, message.user_key
+            )
         if status == "FAILED":
             family.failed_count += 1
+            if message.conversation_id not in family.failed_conversations:
+                family.failed_conversations.append(message.conversation_id)
         if _is_negative_feedback(message.feedback):
             family.negative_feedback_count += 1
+            if message.conversation_id not in family.negative_feedback_conversations:
+                family.negative_feedback_conversations.append(message.conversation_id)
         _update_seen(family, message.created_at)
 
     covered_keys = {
@@ -146,7 +189,7 @@ def analyze_traffic_gaps(
             signals=signals,
             conversation_urls=[
                 conversation_url(conversation_id)
-                for conversation_id in family.conversations[:3]
+                for conversation_id in _evidence_conversations(family, signals)
             ],
             first_seen_at=family.first_seen_at,
             last_seen_at=family.last_seen_at,

--- a/backend/watch/services/traffic_gaps.py
+++ b/backend/watch/services/traffic_gaps.py
@@ -80,23 +80,20 @@ def _evidence_conversations(family: _Family, signals: list[str]) -> list[str]:
         if conversation_id and conversation_id not in selected and len(selected) < 3:
             selected.append(conversation_id)
 
-    if "negative_feedback" in signals and family.negative_feedback_conversations:
-        add(family.negative_feedback_conversations[0])
-    if "failed" in signals and family.failed_conversations:
-        add(family.failed_conversations[0])
-
     if "cross_user_repeat" in signals:
-        represented_users = {
-            family.conversation_users.get(conversation_id, "")
-            for conversation_id in selected
-        }
+        represented_users: set[str] = set()
         for conversation_id in family.conversations:
             user_key = family.conversation_users.get(conversation_id, "")
             if user_key and user_key not in represented_users:
                 add(conversation_id)
                 represented_users.add(user_key)
-            if len(represented_users) >= 2 or len(selected) >= 3:
+            if len(represented_users) >= 2:
                 break
+
+    if "negative_feedback" in signals and family.negative_feedback_conversations:
+        add(family.negative_feedback_conversations[0])
+    if "failed" in signals and family.failed_conversations:
+        add(family.failed_conversations[0])
 
     for conversation_id in family.negative_feedback_conversations:
         add(conversation_id)

--- a/docs/docs/getting-started/architecture-overview.md
+++ b/docs/docs/getting-started/architecture-overview.md
@@ -93,10 +93,13 @@ The backend is a FastAPI application (`backend/main.py`) that provides REST API 
 | `usage.py` | `/api/watch` | Per-Agent query volume and usage trends |
 | `feedback.py` | `/api/watch` | User feedback signals and comments |
 | `resources.py` | `/api/watch` | Executed-resource lineage, rollups, and graph |
+| `traffic_gaps.py` | `/api/watch/spaces` | Manager-only benchmark candidate gaps from production traffic |
 | `settings.py` | `/api/watch/settings` | Watch health and cache refresh |
 | `admin.py` | `/api/watch/admin` | Admin-gated rollup refresh |
 
-GenieWatch queries Databricks **system tables** (`system.query.history`, `system.billing.usage`, `system.access.audit`, `system.access.table_lineage`). System tables are **not** OBO-readable, so `watch/services/system_tables.py` always runs as the **service principal** and caches results in an in-process TTL cache. The SP needs `USE CATALOG system` plus schema/SELECT grants — `scripts/grant_permissions.py` is the source of truth for that list.
+Most GenieWatch metrics come from Databricks **system tables** (`system.query.history`, `system.billing.usage`, `system.access.audit`, `system.access.table_lineage`). System tables are **not** OBO-readable, so `watch/services/system_tables.py` runs as the **service principal** and caches results in an in-process TTL cache. The SP needs `USE CATALOG system` plus schema/SELECT grants; `scripts/grant_permissions.py` is the source of truth for that list.
+
+The candidate-gap endpoint is the exception. It uses only the signed-in user's OBO token and requires `CAN_MANAGE` on the Agent. It reads the complete conversation history and current benchmarks in memory, returns aggregate signals and up to three conversation links per candidate, and does not persist question text or user identities. If any page is unavailable, it returns no analysis.
 
 See [Appendix A: API Reference](/docs/reference/api) for the complete endpoint list.
 

--- a/docs/docs/getting-started/introduction.md
+++ b/docs/docs/getting-started/introduction.md
@@ -15,7 +15,7 @@ Genie Workbench provides five capabilities that form a continuous improvement lo
 2. **Score** — A rule-based IQ Scanner that evaluates agent quality across 12 checks and assigns a maturity tier.
 3. **Optimize** — A benchmark-driven pipeline (Auto-Optimize / GSO) that measures real accuracy, diagnoses failures, and iteratively improves the agent configuration.
 4. **Track** — Persistent history of every scan, optimization run, and configuration change, stored in Lakebase.
-5. **Watch** — GenieWatch, an observability surface that reports per-Agent cost, usage, feedback, and executed-resource lineage from Databricks system tables.
+5. **Watch** — GenieWatch reports per-Agent cost, usage, feedback, executed-resource lineage, and manager-reviewable benchmark candidate gaps.
 
 :::note
 An earlier LLM-based "Fix" capability (Quick Fix) has been removed. Auto-Optimize is now the only path that mutates Agent configuration.
@@ -60,7 +60,7 @@ flowchart LR
 - **IQ Scanner** evaluates the agent and produces findings with recommended next steps.
 - **Auto-Optimize** runs a deeper benchmark-driven pipeline for accuracy improvement.
 - **Track** persists all results to Lakebase so you can see progress over time.
-- **GenieWatch** reports how the Agent is actually being used in production — cost, query volume, user feedback, and which tables answered real questions.
+- **GenieWatch** reports how the Agent is used in production: cost, query volume, user feedback, executed tables, and repeated or unsuccessful question families that are not exact matches for existing benchmarks. Candidate gaps require manager review; GenieWatch does not add benchmarks or change the Agent.
 - The cycle repeats: after optimization, re-scan to see the updated score.
 
 ## Next Steps

--- a/docs/docs/platform/authentication.md
+++ b/docs/docs/platform/authentication.md
@@ -33,11 +33,21 @@ flowchart LR
    The explicit `auth_type="pat"` is required because the Databricks Apps environment has `DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET` set for the SP. Without it, the SDK would default to OAuth M2M instead of the user's token.
    :::
 
-4. All downstream service calls use `get_workspace_client()`, which returns the OBO client if set, otherwise falls back to the SP singleton.
+4. Most downstream service calls use `get_workspace_client()`, which returns the OBO client if set, otherwise falls back to the SP singleton.
+
+5. Routes whose visibility must stay bound to the signed-in user instead call `require_obo_workspace_client()`, which returns only the request's user client and **never** falls back to the SP. If no OBO client is set, the request fails rather than widening access. GenieWatch traffic-gap reads use this path — see [OBO-only routes](#obo-only-routes).
 
 ### SSE streaming caveat
 
 For the Create Agent's Server-Sent Events endpoint, the `ContextVar` is **not** cleared after `call_next` in the middleware. This is because the response body streams lazily — the generator runs after the middleware returns. Streaming handlers stash the raw token on `request.state.user_token` and re-set it inside the generator function.
+
+### OBO-only routes
+
+Some reads expose data that the app's SP could see but the signed-in user must not. Those routes require user authorization and have no SP fallback.
+
+| Route | Requirement | Reason |
+|-------|-------------|--------|
+| `GET /api/watch/spaces/{space_id}/traffic-gaps` | OBO only, user needs `CAN_MANAGE` on the Agent | Reads production conversation traffic. The Genie [list conversations API](https://docs.databricks.com/api/azure/workspace/genie/listconversations) requires `CAN_MANAGE`, so SP fallback would let a non-manager read other users' questions. |
 
 ### What OBO protects
 
@@ -120,7 +130,7 @@ The `user_api_scopes` in `app.yaml` request these scopes for the user's OBO toke
 | `catalog.tables:read` | Browse Unity Catalog tables |
 | `files.files` | Access workspace files |
 
-If the workspace or user's OAuth consent doesn't grant all scopes, the app degrades gracefully — the SP fallback handles the most common gap (`dashboards.genie`).
+If the workspace or user's OAuth consent doesn't grant all scopes, the app degrades gracefully — the SP fallback handles the most common gap (`dashboards.genie`). [OBO-only routes](#obo-only-routes) are the exception: they return `401` instead of falling back.
 
 ## SP Permissions Required
 
@@ -170,6 +180,7 @@ These are granted automatically by `scripts/grant_permissions.py` during deploym
 | Operation | Identity | Code Reference | Rationale |
 |-----------|----------|---------------|-----------|
 | Browse Genie Agents, UC catalogs/schemas/tables | OBO (user) | `services/uc_client.py`, `routers/create.py` | User sees only what they have access to |
+| GenieWatch traffic-gap analysis | OBO only, no SP fallback | `watch/routers/traffic_gaps.py` `require_obo_workspace_client()` | Conversation traffic requires `CAN_MANAGE`; SP fallback would leak other users' questions |
 | Genie API — fetch/list agents | OBO → SP fallback | `services/genie_client.py` `_is_scope_error()` | User token may lack `dashboards.genie` scope |
 | Create Agent — tools, SQL, agent creation | OBO (user) | `services/create_agent.py`, `services/create_agent_tools.py` | Agent created under user identity |
 | Trigger optimization — permission check | OBO (user) | `integration/trigger.py` `user_can_edit_space()` | Verify user has CAN_EDIT/CAN_MANAGE |

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -93,15 +93,17 @@ All API endpoints are prefixed with `/api` and served by FastAPI routers. This r
 
 ## GenieWatch Routers (`/api/watch`)
 
-GenieWatch reads Databricks **system tables**, which are not OBO-readable. Every
-route below therefore executes as the **service principal**, with results served
-from an in-process TTL cache. Registered separately from the workbench routers in
-`main.py`.
+Most GenieWatch metrics read Databricks **system tables**, which are not OBO-readable,
+so those routes execute as the **service principal** and use an in-process TTL cache.
+The traffic-gap route is user-authorized and does not persist traffic: it requires
+`CAN_MANAGE`, reads all conversation pages transiently, and fails instead of
+returning partial results. These routers are registered separately in `main.py`.
 
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
 | <span className="badge badge--success">GET</span> | `/api/watch/spaces` | <span className="badge badge--secondary">SP</span> | List watched Genie Agents with cost/usage summaries |
 | <span className="badge badge--success">GET</span> | `/api/watch/spaces/{space_id}` | <span className="badge badge--secondary">SP</span> | Watch detail for one Agent |
+| <span className="badge badge--success">GET</span> | `/api/watch/spaces/{space_id}/traffic-gaps` | <span className="badge badge--secondary">OBO</span> | Manager-only, reviewable benchmark candidate gaps; no raw question or user identity in the response |
 | <span className="badge badge--info">POST</span> | `/api/watch/spaces/refresh` | <span className="badge badge--secondary">SP</span> | Refresh the watched-space cache |
 | <span className="badge badge--success">GET</span> | `/api/watch/overview` | <span className="badge badge--secondary">SP</span> | Org-wide cost overview |
 | <span className="badge badge--success">GET</span> | `/api/watch/cost/top` | <span className="badge badge--secondary">SP</span> | Highest-cost Agents |

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -97,13 +97,15 @@ Most GenieWatch metrics read Databricks **system tables**, which are not OBO-rea
 so those routes execute as the **service principal** and use an in-process TTL cache.
 The traffic-gap route is user-authorized and does not persist traffic: it requires
 `CAN_MANAGE`, reads all conversation pages transiently, and fails instead of
-returning partial results. These routers are registered separately in `main.py`.
+returning partial results. It is **OBO-only** — it never falls back to the service
+principal and returns `401` without user authorization. See
+[OBO-only routes](/docs/platform/authentication#obo-only-routes). These routers are registered separately in `main.py`.
 
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
 | <span className="badge badge--success">GET</span> | `/api/watch/spaces` | <span className="badge badge--secondary">SP</span> | List watched Genie Agents with cost/usage summaries |
 | <span className="badge badge--success">GET</span> | `/api/watch/spaces/{space_id}` | <span className="badge badge--secondary">SP</span> | Watch detail for one Agent |
-| <span className="badge badge--success">GET</span> | `/api/watch/spaces/{space_id}/traffic-gaps` | <span className="badge badge--secondary">OBO</span> | Manager-only, reviewable benchmark candidate gaps; no raw question or user identity in the response |
+| <span className="badge badge--success">GET</span> | `/api/watch/spaces/{space_id}/traffic-gaps` | <span className="badge badge--secondary">OBO only</span> | Manager-only, reviewable benchmark candidate gaps; no SP fallback, and no raw question or user identity in the response |
 | <span className="badge badge--info">POST</span> | `/api/watch/spaces/refresh` | <span className="badge badge--secondary">SP</span> | Refresh the watched-space cache |
 | <span className="badge badge--success">GET</span> | `/api/watch/overview` | <span className="badge badge--secondary">SP</span> | Org-wide cost overview |
 | <span className="badge badge--success">GET</span> | `/api/watch/cost/top` | <span className="badge badge--secondary">SP</span> | Highest-cost Agents |

--- a/frontend/src/watch/lib/api.ts
+++ b/frontend/src/watch/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   SpaceListItem,
   SpaceSummary,
   TopQuery,
+  TrafficGapAnalysis,
   UsageRollup,
   WorkspaceOverview,
 } from '@/watch/types/api'
@@ -106,6 +107,9 @@ export const getSpaceFeedback = (spaceId: string, days = 30, limit = 200) =>
   fetchJson<FeedbackEvent[]>(
     `/spaces/${spaceId}/feedback?days=${days}&limit=${limit}`,
   )
+
+export const getTrafficGaps = (spaceId: string) =>
+  fetchJson<TrafficGapAnalysis>(`/spaces/${spaceId}/traffic-gaps`)
 
 export const getFeedback = (days = 7, limit = 500) =>
   fetchJson<FeedbackTabResponse>(`/feedback?days=${days}&limit=${limit}`)

--- a/frontend/src/watch/pages/SpaceDetail.tsx
+++ b/frontend/src/watch/pages/SpaceDetail.tsx
@@ -8,7 +8,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import * as api from '@/watch/lib/api'
 import type {
   CostPerConversation, CostRollup, HealthStatus,
-  ResourceUsage, SpaceSummary, UsageRollup,
+  ResourceUsage, SpaceSummary, TrafficGapAnalysis, UsageRollup,
 } from '@/watch/types/api'
 import { formatDate, formatInt, formatMs, formatUsd, formatDay } from '@/watch/lib/format'
 import { invalidate, useCachedFetch } from '@/watch/lib/cache'
@@ -33,7 +33,7 @@ export function SpaceDetail({ spaceId, onBack }: Props) {
     setRefreshing(true)
     // Clear this space's cached tab data, then bump refreshKey (a fetch dep on
     // every tab) so the kept-alive tabs re-fetch against the now-empty cache.
-    for (const prefix of ['usage:', 'cost:', 'cost-conv:', 'resources:']) {
+    for (const prefix of ['usage:', 'cost:', 'cost-conv:', 'resources:', 'traffic-gaps:']) {
       invalidate(`${prefix}${spaceId}`)
     }
     space.reload()
@@ -86,15 +86,105 @@ export function SpaceDetail({ spaceId, onBack }: Props) {
               <TabsTrigger value="usage">Usage</TabsTrigger>
               <TabsTrigger value="cost">Cost</TabsTrigger>
               <TabsTrigger value="resources">Resources</TabsTrigger>
+              <TabsTrigger value="traffic-gaps">Candidate gaps</TabsTrigger>
             </TabsList>
 
             <TabsContent value="overview" keepAlive><Overview space={space.data} /></TabsContent>
             <TabsContent value="usage" keepAlive><UsageTab spaceId={spaceId} refreshKey={refreshKey} /></TabsContent>
             <TabsContent value="cost" keepAlive><CostTab spaceId={spaceId} refreshKey={refreshKey} /></TabsContent>
             <TabsContent value="resources" keepAlive><ResourcesTab spaceId={spaceId} refreshKey={refreshKey} /></TabsContent>
+            <TabsContent value="traffic-gaps" keepAlive><TrafficGapsTab spaceId={spaceId} refreshKey={refreshKey} /></TabsContent>
           </Tabs>
         </>
       )}
+    </div>
+  )
+}
+
+function TrafficGapsTab({ spaceId, refreshKey }: { spaceId: string; refreshKey: number }) {
+  const { data, error: err } = useCachedFetch<TrafficGapAnalysis>(
+    `traffic-gaps:${spaceId}`,
+    () => api.getTrafficGaps(spaceId),
+    [spaceId, refreshKey],
+  )
+
+  if (err) {
+    return (
+      <Card className="border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-400">
+        Candidate-gap analysis is unavailable. You must manage this agent, and Genie must return the complete conversation history.
+      </Card>
+    )
+  }
+  if (!data) return <LoadingCard />
+  return <TrafficGapsPanel data={data} />
+}
+
+const signalLabels: Record<string, string> = {
+  negative_feedback: 'Negative feedback',
+  failed: 'Failed answer',
+  cross_user_repeat: 'Repeated across users',
+}
+
+export function TrafficGapsPanel({ data }: { data: TrafficGapAnalysis }) {
+  return (
+    <div className="space-y-4">
+      <Card className="border-blue-500/30 bg-blue-500/10 p-3 text-xs text-blue-300">
+        <Info className="mr-1 inline" size={14} />
+        These are review candidates found through exact normalized matching, not proof of semantic benchmark coverage.
+        Question text and user identities are processed transiently and are not returned or stored.
+      </Card>
+
+      <div className="grid gap-3 sm:grid-cols-4">
+        <Stat label="Messages checked" value={formatInt(data.scanned_message_count)} />
+        <Stat label="Question families" value={formatInt(data.family_count)} />
+        <Stat label="Exact benchmark matches" value={formatInt(data.covered_family_count)} />
+        <Stat label="Candidate gaps" value={formatInt(data.candidates.length)} />
+      </div>
+
+      <Card className="p-4">
+        <h2 className="text-sm font-medium uppercase text-muted">Candidate benchmark gaps</h2>
+        <p className="mt-1 text-sm text-muted">
+          Managers should inspect the linked conversations, confirm the intended answer, and decide whether a benchmark belongs in the agent.
+        </p>
+
+        {data.candidates.length === 0 ? (
+          <p className="mt-4 text-sm text-muted">
+            No actionable candidate gaps were found by exact normalized matching.
+          </p>
+        ) : (
+          <div className="mt-4 space-y-3">
+            {data.candidates.map(candidate => (
+              <div key={candidate.candidate_id} className="rounded border border-default p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="font-mono text-sm">{candidate.candidate_id}</span>
+                  <span className="text-xs text-muted">
+                    {candidate.occurrence_count} occurrence{candidate.occurrence_count === 1 ? '' : 's'} ·{' '}
+                    {candidate.distinct_user_count} user{candidate.distinct_user_count === 1 ? '' : 's'}
+                  </span>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {candidate.signals.map(signal => (
+                    <Badge key={signal}>{signalLabels[signal] || signal}</Badge>
+                  ))}
+                </div>
+                <div className="mt-3 flex flex-wrap gap-3 text-sm">
+                  {candidate.conversation_urls.map((url, index) => (
+                    <a
+                      key={url}
+                      href={url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-1 text-muted hover:text-fg"
+                    >
+                      <ExternalLink size={13} /> Evidence {index + 1}
+                    </a>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
     </div>
   )
 }

--- a/frontend/src/watch/pages/TrafficGapsPanel.test.tsx
+++ b/frontend/src/watch/pages/TrafficGapsPanel.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import type { TrafficGapAnalysis } from '@/watch/types/api'
+import { TrafficGapsPanel } from './SpaceDetail'
+
+const analysis: TrafficGapAnalysis = {
+  scanned_message_count: 18,
+  family_count: 10,
+  covered_family_count: 4,
+  candidates: [
+    {
+      candidate_id: 'candidate-1',
+      occurrence_count: 3,
+      distinct_user_count: 2,
+      failed_count: 1,
+      negative_feedback_count: 1,
+      signals: ['negative_feedback', 'failed', 'cross_user_repeat'],
+      conversation_urls: ['https://workspace.example/genie/rooms/s/chats/c'],
+      first_seen_at: '2026-08-01T00:00:00Z',
+      last_seen_at: '2026-08-02T00:00:00Z',
+    },
+  ],
+}
+
+describe('TrafficGapsPanel', () => {
+  it('labels findings as review candidates and links to supporting conversations', () => {
+    const html = renderToStaticMarkup(<TrafficGapsPanel data={analysis} />)
+
+    expect(html).toContain('Candidate benchmark gaps')
+    expect(html).toContain('review candidates')
+    expect(html).toContain('candidate-1')
+    expect(html).toContain('Negative feedback')
+    expect(html).toContain('Failed answer')
+    expect(html).toContain('Repeated across users')
+    expect(html).toContain('href="https://workspace.example/genie/rooms/s/chats/c"')
+    expect(html).toContain('target="_blank"')
+    expect(html).not.toContain('automatically')
+  })
+
+  it('shows a clear empty state without claiming complete semantic coverage', () => {
+    const html = renderToStaticMarkup(
+      <TrafficGapsPanel data={{ ...analysis, candidates: [] }} />,
+    )
+
+    expect(html).toContain('No actionable candidate gaps')
+    expect(html).toContain('exact normalized matching')
+    expect(html).not.toContain('fully covered')
+  })
+})

--- a/frontend/src/watch/types/api.ts
+++ b/frontend/src/watch/types/api.ts
@@ -108,6 +108,25 @@ export interface TopQuery {
   statement_text: string | null
 }
 
+export interface TrafficGapCandidate {
+  candidate_id: string
+  occurrence_count: number
+  distinct_user_count: number
+  failed_count: number
+  negative_feedback_count: number
+  signals: Array<'negative_feedback' | 'failed' | 'cross_user_repeat'>
+  conversation_urls: string[]
+  first_seen_at: string | null
+  last_seen_at: string | null
+}
+
+export interface TrafficGapAnalysis {
+  scanned_message_count: number
+  family_count: number
+  covered_family_count: number
+  candidates: TrafficGapCandidate[]
+}
+
 export interface CostPerConversation {
   conversation_id: string
   user_email: string | null


### PR DESCRIPTION

### Summary

Bring another focused lesson from MaxGenie into Genie Workbench: benchmark
coverage should be informed by the questions people actually ask, especially
when Genie fails or receives negative feedback.

This change adds a read-only Candidate gaps tab to GenieWatch. It identifies
question families that are not exact normalized matches for existing
benchmarks and have at least one actionable signal: a failed answer, negative
feedback, or repetition across two or more users. Managers can open the linked
conversations, determine the intended answer, and decide whether to add a
benchmark.

The feature does not create benchmarks, change a Genie Agent, or claim an
accuracy improvement.

### What changed

- Add a deterministic, in-memory analyzer for exact-normalized question
  families and existing benchmarks.
- Add a user-authorized Genie reader that requests all manager-visible
  conversations and follows every page.
- Add a manager-only `/api/watch/spaces/{space_id}/traffic-gaps` endpoint.
- Add a lazy-loaded Candidate gaps tab with aggregate signals and up to three
  direct conversation links per candidate.
- Document the authentication, privacy, and review boundaries.

### Safety and privacy

- Use only the signed-in user's token. There is no service-principal fallback.
- Rely on Genie's `include_all=true` manager check; users without `CAN_MANAGE`
  receive `403`.
- Process question text and user IDs only in memory. They are not logged,
  persisted, or returned to the browser.
- Return opaque response-local IDs such as `candidate-1`.
- Fail the whole request when pagination, response shape, or safety caps prevent
  a complete read. Partial results are never shown.
- Exclude cancelled and in-flight messages. Single-user replay repetition is
  not an actionable signal.
- Use conservative exact normalization, not fuzzy or semantic matching. The UI
  calls these review candidates, not proof of semantic coverage.
- Preserve quoted business terms and meaningful punctuation; only explicit
  dates and numeric literals are abstracted.
- Select evidence links that substantiate the reported signals. Cross-user
  candidates always reserve links for two distinct known users.

### Live read-only validation

The production reader was run directly against four manager-accessible test
Agents. Only aggregate counts and evidence links were retained.

| Agent | Terminal messages | Families | Exact benchmark matches | Candidates | Evidence |
|---|---:|---:|---:|---:|---|
| TIM Churn | 26 | 12 | 0 | 3 | [1](https://dbc-a5d4177a-49dc.cloud.databricks.com/genie/rooms/01f15917db93105eb2b58b5b2912429e/chats/01f17b835924192185be845302a470f1), [2](https://dbc-a5d4177a-49dc.cloud.databricks.com/genie/rooms/01f15917db93105eb2b58b5b2912429e/chats/01f163c84bb6198589a629c4c0cea298), [3](https://dbc-a5d4177a-49dc.cloud.databricks.com/genie/rooms/01f15917db93105eb2b58b5b2912429e/chats/01f18d050ade1402abcca7fd678ad9c4) |
| Embrapa | 10 | 6 | 0 | 2 | [1](https://dbc-a5d4177a-49dc.cloud.databricks.com/genie/rooms/01f15a06542a14538bc36db4f22b8cc8/chats/01f17b838c8d1d8cb3ba6509ed7e6b18), [2](https://dbc-a5d4177a-49dc.cloud.databricks.com/genie/rooms/01f15a06542a14538bc36db4f22b8cc8/chats/01f18d0d0aa911a29a991eb7e899df91) |
| SKY | 17 | 10 | 0 | 2 | [1](https://dbc-a5d4177a-49dc.cloud.databricks.com/genie/rooms/01f159dd766a115b8f735c090572dfb5/chats/01f18aba6007101da75a3c0feff3f97c), [2](https://dbc-a5d4177a-49dc.cloud.databricks.com/genie/rooms/01f159dd766a115b8f735c090572dfb5/chats/01f17b8384b91f50b65ba1d53ed072b6) |
| MLB Statcast negative control | 115 | 35 | 34 | 0 | [Agent](https://fevm-genie-workbench-dev.cloud.databricks.com/genie/rooms/01f1373efacf157e9526a7f8b21bbcbc) |

TIM, Embrapa, and SKY surfaced seven failed-answer candidates. MLB behaved as
the intended negative control: its repeated traffic is predominantly benchmark
replay, and it produced no candidates.

### Verification

- 527 backend tests passed.
- 197 frontend tests passed.
- Frontend lint and production build passed.
- Documentation production build passed.
- Commit secret scanning and diff checks passed.
- Independent review found no remaining Critical or Important issues.
- A live non-manager identity was rejected before any partial result was
  returned.
- Live validation used the committed production reader; no raw question text or
  user identity was written to an artifact.

### Limitations and follow-up

- Exact normalized matching can over-report gaps when two semantically similar
  questions use different wording. That is why promotion remains a manager
  decision.
- The live validation proves useful candidate routing and a quiet negative
  control. It does not prove an accuracy increase.
- Accuracy validation is a separate follow-up: managers review selected
  candidates, add grounded expected SQL, and compare paired official Eval-Runs
  on cloned Agents.
