### PR TITLE
Require paired evidence before accepting optimizer changes

### DIFF
--- a/docs/docs/features/auto-optimize.md
+++ b/docs/docs/features/auto-optimize.md
@@ -7,7 +7,7 @@ description: "Benchmark-driven Genie optimization with a four-task, auditable hi
 
 Auto-Optimize measures a Genie Agent against its benchmark corpus, diagnoses failures, and tests targeted configuration changes. It is powered by the Genie Space Optimizer package in `packages/genie-space-optimizer/`.
 
-Unlike the [IQ Scanner](/docs/features/iq-scanner), which produces an instant rule-based readiness score, Auto-Optimize runs a bounded optimization job against the live Agent. Every attempt is evaluated, accepted only when accuracy improves, and persisted for audit.
+Unlike the [IQ Scanner](/docs/features/iq-scanner), which produces an instant rule-based readiness score, Auto-Optimize runs a bounded optimization job against the live Agent. Every attempt is evaluated, accepted only when accuracy improves **and** question-level paired evidence supports the change, and persisted for audit.
 
 ## Four-task pipeline
 
@@ -108,14 +108,27 @@ flowchart LR
     diagnose --> propose["Propose one bounded patch set"]
     propose --> safety["Validate & apply"]
     safety --> prove["Run full evaluation"]
-    prove --> decision{"Accuracy improved?"}
+    prove --> decision{"Accuracy improved<br/>and paired evidence passes?"}
     decision -->|Yes| keep["Accept as best"]
     decision -->|No| rollback["Rollback & record reflection"]
     keep --> eval
     rollback --> eval
 ```
 
-Iteration 0 is the baseline. Later rows are patch attempts. A candidate is accepted only when its full-evaluation accuracy is strictly greater than the best accepted accuracy; otherwise its patches and iteration are marked rolled back and the live serialized configuration is restored.
+Iteration 0 is the baseline. Later rows are patch attempts. A candidate is accepted only when both acceptance conditions hold; otherwise its patches and iteration are marked rolled back and the live serialized configuration is restored.
+
+1. Its full-evaluation accuracy is strictly greater than the best accepted accuracy.
+2. Its question-level paired evidence passes at `p <= 0.10`.
+
+### Paired evidence gate
+
+Genie generation is stochastic, so a candidate can score higher than its control by chance. Accuracy alone therefore cannot distinguish a real improvement from run-to-run noise. The gate reuses the official control and candidate evaluation rows already returned by the Eval-Run API, so it adds no Genie evaluations, API calls, or runtime cost.
+
+Rows are aligned by the stable benchmark question id. `GOOD` counts as correct; `BAD` and `NEEDS_REVIEW` count as non-correct. Questions where the two runs disagree are the discordant pairs: a *win* is control non-correct and candidate correct, a *loss* is the reverse. An exact one-sided sign test over those pairs must reach `p <= 0.10`, under the null that a disagreement is equally likely to favor either configuration.
+
+The gate fails closed. Evidence is rejected when rows are missing, a question id is missing or duplicated, the two row sets do not match, a row is unscored, or there are no discordant pairs. The typed evidence reason is one of `paired_evidence_passed`, `insufficient_paired_evidence`, `no_discordant_pairs`, `missing_rows`, `missing_question_id`, `duplicate_question_id`, `question_id_mismatch`, or `unscored_row`.
+
+Wins, losses, ties, discordant count, p-value, threshold, and the evidence reason are persisted in the iteration reflection for both accepted and rolled-back attempts, and the decision reason records why a candidate was accepted or rejected.
 
 The controller stores attempt mode, hypothesis, decision, decision reason, best accuracy, retry memory, terminal reason, and champion state on `genie_opt_iterations`. Terminal stamping adds the terminal reason without overwriting the attempt's existing accept/reject decision.
 

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/unified_loop.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/unified_loop.py
@@ -248,7 +248,7 @@ def _paired_assessment(row: dict[str, Any]) -> bool | None:
     assessment = str(row.get("assessment") or "").strip().upper()
     if assessment == "GOOD":
         return True
-    if assessment == "BAD":
+    if assessment in {"BAD", "NEEDS_REVIEW"}:
         return False
     return None
 
@@ -273,9 +273,9 @@ def paired_sign_evidence(
 ) -> dict[str, Any]:
     """Return fail-closed paired evidence from two official eval outputs.
 
-    Rows are aligned by the stable Genie benchmark question id.  GOOD/BAD
-    disagreements form an exact one-sided sign test under the null that a
-    disagreement is equally likely to favor either configuration.
+    Rows are aligned by the stable Genie benchmark question id.  GOOD versus
+    official non-GOOD disagreements form an exact one-sided sign test under the
+    null that a disagreement is equally likely to favor either configuration.
     """
     control_rows = control_eval.get("rows")
     candidate_rows = candidate_eval.get("rows")

--- a/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/unified_loop.py
+++ b/packages/genie-space-optimizer/src/genie_space_optimizer/optimization/unified_loop.py
@@ -11,6 +11,7 @@ import copy
 import hashlib
 import json
 import logging
+import math
 import os
 import re
 from contextlib import nullcontext
@@ -29,13 +30,13 @@ from genie_space_optimizer.optimization.applier import (
     classify_risk,
     rollback,
 )
+from genie_space_optimizer.optimization.benchmarking import _extract_json
 from genie_space_optimizer.optimization.eval_runner import (
     FULL,
     OfficialBenchmarkRunner,
     build_eval_output_from_official,
     resolve_space_benchmark_qids,
 )
-from genie_space_optimizer.optimization.benchmarking import _extract_json
 from genie_space_optimizer.optimization.leakage import (
     BenchmarkCorpus,
     canonicalize_sql,
@@ -55,9 +56,9 @@ from genie_space_optimizer.optimization.state import (
     mark_patches_rolled_back,
     update_iteration_loop_state,
     update_run_status,
+    write_artifact,
     write_iteration,
     write_patch,
-    write_artifact,
     write_required_artifact,
 )
 from genie_space_optimizer.optimization.wide_schema import (
@@ -144,6 +145,11 @@ _TRANSIENT_EVAL_STATUSES: frozenset[str] = frozenset(
 # window without stalling the loop indefinitely on a persistently-down service.
 _MAX_TRANSIENT_EVAL_RETRIES = 2
 
+# Candidate acceptance requires directional question-level evidence from the
+# same official evaluations already used for aggregate accuracy.  This is a
+# deliberately explicit product policy constant, not an extra evaluation.
+PAIRED_SIGN_EVIDENCE_THRESHOLD = 0.10
+
 _METADATA_PATCH_TYPES: frozenset[str] = frozenset(
     {"update_description", "update_column_description", "add_column_synonym"}
 )
@@ -225,6 +231,121 @@ def _metric(value: Any, default: float = 0.0) -> float:
     except (TypeError, ValueError):
         return default
     return default if result != result else result
+
+
+def _paired_question_id(row: dict[str, Any]) -> str:
+    inputs = row.get("inputs")
+    nested_id = inputs.get("question_id") if isinstance(inputs, dict) else None
+    return str(
+        row.get("question_id")
+        or row.get("inputs/question_id")
+        or nested_id
+        or ""
+    ).strip()
+
+
+def _paired_assessment(row: dict[str, Any]) -> bool | None:
+    assessment = str(row.get("assessment") or "").strip().upper()
+    if assessment == "GOOD":
+        return True
+    if assessment == "BAD":
+        return False
+    return None
+
+
+def _invalid_paired_sign_evidence(reason: str) -> dict[str, Any]:
+    return {
+        "valid": False,
+        "passes": False,
+        "wins": 0,
+        "losses": 0,
+        "ties": 0,
+        "discordant": 0,
+        "p_value": 1.0,
+        "threshold": PAIRED_SIGN_EVIDENCE_THRESHOLD,
+        "reason": reason,
+    }
+
+
+def paired_sign_evidence(
+    control_eval: dict[str, Any],
+    candidate_eval: dict[str, Any],
+) -> dict[str, Any]:
+    """Return fail-closed paired evidence from two official eval outputs.
+
+    Rows are aligned by the stable Genie benchmark question id.  GOOD/BAD
+    disagreements form an exact one-sided sign test under the null that a
+    disagreement is equally likely to favor either configuration.
+    """
+    control_rows = control_eval.get("rows")
+    candidate_rows = candidate_eval.get("rows")
+    if not isinstance(control_rows, list) or not isinstance(candidate_rows, list):
+        return _invalid_paired_sign_evidence("missing_rows")
+    if not control_rows or not candidate_rows:
+        return _invalid_paired_sign_evidence("missing_rows")
+
+    def index_rows(rows: list[Any]) -> tuple[dict[str, bool], str | None]:
+        indexed: dict[str, bool] = {}
+        for row in rows:
+            if not isinstance(row, dict):
+                return {}, "unscored_row"
+            question_id = _paired_question_id(row)
+            if not question_id:
+                return {}, "missing_question_id"
+            if question_id in indexed:
+                return {}, "duplicate_question_id"
+            assessment = _paired_assessment(row)
+            if assessment is None:
+                return {}, "unscored_row"
+            indexed[question_id] = assessment
+        return indexed, None
+
+    control_by_id, error = index_rows(control_rows)
+    if error:
+        return _invalid_paired_sign_evidence(error)
+    candidate_by_id, error = index_rows(candidate_rows)
+    if error:
+        return _invalid_paired_sign_evidence(error)
+    if set(control_by_id) != set(candidate_by_id):
+        return _invalid_paired_sign_evidence("question_id_mismatch")
+
+    wins = 0
+    losses = 0
+    ties = 0
+    for question_id, control_good in control_by_id.items():
+        candidate_good = candidate_by_id[question_id]
+        if candidate_good == control_good:
+            ties += 1
+        elif candidate_good:
+            wins += 1
+        else:
+            losses += 1
+
+    discordant = wins + losses
+    if discordant == 0:
+        p_value = 1.0
+        reason = "no_discordant_pairs"
+        passes = False
+    else:
+        tail_count = sum(
+            math.comb(discordant, successes)
+            for successes in range(wins, discordant + 1)
+        )
+        p_value = tail_count / (2**discordant)
+        passes = p_value <= PAIRED_SIGN_EVIDENCE_THRESHOLD
+        reason = "paired_evidence_passed" if passes else "insufficient_paired_evidence"
+
+    return {
+        "valid": True,
+        "passes": passes,
+        "wins": wins,
+        "losses": losses,
+        "ties": ties,
+        "discordant": discordant,
+        "p_value": p_value,
+        "threshold": PAIRED_SIGN_EVIDENCE_THRESHOLD,
+        "reason": reason,
+    }
 
 
 def _failure_rows(eval_result: dict[str, Any], *, limit: int = 12) -> list[dict[str, Any]]:
@@ -3197,6 +3318,7 @@ def run_unified_optimization_loop(
                     current_config[runtime_key]
                 )
         candidate_accuracy = _metric(candidate_eval.get("overall_accuracy"))
+        sign_evidence = paired_sign_evidence(best_eval, candidate_eval)
 
         write_iteration(
             spark,
@@ -3212,6 +3334,7 @@ def run_unified_optimization_loop(
                 "patch_count": len(patches),
                 "applied_count": len(applied_entries),
                 "dropped_patches": apply_log.get("dropped_patches") or [],
+                "paired_sign_evidence": sign_evidence,
             },
             config_snapshot=submitted_candidate_config,
             observed_config_snapshot=observed_candidate_config,
@@ -3263,7 +3386,7 @@ def run_unified_optimization_loop(
             )
             break
 
-        if candidate_accuracy > best_accuracy:
+        if candidate_accuracy > best_accuracy and sign_evidence["passes"]:
             previous_best_accuracy = best_accuracy
             best_accuracy = candidate_accuracy
             best_iteration = iteration
@@ -3281,7 +3404,9 @@ def run_unified_optimization_loop(
             levers_accepted.append(int(lever))
             decision_reason = (
                 f"accuracy improved to {candidate_accuracy:.2f} "
-                f"from previous best"
+                "from previous best with paired evidence "
+                f"({sign_evidence['wins']} wins, {sign_evidence['losses']} losses, "
+                f"p={sign_evidence['p_value']:.6g})"
             )
             update_iteration_loop_state(
                 spark,
@@ -3320,6 +3445,7 @@ def run_unified_optimization_loop(
                 "rationale": rationale,
                 "patch_types": hypothesis.get("patch_types", []),
                 "patch_family": hypothesis.get("patch_family"),
+                "paired_sign_evidence": sign_evidence,
             }
             if hypothesis.get("patch_family") == "metadata_only":
                 accepted_reflection["next_guidance"] = (
@@ -3338,6 +3464,9 @@ def run_unified_optimization_loop(
                 improvement=round(candidate_accuracy - previous_best_accuracy, 2),
                 champion_accuracy=round(best_accuracy, 2),
                 remaining_failures=len(candidate_eval.get("remaining_failures") or []),
+                paired_wins=sign_evidence["wins"],
+                paired_losses=sign_evidence["losses"],
+                paired_p_value=sign_evidence["p_value"],
                 eval_run_id=candidate_eval.get("eval_run_id"),
                 eval_run_status=candidate_eval.get("eval_run_status"),
             )
@@ -3346,10 +3475,25 @@ def run_unified_optimization_loop(
                 break
             continue
 
-        reason = (
-            f"candidate accuracy {candidate_accuracy:.2f} did not improve "
-            f"on best {best_accuracy:.2f}"
-        )
+        if candidate_accuracy <= best_accuracy:
+            reason = (
+                f"candidate accuracy {candidate_accuracy:.2f} did not improve "
+                f"on best {best_accuracy:.2f}"
+            )
+        elif not sign_evidence["valid"]:
+            reason = (
+                f"candidate accuracy {candidate_accuracy:.2f} improved on best "
+                f"{best_accuracy:.2f}, but paired evidence failed closed: "
+                f"{sign_evidence['reason']}"
+            )
+        else:
+            reason = (
+                f"candidate accuracy {candidate_accuracy:.2f} improved on best "
+                f"{best_accuracy:.2f}, but paired evidence was insufficient "
+                f"({sign_evidence['wins']} wins, {sign_evidence['losses']} losses, "
+                f"p={sign_evidence['p_value']:.6g}, "
+                f"threshold={sign_evidence['threshold']:.2f})"
+            )
         rollback(apply_log, w, space_id, metadata_snapshot=current_config)
         mark_patches_rolled_back(spark, run_id, iteration, reason, catalog, schema)
         mark_iteration_rolled_back(
@@ -3394,6 +3538,7 @@ def run_unified_optimization_loop(
                 "rationale": rationale,
                 "patch_types": hypothesis.get("patch_types", []),
                 "patch_family": hypothesis.get("patch_family"),
+                "paired_sign_evidence": sign_evidence,
             }
         )
         _emit_diagnostic(
@@ -3405,6 +3550,10 @@ def run_unified_optimization_loop(
             candidate_accuracy=round(candidate_accuracy, 2),
             champion_accuracy=round(best_accuracy, 2),
             remaining_failures=len(candidate_eval.get("remaining_failures") or []),
+            paired_wins=sign_evidence["wins"],
+            paired_losses=sign_evidence["losses"],
+            paired_p_value=sign_evidence["p_value"],
+            paired_evidence_reason=sign_evidence["reason"],
             eval_run_id=candidate_eval.get("eval_run_id"),
             eval_run_status=candidate_eval.get("eval_run_status"),
         )

--- a/packages/genie-space-optimizer/tests/unit/test_paired_sign_evidence.py
+++ b/packages/genie-space-optimizer/tests/unit/test_paired_sign_evidence.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import pytest
+from genie_space_optimizer.optimization.unified_loop import (
+    PAIRED_SIGN_EVIDENCE_THRESHOLD,
+    paired_sign_evidence,
+)
+
+
+def _paired_rows(
+    *,
+    wins: int,
+    losses: int,
+    both_good: int = 0,
+    both_bad: int = 0,
+) -> tuple[dict, dict]:
+    control: list[dict[str, str]] = []
+    candidate: list[dict[str, str]] = []
+
+    def append_pair(control_assessment: str, candidate_assessment: str) -> None:
+        question_id = f"q{len(control) + 1}"
+        control.append(
+            {"question_id": question_id, "assessment": control_assessment}
+        )
+        candidate.append(
+            {"question_id": question_id, "assessment": candidate_assessment}
+        )
+
+    for _ in range(wins):
+        append_pair("BAD", "GOOD")
+    for _ in range(losses):
+        append_pair("GOOD", "BAD")
+    for _ in range(both_good):
+        append_pair("GOOD", "GOOD")
+    for _ in range(both_bad):
+        append_pair("BAD", "BAD")
+    return {"rows": control}, {"rows": candidate}
+
+
+def test_formula_five_wins_two_losses_is_rejected() -> None:
+    control, candidate = _paired_rows(wins=5, losses=2, both_good=33, both_bad=47)
+
+    evidence = paired_sign_evidence(control, candidate)
+
+    assert evidence == {
+        "valid": True,
+        "passes": False,
+        "wins": 5,
+        "losses": 2,
+        "ties": 80,
+        "discordant": 7,
+        "p_value": pytest.approx(29 / 128),
+        "threshold": PAIRED_SIGN_EVIDENCE_THRESHOLD,
+        "reason": "insufficient_paired_evidence",
+    }
+
+
+def test_toxicology_thirty_seven_wins_zero_losses_is_accepted() -> None:
+    control, candidate = _paired_rows(wins=37, losses=0, both_good=15, both_bad=26)
+
+    evidence = paired_sign_evidence(control, candidate)
+
+    assert evidence["valid"] is True
+    assert evidence["passes"] is True
+    assert evidence["wins"] == 37
+    assert evidence["losses"] == 0
+    assert evidence["p_value"] == pytest.approx(1 / (2**37))
+
+
+def test_financial_nine_wins_three_losses_is_accepted() -> None:
+    control, candidate = _paired_rows(wins=9, losses=3, both_good=13, both_bad=31)
+
+    evidence = paired_sign_evidence(control, candidate)
+
+    assert evidence["valid"] is True
+    assert evidence["passes"] is True
+    assert evidence["wins"] == 9
+    assert evidence["losses"] == 3
+    assert evidence["p_value"] == pytest.approx(299 / 4096)
+
+
+@pytest.mark.parametrize(
+    ("control_rows", "candidate_rows", "expected_reason"),
+    [
+        ([], [], "missing_rows"),
+        (
+            [{"question_id": "q1", "assessment": "BAD"}],
+            [{"question_id": "q2", "assessment": "GOOD"}],
+            "question_id_mismatch",
+        ),
+        (
+            [
+                {"question_id": "q1", "assessment": "BAD"},
+                {"question_id": "q1", "assessment": "BAD"},
+            ],
+            [{"question_id": "q1", "assessment": "GOOD"}],
+            "duplicate_question_id",
+        ),
+        (
+            [{"assessment": "BAD"}],
+            [{"question_id": "q1", "assessment": "GOOD"}],
+            "missing_question_id",
+        ),
+        (
+            [{"question_id": "q1", "assessment": "NEEDS_REVIEW"}],
+            [{"question_id": "q1", "assessment": "GOOD"}],
+            "unscored_row",
+        ),
+    ],
+)
+def test_invalid_pairings_fail_closed(
+    control_rows: list[dict[str, str]],
+    candidate_rows: list[dict[str, str]],
+    expected_reason: str,
+) -> None:
+    evidence = paired_sign_evidence(
+        {"rows": control_rows},
+        {"rows": candidate_rows},
+    )
+
+    assert evidence["valid"] is False
+    assert evidence["passes"] is False
+    assert evidence["reason"] == expected_reason
+
+
+def test_zero_discordant_pairs_are_rejected() -> None:
+    control, candidate = _paired_rows(wins=0, losses=0, both_good=3, both_bad=2)
+
+    evidence = paired_sign_evidence(control, candidate)
+
+    assert evidence["valid"] is True
+    assert evidence["passes"] is False
+    assert evidence["discordant"] == 0
+    assert evidence["p_value"] == 1.0
+    assert evidence["reason"] == "no_discordant_pairs"

--- a/packages/genie-space-optimizer/tests/unit/test_paired_sign_evidence.py
+++ b/packages/genie-space-optimizer/tests/unit/test_paired_sign_evidence.py
@@ -102,7 +102,7 @@ def test_financial_nine_wins_three_losses_is_accepted() -> None:
             "missing_question_id",
         ),
         (
-            [{"question_id": "q1", "assessment": "NEEDS_REVIEW"}],
+            [{"question_id": "q1", "assessment": ""}],
             [{"question_id": "q1", "assessment": "GOOD"}],
             "unscored_row",
         ),
@@ -133,3 +133,14 @@ def test_zero_discordant_pairs_are_rejected() -> None:
     assert evidence["discordant"] == 0
     assert evidence["p_value"] == 1.0
     assert evidence["reason"] == "no_discordant_pairs"
+
+
+def test_needs_review_is_counted_as_an_official_non_good_outcome() -> None:
+    evidence = paired_sign_evidence(
+        {"rows": [{"question_id": "q1", "assessment": "NEEDS_REVIEW"}]},
+        {"rows": [{"question_id": "q1", "assessment": "GOOD"}]},
+    )
+
+    assert evidence["valid"] is True
+    assert evidence["wins"] == 1
+    assert evidence["losses"] == 0

--- a/packages/genie-space-optimizer/tests/unit/test_unified_loop_observed_config.py
+++ b/packages/genie-space-optimizer/tests/unit/test_unified_loop_observed_config.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-
 from genie_space_optimizer.optimization import unified_loop
 
 
@@ -17,6 +16,16 @@ def _config(content: list[str]) -> dict:
             "text_instructions": [{"id": "instruction-1", "content": content}],
         },
     }
+
+
+def _assessment_rows(total: int, good_ids: set[int]) -> list[dict[str, str]]:
+    return [
+        {
+            "question_id": f"q{index}",
+            "assessment": "GOOD" if index in good_ids else "BAD",
+        }
+        for index in range(1, total + 1)
+    ]
 
 
 def test_settled_observation_failure_is_non_fatal(monkeypatch) -> None:
@@ -210,23 +219,23 @@ def test_accepted_attempt_emits_bounded_decision_diagnostics(monkeypatch) -> Non
         [
             {
                 "overall_accuracy": 70.0,
-                "total_questions": 10,
-                "correct_count": 7,
+                "total_questions": 60,
+                "correct_count": 42,
                 "scores": {},
                 "failures": ["q8", "q9", "q10"],
                 "remaining_failures": ["q8", "q9", "q10"],
                 "thresholds_met": False,
-                "rows": [],
+                "rows": _assessment_rows(60, set(range(1, 43))),
             },
             {
                 "overall_accuracy": 80.0,
-                "total_questions": 10,
-                "correct_count": 8,
+                "total_questions": 60,
+                "correct_count": 48,
                 "scores": {},
                 "failures": ["q9", "q10"],
                 "remaining_failures": ["q9", "q10"],
                 "thresholds_met": False,
-                "rows": [],
+                "rows": _assessment_rows(60, set(range(4, 52))),
             },
         ]
     )
@@ -305,3 +314,108 @@ def test_accepted_attempt_emits_bounded_decision_diagnostics(monkeypatch) -> Non
     assert accepted["improvement"] == 10.0
     assert accepted["champion_accuracy"] == 80.0
     assert "Improve revenue metadata" not in str(diagnostics)
+
+
+def test_aggregate_improvement_is_rolled_back_without_paired_evidence(
+    monkeypatch,
+) -> None:
+    baseline_config = _config(["PURPOSE:\n- Help users"])
+    candidate_config = _config(["PURPOSE:\n- Help users", "TERMS:\n- Revenue"])
+    patch = {
+        "type": "update_column",
+        "lever": 1,
+        "target": "main.sales.orders.revenue",
+    }
+    control_good = set(range(6, 16))
+    candidate_good = set(range(1, 6)) | set(range(8, 16))
+    evaluations = iter(
+        [
+            {
+                "overall_accuracy": 50.0,
+                "total_questions": 20,
+                "correct_count": 10,
+                "rows": _assessment_rows(20, control_good),
+                "remaining_failures": [],
+            },
+            {
+                "overall_accuracy": 65.0,
+                "total_questions": 20,
+                "correct_count": 13,
+                "rows": _assessment_rows(20, candidate_good),
+                "remaining_failures": [],
+            },
+        ]
+    )
+    rollback = MagicMock(name="rollback")
+    loop_states: list[dict] = []
+
+    monkeypatch.setattr(
+        unified_loop,
+        "fetch_space_config",
+        lambda *_args, **_kwargs: {"_parsed_space": copy.deepcopy(baseline_config)},
+    )
+    monkeypatch.setattr(
+        unified_loop,
+        "run_space_quality_enrichment",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            current_config=copy.deepcopy(baseline_config)
+        ),
+    )
+    monkeypatch.setattr(
+        unified_loop, "_native_eval", lambda *_args, **_kwargs: next(evaluations)
+    )
+    monkeypatch.setattr(
+        unified_loop,
+        "propose_patches",
+        lambda *_args, **_kwargs: (1, "Improve revenue metadata", [patch], "{}"),
+    )
+    monkeypatch.setattr(
+        unified_loop,
+        "_preapply_safety_screen",
+        lambda patches, **_kwargs: (patches, []),
+    )
+    monkeypatch.setattr(
+        unified_loop,
+        "apply_patch_set",
+        lambda *_args, **_kwargs: {
+            "patch_deployed": True,
+            "applied": [{"patch": patch, "action": {}}],
+            "post_snapshot": copy.deepcopy(candidate_config),
+            "dropped_patches": [],
+        },
+    )
+    monkeypatch.setattr(unified_loop, "rollback", rollback)
+    monkeypatch.setattr(
+        unified_loop,
+        "update_iteration_loop_state",
+        lambda *_args, **kwargs: loop_states.append(kwargs["loop_state"]),
+    )
+    for name in (
+        "write_iteration",
+        "write_patch",
+        "update_run_status",
+        "mark_patches_rolled_back",
+        "mark_iteration_rolled_back",
+        "_stamp_terminal",
+    ):
+        monkeypatch.setattr(unified_loop, name, lambda *_args, **_kwargs: None)
+
+    result = unified_loop.run_unified_optimization_loop(
+        MagicMock(),
+        MagicMock(),
+        run_id="run-1",
+        space_id="space-1",
+        benchmarks=[],
+        catalog="catalog",
+        schema="schema",
+        levers=[1],
+        max_attempts=1,
+        target_accuracy=90.0,
+    )
+
+    assert result["accuracy"] == 50.0
+    assert result["accepted_attempts"] == 0
+    rollback.assert_called_once()
+    assert loop_states[-1]["decision"] == "reject"
+    assert "paired evidence" in loop_states[-1]["decision_reason"]
+    assert "5 wins, 2 losses" in loop_states[-1]["decision_reason"]


### PR DESCRIPTION
## Summary

Prevent GSO from accepting optimizer changes based only on stochastic score movement.

A candidate must now:

1. Improve aggregate correctness.
2. Show sufficient question-level paired evidence that corrected answers outnumber newly broken answers.

The gate uses the existing official control and candidate results, so it adds no Genie evaluations or API calls.

## Why

Genie results can vary between identical runs. In the Formula evaluation, the control and candidate configurations were byte-for-byte identical, but correctness changed from 40/87 to 43/87. The existing aggregate-only rule would accept that apparent improvement even though nothing changed.

The new gate aligns results by benchmark question ID and applies an exact one-sided paired sign test. It fails closed when rows are missing, duplicated, unmatched, or unscored.

## Retained official evaluation replay

| Dataset | Official results | Paired outcome | Decision |
|---|---|---:|---|
| Formula | [Control 40/87](https://fevm-reusableipanirban.cloud.databricks.com/api/2.0/genie/spaces/01f19375dead18bba6620a78ae8fb9fb/eval-runs/01f19375df391654bd858df794e61b1c/results) → [Candidate 43/87](https://fevm-reusableipanirban.cloud.databricks.com/api/2.0/genie/spaces/01f19375dead18bba6620a78ae8fb9fb/eval-runs/01f1937841d6169fa8ef80626dc2a247/results) | 5 wins, 2 losses; p=0.227 | Reject identical-config noise |
| Toxicology | [Control 15/78](https://fevm-reusableipanirban.cloud.databricks.com/api/2.0/genie/spaces/01f19389c9271a89afb88ff93bfbac1e/eval-runs/01f19389ca3e125e8f3fb46d3721c094/results) → [Candidate 52/78](https://fevm-reusableipanirban.cloud.databricks.com/api/2.0/genie/spaces/01f19389c9271a89afb88ff93bfbac1e/eval-runs/01f1938c980212fe8101c392bcb8dcf9/results) | 37 wins, 0 losses; p<0.000001 | Accept |
| Financial | [Control 22/56](https://fevm-reusableipanirban.cloud.databricks.com/api/2.0/genie/spaces/01f19392c79b1a27ae77449b1138587c/eval-runs/01f19394742111e39f08ff8e4d20ecbf/results) → [Candidate 28/56](https://fevm-reusableipanirban.cloud.databricks.com/api/2.0/genie/spaces/01f19392c79b1a27ae77449b1138587c/eval-runs/01f19392c849165fadfcb7428cd6a6f9/results) | 9 wins, 3 losses; p=0.073 | Accept |

This rejects the demonstrated false positive while preserving both previously validated improvements.

## Behavior

- Align control and candidate results using stable question IDs.
- Treat `GOOD` as correct and `BAD` or `NEEDS_REVIEW` as non-good.
- Require aggregate improvement and paired evidence at the explicit `p <= 0.10` threshold.
- Reject incomplete or inconsistent paired evidence.
- Persist wins, losses, ties, p-value, and the acceptance or rollback reason.
- Add no dependencies and make no additional Genie calls.

## Verification

- 882 product unit tests passed.
- 15 focused paired-gate and loop tests passed.
- Deterministic replay tests passed against the retained official results.
- Diff checks passed.
- Independent review found no issues.

## Scope

This gate controls stochastic false acceptance. It does not claim to prove unseen generalization; it makes the optimizer's existing acceptance decision more trustworthy.
